### PR TITLE
[draft] MODCLUSTER-756 table reads repeated in proxy_cluster_pre_request degrade performance

### DIFF
--- a/native/common/common.c
+++ b/native/common/common.c
@@ -20,7 +20,7 @@
 #include "mod_proxy_cluster.h"
 
 /* Read the virtual host table from shared memory */
-proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method *host_storage)
+proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method *host_storage, int for_cache)
 {
     int i;
     int size;
@@ -35,7 +35,32 @@ proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method
 
     vhost_table->vhosts =  apr_palloc(pool, sizeof(int) * host_storage->get_max_size_host());
     vhost_table->sizevhost = host_storage->get_ids_used_host(vhost_table->vhosts);
-    vhost_table->vhost_info = apr_palloc(pool, sizeof(hostinfo_t) * vhost_table->sizevhost);
+    if (for_cache)
+        vhost_table->vhost_info = apr_palloc(pool, sizeof(hostinfo_t) * size);
+    else
+        vhost_table->vhost_info = apr_palloc(pool, sizeof(hostinfo_t) * vhost_table->sizevhost);
+    for (i = 0; i < vhost_table->sizevhost; i++) {
+        hostinfo_t* h;
+        int host_index = vhost_table->vhosts[i];
+        host_storage->read_host(host_index, &h);
+        vhost_table->vhost_info[i] = *h;
+    }
+    return vhost_table;
+}
+/* Update the virtual host table from shared memory to populate a cached table */
+proxy_vhost_table *update_vhost_table_cached(proxy_vhost_table *vhost_table, struct host_storage_method *host_storage)
+{
+    int i;
+    int size;
+    size = host_storage->get_max_size_host();
+    if (size == 0) {
+        vhost_table->sizevhost = 0;
+        vhost_table->vhosts = NULL;
+        vhost_table->vhost_info = NULL;
+        return vhost_table;
+    }
+
+    vhost_table->sizevhost = host_storage->get_ids_used_host(vhost_table->vhosts);
     for (i = 0; i < vhost_table->sizevhost; i++) {
         hostinfo_t* h;
         int host_index = vhost_table->vhosts[i];
@@ -46,7 +71,7 @@ proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method
 }
 
 /* Read the context table from shared memory */
-proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage_method *context_storage)
+proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage_method *context_storage, int for_cache)
 {
     int i;
     int size;
@@ -60,7 +85,32 @@ proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage
     }
     context_table->contexts =  apr_palloc(pool, sizeof(int) * size);
     context_table->sizecontext = context_storage->get_ids_used_context(context_table->contexts);
-    context_table->context_info = apr_palloc(pool, sizeof(contextinfo_t) * context_table->sizecontext);
+    if (for_cache)
+        context_table->context_info = apr_palloc(pool, sizeof(contextinfo_t) * size);
+    else
+        context_table->context_info = apr_palloc(pool, sizeof(contextinfo_t) * context_table->sizecontext);
+    for (i = 0; i < context_table->sizecontext; i++) {
+        contextinfo_t* h;
+        int context_index = context_table->contexts[i];
+        context_storage->read_context(context_index, &h);
+        context_table->context_info[i] = *h;
+    }
+    return context_table;
+}
+
+/* Update the context table from shared memory to populate a cached table */
+proxy_context_table *update_context_table_cached(proxy_context_table *context_table, struct context_storage_method *context_storage)
+{
+    int i;
+    int size;
+    size = context_storage->get_max_size_context();
+    if (size == 0) {
+        context_table->sizecontext = 0;
+        context_table->contexts = NULL;
+        context_table->context_info = NULL;
+        return context_table;
+    }
+    context_table->sizecontext = context_storage->get_ids_used_context(context_table->contexts);
     for (i = 0; i < context_table->sizecontext; i++) {
         contextinfo_t* h;
         int context_index = context_table->contexts[i];
@@ -71,7 +121,7 @@ proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage
 }
 
 /* Read the balancer table from shared memory */
-proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage)
+proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage, int for_cache)
 {
     int i;
     int size;
@@ -85,7 +135,32 @@ proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_stor
     }
     balancer_table->balancers =  apr_palloc(pool, sizeof(int) * size);
     balancer_table->sizebalancer = balancer_storage->get_ids_used_balancer(balancer_table->balancers);
