### PR TITLE
Fix for mod_manager.c,opening files in children processes and shared memory creation [MODCLUSTER-726][MODCLUSTER-725]

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -570,6 +570,7 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
     char *sessionid;
     char *domain;
     char *version;
+    char *filename;
     version_data *base;
     void *data;
     const char *userdata_key = "mod_manager_init";
@@ -606,6 +607,19 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
         mconf->maxhost = mconf->maxnode;
     if (mconf->maxcontext < mconf->maxhost)
         mconf->maxcontext = mconf->maxhost;
+
+    filename = apr_pstrcat(p, node , ".lock", NULL);
+    if (apr_file_open(&nodes_global_lock, filename, APR_WRITE|APR_CREATE, APR_OS_DEFAULT, p) != APR_SUCCESS) {
+        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,"manager_init: apr_file_open for lock failed");
+        return !OK;
+    }
+
+    filename = apr_pstrcat(p, context , ".lock", NULL);
+    if (apr_file_open(&contexts_global_lock, filename, APR_WRITE|APR_CREATE, APR_OS_DEFAULT, p) != APR_SUCCESS) {
+        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
+                    "manager_init: apr_file_open for lock failed");
+            return !OK;
+    }
 
     /* Get a provider to handle the shared memory */
     storage = ap_lookup_provider(SLOTMEM_STORAGE, "shared", "0");
@@ -661,7 +675,16 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
     if (is_child_process()) {
         rv = apr_shm_attach(&versionipc_shm, (const char *) version, p);
     } else {
-        rv = apr_shm_create(&versionipc_shm, sizeof(version_data), (const char *) version, p);
+        /* Use anonymous shm by default, fall back on name-based. */
+        rv = apr_shm_create(&versionipc_shm, sizeof(version_data), NULL, p);
+        if ( rv == APR_ENOTIMPL ) 
+        {
+            /* For a name-based segment, remove it first in case of a
+            * previous unclean shutdown. */
+            apr_shm_remove((const char *) version, p);
+            /* Now create that segment */
+            rv = apr_shm_create(&versionipc_shm, sizeof(version_data), (const char *) version, p);
+        }
     }
     if (rv != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_EMERG, rv, s, "create_share_version failed");
@@ -3059,7 +3082,6 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
     char *host;
     char *balancer;
     char *sessionid;
-    char *filename;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
 
     if (storage == NULL) {
@@ -3093,21 +3115,6 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
         balancer = ap_server_root_relative(p, "logs/manager.balancer");
         sessionid = ap_server_root_relative(p, "logs/manager.sessionid");
     }
-
-    /* create the global node file look */
-    filename = apr_pstrcat(p, node , ".lock", NULL);
-    if (apr_file_open(&nodes_global_lock, filename, APR_WRITE|APR_CREATE, APR_OS_DEFAULT, p) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "manager_child_init: apr_file_open for lock failed");
-        return;
-    }
-    filename = apr_pstrcat(p, context , ".lock", NULL);
-    if (apr_file_open(&contexts_global_lock, filename, APR_WRITE|APR_CREATE, APR_OS_DEFAULT, p) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "manager_child_init: apr_file_open for lock failed");
-        return;
-    }
-
 
     nodestatsmem = get_mem_node(node, &mconf->maxnode, p, storage);
     if (nodestatsmem == NULL) {


### PR DESCRIPTION
mod_manager.c had an issue where it would try to open some .lock files in the manager_child_init function, it wouldn't find them and try to create them but it didn't have the permissions since it was a child process.
I just created the .lock files in the manager_init function so all the child processes could inherit the file descriptors.

EDIT**

Also fixed some problems that mod_manager.c has with shared memories.
It would create a shared memory with apr_shm_create, which if httpd didn't shut down properly was never clean up, as a result when httpd would be started again it would try to apr_shm_create the same file and get file exists error.
Now it tries to create an anonymous shared memory, if the system doesn't support anonymous shared memories it removes the old named shared memory if it exists and creates a new one.