### PR TITLE
MODCLUSTER-590 - workers array for Deterministic failover is allo…

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2200,7 +2200,7 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
     int checked_standby = 0;
     int checked_domain = 1;
     // Create a separate array of available workers, to be sorted later
-    proxy_worker *workers[balancer->workers->nelts];
+    proxy_worker *workers = apr_pcalloc(balancer->workers->pool, sizeof(proxy_worker) * balancer->workers->nelts);
     int workers_length = 0;
     const char *session_id_with_route;
     char *tokenizer;
@@ -2289,7 +2289,7 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
                         continue;
                     }
                 }
-                workers[workers_length++] = worker;
+                workers[workers_length++] = *worker;
                 if (worker->s->lbfactor == 0 && checking_standby) {
                     mycandidate = worker;
                     mynodecontext = nodecontext;
@@ -2332,7 +2332,7 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
             for (i = 0; session_id[i] != 0; ++i) {
                 hash += session_id[i];
             }
-            mycandidate = workers[hash % workers_length];
+            mycandidate = &workers[hash % workers_length];
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "Using deterministic failover target: %s", mycandidate->s->route);
         }
         if (mycandidate)


### PR DESCRIPTION
…cated dynamically now

## Before patch
Doesn't even compile.
```
mod_proxy_cluster.c(2203): error C2057: expected constant expression
mod_proxy_cluster.c(2203): error C2466: cannot allocate an array of constant size 0
mod_proxy_cluster.c(2203): error C2133: 'workers': unknown size
```

## After patch
```
[Thu Jun 15 20:17:16.181198 2017] [mpm_winnt:notice] [pid 4732:tid 624] AH00455: Apache/2.4.23 (Win64) mod_cluster/2.0.0.Alpha1-SNAPSHOT OpenSSL/1.0.2h configured -- resuming normal operations
<SNIP>
[pid 7548:tid 1908] mod_proxy_cluster.c(2919): cluster: balancer://qacluster Found value JuJ8S_O87OvyrLtC4GM2YUSPAnwB3Jl0R9Hn3mFp.jboss-eap-7.1-3 for stickysession JSESSIONID|jsessionid
[pid 7548:tid 1908] mod_proxy_cluster.c(1057): update_workers_node starting
[pid 7548:tid 1908] mod_proxy_cluster.c(334): Created: reusing worker for ajp://172.16.27.132:8312
[pid 7548:tid 1908] mod_proxy_cluster.c(334): Created: reusing worker for ajp://172.16.27.132:8312
[pid 7548:tid 1908] mod_proxy_cluster.c(1069): update_workers_node done
[pid 7548:tid 1908] mod_proxy_cluster.c(2336): Using deterministic failover target: jboss-eap-7.1-4
<SNIP>
```

JIRA: [MODCLUSTER-590](https://issues.jboss.org/browse/MODCLUSTER-590)