-    balancer_table->balancer_info = apr_palloc(pool, sizeof(balancerinfo_t) * balancer_table->sizebalancer);
+    if (for_cache)
+        balancer_table->balancer_info = apr_palloc(pool, sizeof(balancerinfo_t) * size);
+    else
+        balancer_table->balancer_info = apr_palloc(pool, sizeof(balancerinfo_t) * balancer_table->sizebalancer);
+    for (i = 0; i < balancer_table->sizebalancer; i++) {
+        balancerinfo_t* h;
+        int balancer_index = balancer_table->balancers[i];
+        balancer_storage->read_balancer(balancer_index, &h);
+        balancer_table->balancer_info[i] = *h;
+    }
+    return balancer_table;
+}
+
+/* Update the balancer table from shared memory to populate a cached table */
+proxy_balancer_table *update_balancer_table_cached(proxy_balancer_table *balancer_table, struct balancer_storage_method *balancer_storage)
+{
+    int i;
+    int size;
+    size = balancer_storage->get_max_size_balancer();
+    if (size == 0) {
+        balancer_table->sizebalancer = 0;
+        balancer_table->balancers = NULL;
+        balancer_table->balancer_info = NULL;
+        return balancer_table;
+    }
+    balancer_table->sizebalancer = balancer_storage->get_ids_used_balancer(balancer_table->balancers);
     for (i = 0; i < balancer_table->sizebalancer; i++) {
         balancerinfo_t* h;
         int balancer_index = balancer_table->balancers[i];
@@ -96,7 +171,7 @@ proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_stor
 }
 
 /* Read the node table from shared memory */
-proxy_node_table *read_node_table(apr_pool_t *pool, struct node_storage_method *node_storage)
+proxy_node_table *read_node_table(apr_pool_t *pool, struct node_storage_method *node_storage, int for_cache)
 {
     int i;
     int size;
@@ -110,12 +185,54 @@ proxy_node_table *read_node_table(apr_pool_t *pool, struct node_storage_method *
     }
     node_table->nodes =  apr_palloc(pool, sizeof(int) * size);
     node_table->sizenode = node_storage->get_ids_used_node(node_table->nodes);
-    node_table->node_info = apr_palloc(pool, sizeof(nodeinfo_t) * node_table->sizenode);
+    if (for_cache) {
+        node_table->node_info = apr_palloc(pool, sizeof(nodeinfo_t) * size);
+        node_table->ptr_node = apr_palloc(pool, sizeof(char *) * size);
+    } else {
+        node_table->node_info = apr_palloc(pool, sizeof(nodeinfo_t) * node_table->sizenode);
+        node_table->ptr_node = apr_palloc(pool, sizeof(char *) * node_table->sizenode);
+    }
     for (i = 0; i < node_table->sizenode; i++) {
         nodeinfo_t* h;
         int node_index = node_table->nodes[i];
-        node_storage->read_node(node_index, &h);
-        node_table->node_info[i] = *h;
+        apr_status_t rv = node_storage->read_node(node_index, &h);
+        if (rv == APR_SUCCESS) {
+            node_table->node_info[i] = *h;
+            node_table->ptr_node[i] = (char *) h;
+        } else {
+            /* we can't read the node! */
+            node_table->ptr_node[i] = NULL;
+            memset(&node_table->node_info[i], 0, sizeof(nodeinfo_t));
+        }
+    }
+    return node_table;
+}
+
+/* Update the node table from shared memory to populate a cached table*/
+proxy_node_table *update_node_table_cached(proxy_node_table *node_table, struct node_storage_method *node_storage)
+{
+    int i;
+    int size;
+    size = node_storage->get_max_size_node();
+    if (size == 0) {
+        node_table->sizenode = 0;
+        node_table->nodes = NULL;
+        node_table->node_info = NULL;
+        return node_table;
+    }
+    node_table->sizenode = node_storage->get_ids_used_node(node_table->nodes);
+    for (i = 0; i < node_table->sizenode; i++) {
+        nodeinfo_t* h;
+        int node_index = node_table->nodes[i];
+        apr_status_t rv = node_storage->read_node(node_index, &h);
+        if (rv == APR_SUCCESS) {
+            node_table->node_info[i] = *h;
+            node_table->ptr_node[i] = (char *) h;
+        } else {
+            /* we can't read the node! */
+            node_table->ptr_node[i] = NULL;
+            memset(&node_table->node_info[i], 0, sizeof(nodeinfo_t));
+        }
     }
     return node_table;
 }

--- a/native/include/mod_proxy_cluster.h
+++ b/native/include/mod_proxy_cluster.h
@@ -79,12 +79,13 @@ struct proxy_balancer_table
 };
 typedef struct proxy_balancer_table proxy_balancer_table;
 
