### PR TITLE
[MODCLUSTER-765] avoid update_workers_node calls per request if using CacheShareFor

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1272,7 +1272,8 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
 #endif
 
     /* create workers for new nodes */
-    update_workers_node(conf, r->pool, r->server, 1, node_table);
+    if (!cache_share_for)
+        update_workers_node(conf, r->pool, r->server, 1, node_table);
 
     /* First try to see if we have available candidate */
     if (domain && strlen(domain)>0)
@@ -2016,7 +2017,9 @@ static int proxy_cluster_trans(request_rec *r)
 #endif
 
     /* make sure we have up to date workers and balancers in our process */
-    update_workers_node(conf, r->pool, r->server, 1, node_table);
+    if (!cache_share_for)
+        update_workers_node(conf, r->pool, r->server, 1, node_table);
+
     balancer = get_route_balancer(r, conf, vhost_table, context_table, balancer_table, node_table, use_alias);
     if (!balancer) {
         balancer = get_context_host_balancer(r, vhost_table, context_table, node_table, use_alias);


### PR DESCRIPTION
https://issues.redhat.com/browse/MODCLUSTER-765