### PR TITLE
Fix for https://issues.redhat.com/browse/MODCLUSTER-714

### DIFF
--- a/native/include/mod_clustersize.h
+++ b/native/include/mod_clustersize.h
@@ -40,6 +40,7 @@
 #define HOSTNODESZ 64
 #define PORTNODESZ 7
 #define SCHEMENDSZ 16
+#define AJPSECRETSZ 64
 
 /* For balancer.h */
 #define COOKNAMESZ 30

--- a/native/include/node.h
+++ b/native/include/node.h
@@ -57,6 +57,7 @@ struct nodemess {
     char Port[PORTNODESZ];
     char Type[SCHEMENDSZ];
     char Upgrade[SCHEMENDSZ];
+    char AJPSecret[AJPSECRETSZ];
     int  reversed; /* 1 : reversed... 0 : normal */
     int  remove;   /* 1 : removed     0 : normal */
 

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -1080,13 +1080,16 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
             strcpy(nodeinfo.mess.Type, "ws");
         if (!strcmp(nodeinfo.mess.Type, "https"))
             strcpy(nodeinfo.mess.Type, "wss");
-        if (mconf->ws_upgrade_header)
-            strcpy(nodeinfo.mess.Upgrade,mconf->ws_upgrade_header);
+        if (mconf->ws_upgrade_header) {
+            strncpy(nodeinfo.mess.Upgrade,mconf->ws_upgrade_header, sizeof(nodeinfo.mess.Upgrade));
+            nodeinfo.mess.Upgrade[sizeof(nodeinfo.mess.Upgrade)-1] = '\0';
+        }
     }
 
     if (strcmp(nodeinfo.mess.Type, "ajp") == 0) {
         if (mconf->ajp_secret) {
-            strcpy(nodeinfo.mess.AJPSecret,mconf->ajp_secret);
+            strncpy(nodeinfo.mess.AJPSecret,mconf->ajp_secret, sizeof(nodeinfo.mess.AJPSecret));
+            nodeinfo.mess.AJPSecret[sizeof(nodeinfo.mess.AJPSecret)-1] = '\0';
         }
     }
     /* Insert or update balancer description */

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -250,8 +250,10 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
                     worker->s->status = PROXY_WORKER_INITIALIZED;
                     strncpy(worker->s->route, node->mess.JVMRoute, sizeof( worker->s->route));
                     worker->s->route[sizeof(worker->s->route)-1] = '\0';
-                    strcpy(worker->s->upgrade, node->mess.Upgrade);
-                    strcpy(worker->s->secret, node->mess.AJPSecret);
+                    strncpy(worker->s->upgrade, node->mess.Upgrade, sizeof(worker->s->upgrade));
+                    worker->s->upgrade[sizeof(worker->s->upgrade)-1] = '\0';
+                    strncpy(worker->s->secret, node->mess.AJPSecret, sizeof(worker->s->secret));
+                    worker->s->secret[sizeof(worker->s->secret)-1] = '\0';
                     /* XXX: We need that information from TC */
                     worker->s->redirect[0] = '\0';
                     worker->s->lbstatus = 0;
@@ -306,8 +308,10 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
             worker->s->hmax = node->mess.smax + 1;
         strncpy(worker->s->route, node->mess.JVMRoute, sizeof(worker->s->route));
         worker->s->route[sizeof(worker->s->route)-1] = '\0';
-        strcpy(worker->s->upgrade, node->mess.Upgrade);
-        strcpy(worker->s->secret, node->mess.AJPSecret);
+        strncpy(worker->s->upgrade, node->mess.Upgrade, sizeof(worker->s->upgrade));
+        worker->s->upgrade[sizeof(worker->s->upgrade)-1] = '\0';
+        strncpy(worker->s->secret, node->mess.AJPSecret, sizeof(worker->s->secret));
+        worker->s->secret[sizeof(worker->s->secret)-1] = '\0';
         worker->s->redirect[0] = '\0';
         worker->s->smax = node->mess.smax;
         worker->s->ttl = node->mess.ttl;

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -251,6 +251,7 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
                     strncpy(worker->s->route, node->mess.JVMRoute, sizeof( worker->s->route));
                     worker->s->route[sizeof(worker->s->route)-1] = '\0';
                     strcpy(worker->s->upgrade, node->mess.Upgrade);
+                    strcpy(worker->s->secret, node->mess.AJPSecret);
                     /* XXX: We need that information from TC */
                     worker->s->redirect[0] = '\0';
                     worker->s->lbstatus = 0;
@@ -306,6 +307,7 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
         strncpy(worker->s->route, node->mess.JVMRoute, sizeof(worker->s->route));
         worker->s->route[sizeof(worker->s->route)-1] = '\0';
         strcpy(worker->s->upgrade, node->mess.Upgrade);
+        strcpy(worker->s->secret, node->mess.AJPSecret);
         worker->s->redirect[0] = '\0';
         worker->s->smax = node->mess.smax;
         worker->s->ttl = node->mess.ttl;


### PR DESCRIPTION
Secret is already supported in the ajp proxy in Apache httpd trunk and 2.4.42 (and JBCS-httpd-2.4.37).