-/* Node table copy for local use */
+/* Node table copy for local use, the ptr_node is the shared memory address (slotmem address) */
 struct proxy_node_table
 {
 	int sizenode;
 	int* nodes;
 	nodeinfo_t*  node_info;
+        char **ptr_node;
 };
 typedef struct proxy_node_table proxy_node_table;
 
@@ -97,10 +98,14 @@ struct node_context
 typedef struct node_context node_context;
 
 /* common routines */
-proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method *host_storage);
-proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage_method *context_storage);
-proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage);
-proxy_node_table *read_node_table(apr_pool_t *pool, struct node_storage_method *node_storage);
+proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method *host_storage, int for_cache);
+proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage_method *context_storage, int for_cache);
+proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage, int for_cache);
+proxy_node_table *read_node_table(apr_pool_t *pool, struct node_storage_method *node_storage, int for_cache);
+proxy_vhost_table *update_vhost_table_cached(proxy_vhost_table *proxy_vhost_table, struct host_storage_method *host_storage);
+proxy_context_table *update_context_table_cached(proxy_context_table *context_table, struct context_storage_method *context_storage);
+proxy_balancer_table *update_balancer_table_cached(proxy_balancer_table *balancer_table, struct balancer_storage_method *balancer_storage);
+proxy_node_table *update_node_table_cached(proxy_node_table *node_table, struct node_storage_method *node_storage);
 
 const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
                                       proxy_vhost_table *vhost_table,

--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -120,7 +120,9 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id)
 
     node->mess.id = 0;
     now = apr_time_now();
-    s->storage->ap_slotmem_lock(s->slotmem);
+    rv = s->storage->ap_slotmem_lock(s->slotmem);
+    if (rv != APR_SUCCESS)
+        return(rv);
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &node, s->p);
     if (node->mess.id != 0 && rv == APR_SUCCESS) {
         s->storage->ap_slotmem_unlock(s->slotmem);
@@ -190,7 +192,9 @@ nodeinfo_t * read_node(mem_t *s, nodeinfo_t *node)
 apr_status_t get_node(mem_t *s, nodeinfo_t **node, int ids)
 {
   apr_status_t status;
-  s->storage->ap_slotmem_lock(s->slotmem);
+  status = s->storage->ap_slotmem_lock(s->slotmem);
+  if (status != APR_SUCCESS)
+    return(status);
   status = s->storage->ap_slotmem_mem(s->slotmem, ids, (void **) node);
   s->storage->ap_slotmem_unlock(s->slotmem);
   return(status);

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1641,6 +1641,7 @@ static void proxy_cluster_watchdog_func(server_rec *s, apr_pool_t *pool)
                     ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
                                  "cached_pool: should have been created in proxy_cluster_child_init!");
                 }
+                apr_thread_mutex_unlock(lock);
             }
             node_table = cached_node_table;
         } else {

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1593,7 +1593,7 @@ static void remove_workers_nodes(proxy_server_conf *conf, apr_pool_t *pool, serv
     }
     apr_thread_mutex_unlock(lock);
 }
