### PR TITLE
Fix for https://issues.redhat.com/browse/MODCLUSTER-755

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -2403,6 +2403,29 @@ static int manager_trans(request_rec *r)
     return DECLINED;
 }
 
+/* fixup logic to prevent subrequest to our methods */
+static int manager_map_to_storage(request_rec *r)
+{
+    int ours = 0;
+    mod_manager_config *mconf = ap_get_module_config(r->server->module_config,
+                                                     &manager_module);
+    if (r->method_number != M_INVALID)
+        return DECLINED;
+    if (!mconf->enable_mcpm_receive)
+        return DECLINED; /* Not allowed to receive MCMP */
+
+    ours = check_method(r); 
+    if (ours) {
+        int i;
+        /* The method one of ours */
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                    "manager_map_to_storage %s (%s)", r->method, r->uri);
+        return OK;
+    }
+    
+    return DECLINED;
+}
+
 /* Create the commands that are possible on the context */
 static char*context_string(request_rec *r, contextinfo_t *ou, char *Alias, char *JVMRoute)
 {
@@ -3595,6 +3618,9 @@ static void manager_hooks(apr_pool_t *p)
 
     /* Process the request from the ModClusterService */
     ap_hook_handler(manager_handler, NULL, NULL, APR_HOOK_REALLY_FIRST);
+
+    /* prevent subrequest to map our / or what ever is send with our methods. */
+    ap_hook_map_to_storage(manager_map_to_storage, NULL, NULL, APR_HOOK_REALLY_FIRST);
 
     /* Register nodes/hosts/contexts table provider */
     ap_register_provider(p, "manager" , "shared", "0", &node_storage);

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2453,9 +2453,19 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
     proxy_cluster_helper *helper;
     const char *context_id;
 
-    proxy_vhost_table *vhost_table = read_vhost_table(r->pool, host_storage);
-    proxy_context_table *context_table = read_context_table(r->pool, context_storage);
-    proxy_node_table *node_table = read_node_table(r->pool, node_storage);
+    /* the node should be filled in trans(). */
+    proxy_vhost_table *vhost_table = (proxy_vhost_table *) apr_table_get(r->notes, "vhost-table");
+    proxy_context_table *context_table  = (proxy_context_table *) apr_table_get(r->notes, "context-table");
+    proxy_node_table *node_table  = (proxy_node_table *) apr_table_get(r->notes, "node-table");
+
+    if (!vhost_table)
+        vhost_table = read_vhost_table(r->pool, host_storage);
+
+    if (!context_table)
+        context_table = read_context_table(r->pool, context_storage);
+
+    if (!node_table)
+        node_table = read_node_table(r->pool, node_storage);
 
     *worker = NULL;
 #if HAVE_CLUSTER_EX_DEBUG


### PR DESCRIPTION
In the mapping of the MCMP / are triggering a subrequest to /index.html that forces a call to update_workers_node() for each MCMP messages.
The fix adds a manager_map_to_storage() to prevent other httpd modules to try to map our URL (/ and */).