### PR TITLE
Allow MemManagerFile to use ServerRoot relative paths fix for MODCLUSTER-760

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -3277,7 +3277,7 @@ static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void *mconfig, con
     if (err != NULL) {
         return err;
     }
-    mconf->basefilename = p_server_root_relative(cmd->pool, word);
+    mconf->basefilename = ap_server_root_relative(cmd->pool, word);
     if (apr_dir_make_recursive(mconf->basefilename, APR_UREAD | APR_UWRITE | APR_UEXECUTE, cmd->pool) != APR_SUCCESS)
         return  "Can't create directory corresponding to MemManagerFile";
     return NULL;

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -3277,7 +3277,7 @@ static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void *mconfig, con
     if (err != NULL) {
         return err;
     }
-    mconf->basefilename = apr_pstrdup(cmd->pool, word);
+    mconf->basefilename = p_server_root_relative(cmd->pool, word);
     if (apr_dir_make_recursive(mconf->basefilename, APR_UREAD | APR_UWRITE | APR_UEXECUTE, cmd->pool) != APR_SUCCESS)
         return  "Can't create directory corresponding to MemManagerFile";
     return NULL;


### PR DESCRIPTION
MemManagerFile directive requires absolute path to directory where runtime data is stored.
The patch allows to have relative paths against ServerRoot.

One can use 'MemManagerFile cache/mod_proxy_cluster' instead 'MemManagerFile /var/cache/httpd/mod_proxy_cluster'. The patch allows current configurations that have absolute path to work as before, while ensuring that relative paths are created inside ServerRoot.

https://issues.redhat.com/browse/MODCLUSTER-760