-/* Called by mc_watchdog_callback every seconds and for each server and from one child only */
+/* Called by mc_watchdog_callback every seconds and for each server */
 static void proxy_cluster_watchdog_func(server_rec *s, apr_pool_t *pool)
 {
     void *sconf = s->module_config;
@@ -1786,7 +1786,7 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
     }
     if (mc_watchdog_get_instance(&watchdog,
                                   LB_CLUSTER_WATHCHDOG_NAME,
-                                  0, 1, p)) {
+                                  0, 0, p)) {
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03263)
                      "Failed to create watchdog instance (%s)",
                      LB_CLUSTER_WATHCHDOG_NAME);

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -105,6 +105,16 @@ static int enable_options = -1; /* Use OPTIONS * for CPING/CPONG */
 #define TIMESESSIONID 300                    /* after 5 minutes the sessionid have probably timeout */
 #define TIMEDOMAIN    300                    /* after 5 minutes the sessionid have probably timeout */
 
+
+/* Create static table references we can look back to instead of fetching each request */
+static apr_time_t cache_share_for =  apr_time_from_sec(0); /* cache the shared memory in the process for n seconds */
+static apr_time_t last_cached = 0;
+static apr_pool_t *cached_pool = NULL;
+static proxy_vhost_table *cached_vhost_table = NULL;
+static proxy_context_table *cached_context_table = NULL;
+static proxy_balancer_table *cached_balancer_table = NULL;
+static proxy_node_table *cached_node_table = NULL;
+
 static int proxy_worker_cmp(const void *a, const void *b)
 {
     const char *route1 = (*(proxy_worker **) a)->s->route;
@@ -144,6 +154,7 @@ static int (*ap_proxy_retry_worker_fn)(const char *proxy_function,
  * XXX: If something goes wrong the worker can't be used and we leak memory... in a pool
  * NOTE: pool is the request pool or any temporary pool. Use conf->pool for any data that live longer.
  * @param node the pointer to the node structure
+ * @param ptr_node the address of the node in shared memory.
  * @param conf a proxy_server_conf.
  * @param balancer the balancer to update.
  * @param pool a temporary pool.
@@ -152,7 +163,7 @@ static int (*ap_proxy_retry_worker_fn)(const char *proxy_function,
  */
 static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balancer,
                           server_rec *server,
-                          nodeinfo_t *node, apr_pool_t *pool)
+                          nodeinfo_t *node, char *ptr_node, apr_pool_t *pool)
 {
     char *url;
     char *ptr;
@@ -216,7 +227,7 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
                          "Created: reusing removed worker for %s", url);
         } else {
             /* Check if the shared memory goes to the right place */
-            char *pptr = (char *) node;
+            char *pptr = ptr_node;
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                          "Created: reusing worker for %s", url);
             pptr = pptr + node->offset;
@@ -245,7 +256,7 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
             } else {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                              "Created: can't reuse worker as it for %s cleaning...", url);
-                ptr = (char *) node;
+                ptr = ptr_node;
                 ptr = ptr + node->offset;
                 shared = worker->s;
                 worker->s = (proxy_worker_shared *) ptr;
@@ -270,7 +281,7 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
      * 3 - we are reusing a removed worker.
      */
     node_storage->lock_nodes();
-    ptr = (char *) node;
+    ptr = ptr_node;
     ptr = ptr + node->offset;
     shared = worker->s;
     worker->s = (proxy_worker_shared *) ptr;
@@ -503,9 +514,10 @@ static void reuse_balancer(proxy_balancer *balancer, char *name, apr_pool_t *poo
  * Adds the balancers and the workers to the VirtualHosts corresponding to node
  * Note that the calling routine should lock before calling us.
  * @param node the node information to add.
+ * @param ptr_node address of the node in shared memory.
  * @param pool  temporary pool to use for temporary buffer.
  */
-static void add_balancers_workers(nodeinfo_t *node, apr_pool_t *pool)
+static void add_balancers_workers(nodeinfo_t *node, char *ptr_node, apr_pool_t *pool)
 {
     server_rec *s = main_server;
     char *name = apr_pstrcat(pool, "balancer://", node->mess.balancer, NULL);
@@ -527,7 +539,7 @@ static void add_balancers_workers(nodeinfo_t *node, apr_pool_t *pool)
             reuse_balancer(balancer, &balancer->s->name[11], pool, s);
         }
         if (balancer)
-            create_worker(conf, balancer, s, node, pool);
+            create_worker(conf, balancer, s, node, ptr_node, pool);
         s = s->next;
     }
 }
@@ -536,10 +548,11 @@ static void add_balancers_workers(nodeinfo_t *node, apr_pool_t *pool)
  * Adds the balancers and the workers to the VirtualHosts corresponding to node
  * Note that the calling routine should lock before calling us.
  * @param node the node information to add.
+ * @param ptr_node the addr of the node in shared memory
  * @param pool  temporary pool to use for temporary buffer.
  * @param server the server to use
  */
-static void add_balancers_workers_for_server(nodeinfo_t *node, apr_pool_t *pool, server_rec *s)
+static void add_balancers_workers_for_server(nodeinfo_t *node, char *ptr_node, apr_pool_t *pool, server_rec *s)
 {
     char *name = apr_pstrcat(pool, "balancer://", node->mess.balancer, NULL);
             
@@ -558,7 +571,7 @@ static void add_balancers_workers_for_server(nodeinfo_t *node, apr_pool_t *pool,
         reuse_balancer(balancer, &balancer->s->name[11], pool, s);
     }
     if (balancer)
-        create_worker(conf, balancer, s, node, pool);
+        create_worker(conf, balancer, s, node, ptr_node, pool);
 }
 
 
@@ -650,10 +663,13 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
  * NOTE: It is called from proxy_cluster_watchdog_func and other locations
  *       It shouldn't call worker_nodes_are_updated() because there may be several VirtualHosts.
  */
-static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server, int check)
+static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server, int check, proxy_node_table *node_table)
 {
-    int *id, size, i;
+    int i;
     unsigned int last;
+
+    if (node_table == NULL)
+        return;
 
     /* Check if we have to do something */
     apr_thread_mutex_lock(lock);
@@ -666,28 +682,19 @@ static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, serve
         }
     }
 
-    /* read the ident of the nodes */
-    size = node_storage->get_max_size_node();
-    if (size == 0) {
-        apr_thread_mutex_unlock(lock);
-        return;
-    }
-    id = apr_pcalloc(pool, sizeof(int) * size);
-    size = node_storage->get_ids_used_node(id);
-
     /* XXX: How to skip the balancer that aren't controled by mod_manager */
 
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
              "update_workers_node starting");
 
     /* Only process the nodes that have been updated since our last update */
-    for (i=0; i<size; i++) {
-        nodeinfo_t *ou;
-        if (node_storage->read_node(id[i], &ou) != APR_SUCCESS)
-            continue;
+    for (i = 0; i < node_table->sizenode; i++) {
+        nodeinfo_t *ou = &node_table->node_info[i];
         if (ou->mess.remove) 
             continue;
-        add_balancers_workers_for_server(ou, pool, server);
+        if (node_table->ptr_node[i] == NULL)
+            continue;
+        add_balancers_workers_for_server(ou, node_table->ptr_node[i], pool, server);
     } 
 
     apr_thread_mutex_unlock(lock);
@@ -1257,7 +1264,7 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
 #endif
 
     /* create workers for new nodes */
-    update_workers_node(conf, r->pool, r->server, 1);
+    update_workers_node(conf, r->pool, r->server, 1, node_table);
 
     /* First try to see if we have available candidate */
     if (domain && strlen(domain)>0)
@@ -1417,10 +1424,11 @@ static int proxy_node_isup(request_rec *r, int id, int load)
     ptr = (char *) node;
     ptr = ptr + node->offset;
     stat = (proxy_worker_shared *) ptr;
+    ptr = (char *) node;
 
     /* create the balancers and workers (that could be the first time) */
     apr_thread_mutex_lock(lock);
-    add_balancers_workers(node, r->pool);
+    add_balancers_workers(node, ptr, r->pool);
     apr_thread_mutex_unlock(lock);
 
     /* search for the worker in the VirtualHosts */ 
@@ -1593,33 +1601,72 @@ static void remove_workers_nodes(proxy_server_conf *conf, apr_pool_t *pool, serv
     }
     apr_thread_mutex_unlock(lock);
 }
-/* Called by mc_watchdog_callback every seconds and for each server */
+/* Called by mc_watchdog_callback every n seconds */
+/* it is called for the main server, we need to loop on all servers */
 static void proxy_cluster_watchdog_func(server_rec *s, apr_pool_t *pool)
 {
     void *sconf = s->module_config;
     proxy_server_conf *conf = (proxy_server_conf *)
         ap_get_module_config(sconf, &proxy_module);
     unsigned int last;
+    server_rec *smain = s;
+    proxy_node_table *node_table = NULL;
 
     if (!conf)
        return;
 
+    /* check if we need to update. */
     last = node_storage->worker_nodes_need_update(s, pool);
 
-    /* Create new workers if the shared memory changes */
-    if (last)
-        update_workers_node(conf, pool, s, 0);
-    /* removed nodes: check for workers */
-    remove_workers_nodes(conf, pool, s);
-    /* Calculate the lbstatus for each node */
-    update_workers_lbstatus(conf, pool, s);
-    /* Free sessionid slots */
-    if (sessionid_storage)
-        remove_timeout_sessionid(conf, pool, s);
-    /* cleanup removed node in shared memory */
-    remove_removed_node(pool, s);
+    /* if we need to update, let's check the cache */
     if (last) {
-        node_storage->worker_nodes_are_updated(s, last);
+        if (cache_share_for) {
+            /* time to refresh or create */
+            apr_time_t now = apr_time_now();
+            if (now >= last_cached+cache_share_for) {
+                apr_thread_mutex_lock(lock);
+                last_cached = now;
+                if (cached_pool) {
+                    /* we need to update the cache */
+                    update_vhost_table_cached(cached_vhost_table, host_storage);
+                    update_context_table_cached(cached_context_table, context_storage);
+                    update_balancer_table_cached(cached_balancer_table, balancer_storage);
+                    update_node_table_cached(cached_node_table, node_storage);
+                } else {
+                    apr_pool_create(&cached_pool, conf->pool);
+                    cached_vhost_table = read_vhost_table(cached_pool, host_storage, 1);
+                    cached_context_table = read_context_table(cached_pool, context_storage, 1);
+                    cached_balancer_table = read_balancer_table(cached_pool, balancer_storage, 1);
+                    cached_node_table = read_node_table(cached_pool, node_storage, 1);
+                    ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
+                                 "cached_pool: should have been created in proxy_cluster_child_init!");
+                }
+            }
+            node_table = cached_node_table;
+        } else {
+            node_table = read_node_table(pool, node_storage, 0);
+        }
+    }
+
+    while (s) {
+        sconf = s->module_config;
+        conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
+        /* Create new workers if the shared memory has changed */
+        if (last)
+            update_workers_node(conf, pool, s, 0, node_table);
+        /* removed nodes: check for workers */
+        remove_workers_nodes(conf, pool, s);
+        /* Calculate the lbstatus for each node */
+        update_workers_lbstatus(conf, pool, s);
+        /* Free sessionid slots */
+        if (sessionid_storage)
+            remove_timeout_sessionid(conf, pool, s);
+        /* cleanup removed node in shared memory */
+        remove_removed_node(pool, s);
+        s = s->next;
+    }
+    if (last) {
+        node_storage->worker_nodes_are_updated(smain, last);
     }
 }
 
@@ -1635,10 +1682,13 @@ static apr_status_t mc_watchdog_callback(int state, void *data,
 
         case AP_WATCHDOG_STATE_RUNNING:
             if (s) {
+               apr_time_t wait = cache_share_for;
                /* It is called for every server defined in httpd */
                proxy_cluster_watchdog_func(s, pool);
-               /* set the next call back XXX = 1 s can't it be better? */
-               mc_watchdog_set_interval(watchdog, apr_time_make(1, 0), s, mc_watchdog_callback);
+               /* set the next call back to cache_share_for or 1 if zero */
+               if (!wait)
+                   wait = apr_time_from_sec(1);
+               mc_watchdog_set_interval(watchdog, wait, s, mc_watchdog_callback);
             }
             break;
 
@@ -1667,15 +1717,28 @@ static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
                     "proxy_cluster_child_init: apr_thread_mutex_create failed");
     }
 
-    if (conf) {
+    if (conf && node_storage && node_storage->get_max_size_node()) {
+        /* fill the cache and create pool */
         apr_pool_t *pool;
+        proxy_node_table *node_table = NULL;
         apr_pool_create(&pool, conf->pool);
+        if (cache_share_for) {
+            apr_pool_create(&cached_pool, conf->pool);
+            cached_vhost_table = read_vhost_table(cached_pool, host_storage, 1);
+            cached_context_table = read_context_table(cached_pool, context_storage, 1);
+            cached_balancer_table = read_balancer_table(cached_pool, balancer_storage, 1);
+            cached_node_table = read_node_table(cached_pool, node_storage, 1);
+            node_table = cached_node_table;
+        } else {
+            node_table = read_node_table(pool, node_storage, 0);
+        }
+        
         while (s) {
             sconf = s->module_config;
             conf = (proxy_server_conf *)
                 ap_get_module_config(sconf, &proxy_module);
 
-            update_workers_node(conf, pool, s, 0);
+            update_workers_node(conf, pool, s, 0, node_table);
 
             s = s->next;
         }
@@ -1792,17 +1855,14 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
                      LB_CLUSTER_WATHCHDOG_NAME);
         return !OK;
     }
-    while (s) {
-        if (mc_watchdog_register_callback(watchdog,
-                AP_WD_TM_SLICE,
-                s,
-                mc_watchdog_callback)) {
-            ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03264)
-                         "Failed to register watchdog callback (%s)",
-                         LB_CLUSTER_WATHCHDOG_NAME);
-            return !OK;
-        }
-        s = s->next;
+    if (mc_watchdog_register_callback(watchdog,
+            AP_WD_TM_SLICE,
+            s,
+            mc_watchdog_callback)) {
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03264)
+                     "Failed to register watchdog callback (%s)",
+                     LB_CLUSTER_WATHCHDOG_NAME);
+        return !OK;
     }
     return OK;
 }
@@ -1910,10 +1970,22 @@ static int proxy_cluster_trans(request_rec *r)
     proxy_server_conf *conf = (proxy_server_conf *)
         ap_get_module_config(sconf, &proxy_module);
 
-    proxy_vhost_table *vhost_table = read_vhost_table(r->pool, host_storage);
-    proxy_context_table *context_table = read_context_table(r->pool, context_storage);
-    proxy_balancer_table *balancer_table = read_balancer_table(r->pool, balancer_storage);
-    proxy_node_table *node_table = read_node_table(r->pool, node_storage);
+    proxy_vhost_table *vhost_table = NULL;
+    proxy_context_table *context_table = NULL;
+    proxy_balancer_table *balancer_table = NULL;
+    proxy_node_table *node_table = NULL;
+
+    if (cache_share_for) {
+        vhost_table = cached_vhost_table;
+        context_table = cached_context_table;
+        balancer_table = cached_balancer_table;
+        node_table = cached_node_table;
+    } else {
+        vhost_table = read_vhost_table(r->pool, host_storage, 0);
+        context_table = read_context_table(r->pool, context_storage, 0);
+        balancer_table = read_balancer_table(r->pool, balancer_storage, 0);
+        node_table = read_node_table(r->pool, node_storage, 0);
+    }
 
     apr_table_setn(r->notes, "vhost-table",  (char *) vhost_table);
     apr_table_setn(r->notes, "context-table",  (char *) context_table);
@@ -1926,13 +1998,12 @@ static int proxy_cluster_trans(request_rec *r)
                  r->proxyreq, r->filename, r->handler, r->uri, r->args, r->unparsed_uri);
 #endif
 
-    /* make sure we have a up to date workers and balancers in our process */
-    update_workers_node(conf, r->pool, r->server, 1);
+    /* make sure we have up to date workers and balancers in our process */
+    update_workers_node(conf, r->pool, r->server, 1, node_table);
     balancer = get_route_balancer(r, conf, vhost_table, context_table, balancer_table, node_table, use_alias);
     if (!balancer) {
         balancer = get_context_host_balancer(r, vhost_table, context_table, node_table, use_alias);
     }
-    
 
     if (balancer) {
         int i;
@@ -2066,16 +2137,16 @@ static int proxy_cluster_canon(request_rec *r, char *url)
         proxy_node_table *node_table  = (proxy_node_table *) apr_table_get(r->notes, "node-table");
 
         if (!vhost_table)
-            vhost_table = read_vhost_table(r->pool, host_storage);
+            vhost_table = read_vhost_table(r->pool, host_storage, 0);
 
         if (!context_table)
-            context_table = read_context_table(r->pool, context_storage);
+            context_table = read_context_table(r->pool, context_storage, 0);
 
         if (!balancer_table)
-            balancer_table = read_balancer_table(r->pool, balancer_storage);
+            balancer_table = read_balancer_table(r->pool, balancer_storage, 0);
 
         if (!node_table)
-            node_table = read_node_table(r->pool, node_storage);
+            node_table = read_node_table(r->pool, node_storage, 0);
 
         get_route_balancer(r, conf, vhost_table, context_table, balancer_table, node_table, use_alias);
     }
@@ -2459,13 +2530,13 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
     proxy_node_table *node_table  = (proxy_node_table *) apr_table_get(r->notes, "node-table");
 
     if (!vhost_table)
-        vhost_table = read_vhost_table(r->pool, host_storage);
+        vhost_table = read_vhost_table(r->pool, host_storage, 0);
 
     if (!context_table)
-        context_table = read_context_table(r->pool, context_storage);
+        context_table = read_context_table(r->pool, context_storage, 0);
 
     if (!node_table)
-        node_table = read_node_table(r->pool, node_storage);
+        node_table = read_node_table(r->pool, node_storage, 0);
 
     *worker = NULL;
 #if HAVE_CLUSTER_EX_DEBUG
@@ -2522,7 +2593,7 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
         !(*balancer = ap_proxy_get_balancer(r->pool, conf, *url, 0))) {
         apr_thread_mutex_unlock(lock);
         /* May be the node has not been created yet */
-        update_workers_node(conf, r->pool, r->server, 1);
+        update_workers_node(conf, r->pool, r->server, 1, node_table);
         apr_thread_mutex_lock(lock);
         if (!(*balancer = ap_proxy_get_balancer(r->pool, conf, *url, 0))) {
             apr_thread_mutex_unlock(lock);
@@ -2894,6 +2965,17 @@ static const char *cmd_proxy_cluster_deterministic_failover(cmd_parms *parms, vo
     return NULL;
 }
 
+static const char*cmd_proxy_cluster_cache_shared_for(cmd_parms *cmd, void *dummy, const char *arg)
+{
+    int val = atoi(arg);
+    if (val<0) {
+        return "CacheShareFor must be greater than 0";
+    } else {
+        cache_share_for = apr_time_from_sec(val);
+    }
+    return NULL;
+}
+
 static const command_rec  proxy_cluster_cmds[] =
 {
     AP_INIT_TAKE1(
@@ -2938,6 +3020,13 @@ static const command_rec  proxy_cluster_cmds[] =
         NULL,
         OR_ALL,
         "DeterministicFailover - controls whether a node upon failover is chosen deterministically (Default: Off)"
+    ),
+    AP_INIT_TAKE1(
+        "CacheShareFor",
+        cmd_proxy_cluster_cache_shared_for,
+        NULL,
+        OR_ALL,
+        "CacheShareFor - Time in seconds for how long the shared information is cached by httpd: (Default: 0 seconds, no-caching)"
     ),
     {NULL}
 };


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/MODCLUSTER-756
Try to cache the shared memory.
And fix the watchdog logic.
Add CacheShareFor (n seconds) Directive.