### PR TITLE
Fix compile warnings

### DIFF
--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -857,5 +857,6 @@ module AP_MODULE_DECLARE_DATA advertise_module =
     create_advertise_server_config,                    /* server config creator                       */
     NULL,                     /* server config merger                        */
     cmd_table,               /* command table                               */
-    register_hooks           /* set up other request processing hooks       */
+    register_hooks,          /* set up other request processing hooks       */
+    AP_MODULE_FLAG_NONE      /* flags */
 };

--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -132,7 +132,7 @@ static ma_global_data_t  *magd = NULL;
 /* ServerAdvertise directive                                                */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy,
+static const char *cmd_advertise_m(cmd_parms *cmd, void * /* dummy */,
                                    const char *arg, const char *opt)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
@@ -169,7 +169,7 @@ static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy,
 /* AdvertiseGroup directive                                                 */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy,
+static const char *cmd_advertise_g(cmd_parms *cmd, void * /* dummy */,
                                    const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
@@ -195,7 +195,7 @@ static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy,
 /* AdvertiseBindAddress directive                                           */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy,
+static const char *cmd_bindaddr(cmd_parms *cmd, void * /* dummy */,
                                    const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
@@ -221,7 +221,7 @@ static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy,
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
 
-static const char *cmd_advertise_f(cmd_parms *cmd, void *dummy,
+static const char *cmd_advertise_f(cmd_parms *cmd, void * /* dummy */,
                                    const char *arg)
 {
     apr_time_t s, u = 0;
@@ -247,7 +247,7 @@ static const char *cmd_advertise_f(cmd_parms *cmd, void *dummy,
 /* AdvertiseSecurityKey directive                                           */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_k(cmd_parms *cmd, void *dummy,
+static const char *cmd_advertise_k(cmd_parms *cmd, void * /* dummy */,
                                    const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
@@ -263,7 +263,7 @@ static const char *cmd_advertise_k(cmd_parms *cmd, void *dummy,
 /* AdvertiseManagerUrl directive                                            */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_h(cmd_parms *cmd, void *dummy,
+static const char *cmd_advertise_h(cmd_parms *cmd, void * /* dummy */,
                                    const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
@@ -430,7 +430,7 @@ static void ma_group_leave()
     }
 }
 
-static void * APR_THREAD_FUNC parent_thread(apr_thread_t *thd, void *data)
+static void * APR_THREAD_FUNC parent_thread(apr_thread_t * /* thd */, void *data)
 {
     static int current_status  = 0;
     int f_time = 1;
@@ -469,7 +469,7 @@ static void * APR_THREAD_FUNC parent_thread(apr_thread_t *thd, void *data)
 
 static apr_status_t pconfig_cleanup(void *data);
 
-static apr_status_t process_cleanup(void *data)
+static apr_status_t process_cleanup(void * /* data */)
 {
     int advertise_run = ma_advertise_run;
 
@@ -499,7 +499,7 @@ static apr_status_t process_cleanup(void *data)
     return APR_SUCCESS;
 }
 
-static apr_status_t pconfig_cleanup(void *data)
+static apr_status_t pconfig_cleanup(void * /* data */)
 {
     int advertise_run = ma_advertise_run;
 
@@ -537,8 +537,8 @@ static apr_status_t pconfig_cleanup(void *data)
 /* Create management thread in parent and initializes Manager               */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
-                            apr_pool_t *ptemp, server_rec *s)
+static int post_config_hook(apr_pool_t *pconf, apr_pool_t * /* plog */,
+                            apr_pool_t * /* ptemp */, server_rec *s)
 {
     apr_status_t rv;
     const char *pk = "advertise_init_module_tag";
@@ -704,7 +704,7 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
     return OK;
 }
 
-static void  child_init_hook(apr_pool_t *p, server_rec *s)
+static void  child_init_hook(apr_pool_t * /* p */, server_rec *s)
 {
     main_server = s;
 }
@@ -814,7 +814,7 @@ static void register_hooks(apr_pool_t *p)
 }
 
 /* Create a default conf structure */
-static void *create_advertise_server_config(apr_pool_t *p, server_rec *s)
+static void *create_advertise_server_config(apr_pool_t *p, server_rec * /* s */)
 {
     mod_advertise_config *mconf = apr_pcalloc(p, sizeof(*mconf));
 

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -437,5 +437,6 @@ AP_DECLARE_MODULE(lbmethod_cluster) = {
     NULL,        /* create per-server config structure */
     NULL,         /* merge per-server config structures */
     NULL,                       /* command apr_table_t */
-    register_hooks              /* register hooks */
+    register_hooks,             /* register hooks */
+    AP_MODULE_FLAG_NONE         /* flags */
 };

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -138,17 +138,17 @@ static proxy_worker *find_best(proxy_balancer *balancer,
     return mycandidate;
 }
 
-static apr_status_t reset(proxy_balancer *balancer, server_rec *s)
+static apr_status_t reset(proxy_balancer * /* balancer */, server_rec * /* s */)
 {
     return APR_SUCCESS;
 }
 
-static apr_status_t age(proxy_balancer *balancer, server_rec *s)
+static apr_status_t age(proxy_balancer * /* balancer */, server_rec * /* s */)
 {
     return APR_SUCCESS;
 }
 
-static apr_status_t updatelbstatus(proxy_balancer *balancer, proxy_worker *elected, server_rec *s)
+static apr_status_t updatelbstatus(proxy_balancer * /* balancer */, proxy_worker * /* elected */, server_rec * /* s */)
 {
     return APR_SUCCESS;
 }
@@ -228,7 +228,7 @@ static int lbmethod_cluster_trans(request_rec *r)
 /*
  * Remove node that have beeen marked removed for more than 10 seconds.
  */
-static void remove_removed_node(server_rec *s, apr_pool_t *pool, apr_time_t now, proxy_node_table *node_table)
+static void remove_removed_node(server_rec * /* s */, apr_pool_t *pool, apr_time_t now, proxy_node_table *node_table)
 {
     int i;
 
@@ -343,8 +343,8 @@ static apr_status_t mc_watchdog_callback(int state, void *data,
     return rv;
 }
 
-static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
-                                     apr_pool_t *ptemp, server_rec *s)
+static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t * /* plog */,
+                                     apr_pool_t * /* ptemp */, server_rec *s)
 {
    APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) *mc_watchdog_get_instance;
    APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;

--- a/native/common/common.c
+++ b/native/common/common.c
@@ -570,7 +570,7 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
 }
 
 /* Given the route find the corresponding domain (if there is a domain) */
-static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, const char *balancer, proxy_node_table *node_table)
+static apr_status_t find_nodedomain(request_rec * /* r */, char **domain, char *route, const char *balancer, proxy_node_table *node_table)
 {
     int i;
     /* XXX JFCLERE!!!! domaininfo_t *dom; */
@@ -610,7 +610,7 @@ static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, 
 const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
                                       proxy_vhost_table *vhost_table,
                                       proxy_context_table *context_table,
-                                      proxy_balancer_table *balancer_table,
+                                      proxy_balancer_table * /* balancer_table */,
                                       proxy_node_table *node_table,
                                       int use_alias)
 {

--- a/native/mod_cluster_slotmem/mod_sharedmem.c
+++ b/native/mod_cluster_slotmem/mod_sharedmem.c
@@ -42,7 +42,7 @@
 #include  "slotmem.h"
 
 /* make sure the shared memory is cleaned */
-static int initialize_cleanup(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
+static int initialize_cleanup(apr_pool_t *p, apr_pool_t * /* plog */, apr_pool_t * /* ptemp */, server_rec *s)
 {
     void *data;
     const char *userdata_key = "mod_sharedmem_init";
@@ -62,8 +62,8 @@ static int initialize_cleanup(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp
  * that is to allow the resize the shared memory area using a graceful start
  * No sure that is a very good idea...
  */
-static int pre_config(apr_pool_t *p, apr_pool_t *plog,
-                             apr_pool_t *ptemp)
+static int pre_config(apr_pool_t * /* p */, apr_pool_t * /* plog */,
+                             apr_pool_t * /* ptemp */)
 {
     apr_pool_t *global_pool;
     apr_status_t rv;
@@ -81,7 +81,7 @@ static int pre_config(apr_pool_t *p, apr_pool_t *plog,
 /*
  * Create the mutex of the insert/remove logic
  */
-static void child_init(apr_pool_t *p, server_rec *s)
+static void child_init(apr_pool_t *p, server_rec * /* s */)
 {
     sharedmem_initialize_child(p);
 }

--- a/native/mod_cluster_slotmem/mod_sharedmem.c
+++ b/native/mod_cluster_slotmem/mod_sharedmem.c
@@ -103,5 +103,6 @@ module AP_MODULE_DECLARE_DATA cluster_slotmem_module = {
     NULL,       /* create per-server config structure */
     NULL,       /* merge per-server config structures */
     NULL,       /* command apr_table_t */
-    ap_sharedmem_register_hook /* register hooks */
+    ap_sharedmem_register_hook, /* register hooks */
+    AP_MODULE_FLAG_NONE         /* flags */
 };

--- a/native/mod_cluster_slotmem/sharedmem_util.c
+++ b/native/mod_cluster_slotmem/sharedmem_util.c
@@ -166,7 +166,7 @@ static void restore_slotmem(void *ptr, const char *name, apr_size_t item_size, i
     if (rv == APR_SUCCESS) {
         apr_finfo_t fi;
         if (apr_file_info_get(&fi, APR_FINFO_SIZE, fp) == APR_SUCCESS) {
-            if (fi.size == nbytes) {
+            if (fi.size == (long long int) nbytes) {
                 apr_file_read(fp, ptr, &nbytes);
             }
             else {

--- a/native/mod_cluster_slotmem/sharedmem_util.c
+++ b/native/mod_cluster_slotmem/sharedmem_util.c
@@ -501,7 +501,7 @@ static apr_status_t ap_slotmem_mem(ap_slotmem_t *score, int id, void**mem)
     return APR_SUCCESS;
 }
 
-static apr_status_t ap_slotmem_alloc(ap_slotmem_t *score, int *item_id, void**mem)
+static apr_status_t ap_slotmem_alloc(ap_slotmem_t *score, int *item_id, void **mem)
 {
     int ff;
     int *ident;
@@ -521,7 +521,7 @@ static apr_status_t ap_slotmem_alloc(ap_slotmem_t *score, int *item_id, void**me
     
     return rv;
 }
-static apr_status_t ap_slotmem_free(ap_slotmem_t *score, int item_id, void*mem)
+static apr_status_t ap_slotmem_free(ap_slotmem_t *score, int item_id, void * /* mem */)
 {
     int ff;
     int *ident;
@@ -579,7 +579,7 @@ static const slotmem_storage_method storage = {
 
 /* make the storage usuable from outside
  * and initialise the global pool */
-const slotmem_storage_method *mem_getstorage(apr_pool_t *p, char *type)
+const slotmem_storage_method *mem_getstorage(apr_pool_t *p, char * /* type */)
 {
     if (globalpool == NULL && p != NULL)
         globalpool = p;
@@ -591,7 +591,7 @@ void sharedmem_initialize_cleanup(apr_pool_t *p)
     apr_pool_cleanup_register(p, &globallistmem, cleanup_slotmem, apr_pool_cleanup_null);
 }
 /* Create the mutex for insert/remove logic */
-apr_status_t sharedmem_initialize_child(apr_pool_t *p)
+apr_status_t sharedmem_initialize_child(apr_pool_t * /* p */)
 {
     return (apr_thread_mutex_create(&globalmutex_lock, APR_THREAD_MUTEX_DEFAULT, globalpool));
 }

--- a/native/mod_manager/balancer.c
+++ b/native/mod_manager/balancer.c
@@ -75,7 +75,7 @@ static mem_t * create_attach_mem_balancer(char *string, int *num, int type, apr_
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t * /* pool */)
 {
     balancerinfo_t *in = (balancerinfo_t *)*data;
     balancerinfo_t *ou = (balancerinfo_t *)mem;
@@ -122,7 +122,7 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
  * @param balancer balancer to read from the shared table.
  * @return address of the read balancer or NULL if error.
  */
-static apr_status_t loc_read_balancer(void* mem, void **data, int id, apr_pool_t *pool) {
+static apr_status_t loc_read_balancer(void* mem, void **data, int /* id */, apr_pool_t * /* pool */) {
     balancerinfo_t *in = (balancerinfo_t *)*data;
     balancerinfo_t *ou = (balancerinfo_t *)mem;
 

--- a/native/mod_manager/context.c
+++ b/native/mod_manager/context.c
@@ -75,7 +75,7 @@ static mem_t * create_attach_mem_context(char *string, int *num, int type, apr_p
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t * /* pool */)
 {
     contextinfo_t *in = (contextinfo_t *)*data;
     contextinfo_t *ou = (contextinfo_t *)mem;
@@ -125,7 +125,7 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
  * @param context context to read from the shared table.
  * @return address of the read context or NULL if error.
  */
-static apr_status_t loc_read_context(void* mem, void **data, int id, apr_pool_t *pool) {
+static apr_status_t loc_read_context(void* mem, void **data, int /* id */, apr_pool_t * /* pool */) {
     contextinfo_t *in = (contextinfo_t *)*data;
     contextinfo_t *ou = (contextinfo_t *)mem;
     if (strcmp(in->context, ou->context) == 0 &&

--- a/native/mod_manager/domain.c
+++ b/native/mod_manager/domain.c
@@ -75,7 +75,7 @@ static mem_t * create_attach_mem_domain(char *string, int *num, int type, apr_po
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t * /* pool */)
 {
     domaininfo_t *in = (domaininfo_t *)*data;
     domaininfo_t *ou = (domaininfo_t *)mem;
@@ -122,7 +122,7 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
  * @param domain domain to read from the shared table.
  * @return address of the read domain or NULL if error.
  */
-static apr_status_t loc_read_domain(void* mem, void **data, int id, apr_pool_t *pool) {
+static apr_status_t loc_read_domain(void* mem, void **data, int /* id */, apr_pool_t * /* pool */) {
     domaininfo_t *in = (domaininfo_t *)*data;
     domaininfo_t *ou = (domaininfo_t *)mem;
 

--- a/native/mod_manager/host.c
+++ b/native/mod_manager/host.c
@@ -75,7 +75,7 @@ static mem_t * create_attach_mem_host(char *string, int *num, int type, apr_pool
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t * /* pool */)
 {
     hostinfo_t *in = (hostinfo_t *)*data;
     hostinfo_t *ou = (hostinfo_t *)mem;
@@ -122,7 +122,7 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
  * @param host host to read from the shared table.
  * @return address of the read host or NULL if error.
  */
-static apr_status_t loc_read_host(void* mem, void **data, int id, apr_pool_t *pool) {
+static apr_status_t loc_read_host(void* mem, void **data, int /* id */, apr_pool_t * /* pool */) {
     hostinfo_t *in = (hostinfo_t *)*data;
     hostinfo_t *ou = (hostinfo_t *)mem;
 

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -236,7 +236,7 @@ static void inc_version_node(void)
  *   0 : No update of the nodes since last time.
  *   x: The version has changed the local table need to be updated.
  */
-static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
+static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t * /* pool */)
 {
     int size;
     server_rec *s = (server_rec *) data;
@@ -503,7 +503,7 @@ struct cluster_host {
 /*
  * cleanup logic
  */
-static apr_status_t cleanup_manager(void *param)
+static apr_status_t cleanup_manager(void * /* param */)
 {
     /* shared memory */
     contextstatsmem = NULL;
@@ -564,7 +564,7 @@ static APR_INLINE int is_child_process(void)
  * call after parser the configuration.
  * create the shared memory.
  */
-static int manager_init(apr_pool_t *p, apr_pool_t *plog,
+static int manager_init(apr_pool_t *p, apr_pool_t * /* plog */,
                           apr_pool_t *ptemp, server_rec *s)
 {
     char *node;
@@ -1276,7 +1276,7 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
 /*
  * Process a DUMP command.
  */
-static char * process_dump(request_rec *r, int *errtype)
+static char * process_dump(request_rec *r, int * /* errtype */)
 {
     int size, i;
     int *id;
@@ -1495,7 +1495,7 @@ static char * process_dump(request_rec *r, int *errtype)
  * Process a INFO command.
  * Statics informations ;-)
  */
-static char * process_info(request_rec *r, int *errtype)
+static char * process_info(request_rec *r, int * /* errtype */)
 {
     int size, i;
     int *id;
@@ -1725,7 +1725,7 @@ static char * process_info(request_rec *r, int *errtype)
 }
 
 /* Process a *-APP command that applies to the node NOTE: the node is locked */
-static char * process_node_cmd(request_rec *r, int status, int *errtype, nodeinfo_t *node)
+static char * process_node_cmd(request_rec *r, int status, int * /* errtype */, nodeinfo_t *node)
 {
     /* for read the hosts */
     int i,j;
@@ -2127,7 +2127,7 @@ static char * process_status(request_rec *r, char **ptr, int *errtype)
 /*
  * Process the VERSION command
  */
-static char * process_version(request_rec *r, char **ptr, int *errtype)
+static char * process_version(request_rec *r, char ** /* ptr */, int * /* errtype */)
 {
     const char *accept_header = apr_table_get(r->headers_in, "Accept");
 
@@ -3253,7 +3253,7 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
 /*
  * Supported directives.
  */
-static const char *cmd_manager_maxcontext(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_maxcontext(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3263,7 +3263,7 @@ static const char *cmd_manager_maxcontext(cmd_parms *cmd, void *mconfig, const c
     mconf->maxcontext = atoi(word);
     return NULL;
 }
-static const char *cmd_manager_maxnode(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_maxnode(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3273,7 +3273,7 @@ static const char *cmd_manager_maxnode(cmd_parms *cmd, void *mconfig, const char
     mconf->maxnode = atoi(word);
     return NULL;
 }
-static const char *cmd_manager_maxhost(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_maxhost(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3283,7 +3283,7 @@ static const char *cmd_manager_maxhost(cmd_parms *cmd, void *mconfig, const char
     mconf->maxhost = atoi(word);
     return NULL;
 }
-static const char *cmd_manager_maxsessionid(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_maxsessionid(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3293,7 +3293,7 @@ static const char *cmd_manager_maxsessionid(cmd_parms *cmd, void *mconfig, const
     mconf->maxsessionid = atoi(word);
     return NULL;
 }
-static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3305,14 +3305,14 @@ static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void *mconfig, con
         return  "Can't create directory corresponding to MemManagerFile";
     return NULL;
 }
-static const char *cmd_manager_balancername(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_balancername(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     mconf->balancername = apr_pstrdup(cmd->pool, word);
     normalize_balancer_name(mconf->balancername, cmd->server);
     return NULL;
 }
-static const char*cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_manager_pers(cmd_parms *cmd, void * /* dummy */, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3330,7 +3330,7 @@ static const char*cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg)
     return NULL;
 }
 
-static const char*cmd_manager_nonce(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_manager_nonce(cmd_parms *cmd, void * /* dummy */, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
@@ -3343,7 +3343,7 @@ static const char*cmd_manager_nonce(cmd_parms *cmd, void *dummy, const char *arg
     }
     return NULL;
 }
-static const char*cmd_manager_allow_display(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_manager_allow_display(cmd_parms *cmd, void * /* dummy */, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
@@ -3356,7 +3356,7 @@ static const char*cmd_manager_allow_display(cmd_parms *cmd, void *dummy, const c
     }
     return NULL;
 }
-static const char*cmd_manager_allow_cmd(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_manager_allow_cmd(cmd_parms *cmd, void * /* dummy */, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
@@ -3369,7 +3369,7 @@ static const char*cmd_manager_allow_cmd(cmd_parms *cmd, void *dummy, const char 
     }
     return NULL;
 }
-static const char*cmd_manager_reduce_display(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_manager_reduce_display(cmd_parms *cmd, void * /* dummy */, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
@@ -3382,7 +3382,7 @@ static const char*cmd_manager_reduce_display(cmd_parms *cmd, void *dummy, const 
     }
     return NULL;
 }
-static const char*cmd_manager_maxmesssize(cmd_parms *cmd, void *mconfig, const char *word)
+static const char*cmd_manager_maxmesssize(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3394,7 +3394,7 @@ static const char*cmd_manager_maxmesssize(cmd_parms *cmd, void *mconfig, const c
        return "MaxMCMPMessSize must bigger than 1024";
     return NULL;
 }
-static const char*cmd_manager_enable_mcpm_receive(cmd_parms *cmd, void *dummy)
+static const char*cmd_manager_enable_mcpm_receive(cmd_parms *cmd, void * /* dummy */)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (!cmd->server->is_virtual)
@@ -3402,7 +3402,7 @@ static const char*cmd_manager_enable_mcpm_receive(cmd_parms *cmd, void *dummy)
     mconf->enable_mcpm_receive = -1;
     return NULL;
 }
-static const char*cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void *dummy)
+static const char*cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void * /* dummy */)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3417,7 +3417,7 @@ static const char*cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void *dummy)
     }
 }
 
-static const char*cmd_manager_ws_upgrade_header(cmd_parms *cmd, void *mconfig, const char *word)
+static const char*cmd_manager_ws_upgrade_header(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3437,7 +3437,7 @@ static const char*cmd_manager_ws_upgrade_header(cmd_parms *cmd, void *mconfig, c
     }
 }
 
-static const char*cmd_manager_ajp_secret(cmd_parms *cmd, void *mconfig, const char *word)
+static const char*cmd_manager_ajp_secret(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3456,7 +3456,7 @@ static const char*cmd_manager_ajp_secret(cmd_parms *cmd, void *mconfig, const ch
     }
 }
 
-static const char*cmd_manager_responsefieldsize(cmd_parms *cmd, void *mconfig, const char *word)
+static const char*cmd_manager_responsefieldsize(cmd_parms *cmd, void * /* mconfig */, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
@@ -3658,7 +3658,7 @@ static void *create_manager_config(apr_pool_t *p)
     return mconf;
 }
 
-static void *create_manager_server_config(apr_pool_t *p, server_rec *s)
+static void *create_manager_server_config(apr_pool_t *p, server_rec * /* s */)
 {
     return(create_manager_config(p));
 }

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -1883,7 +1883,7 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
     hostinfo.node = node->mess.id;
     if (vhost->host != NULL) {
         char *s = hostinfo.host;
-        int j = 1;
+        unsigned j = 1;
         strncpy(hostinfo.host, vhost->host, HOSTALIASZ);
         while (*s != ',' && j<sizeof(hostinfo.host)) {
            j++;
@@ -2416,7 +2416,6 @@ static int manager_map_to_storage(request_rec *r)
 
     ours = check_method(r); 
     if (ours) {
-        int i;
         /* The method one of ours */
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
                     "manager_map_to_storage %s (%s)", r->method, r->uri);
@@ -3771,6 +3770,7 @@ module AP_MODULE_DECLARE_DATA manager_module = {
     NULL,
     create_manager_server_config,
     merge_manager_server_config,
-    manager_cmds,      /* command table */
-    manager_hooks      /* register hooks */
+    manager_cmds,       /* command table */
+    manager_hooks,      /* register hooks */
+    AP_MODULE_FLAG_NONE /* flags */
 };

--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -89,7 +89,7 @@ apr_status_t get_last_mem_error(mem_t *mem) {
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t * /* pool */)
 {
     nodeinfo_t *in = (nodeinfo_t *)*data;
     nodeinfo_t *ou = (nodeinfo_t *)mem;
@@ -159,7 +159,7 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id)
  * @param node node to read from the shared table.
  * @return address of the read node or NULL if error.
  */
-static apr_status_t loc_read_node(void* mem, void **data, int id, apr_pool_t *pool) {
+static apr_status_t loc_read_node(void* mem, void **data, int /* id */, apr_pool_t * /* pool */) {
     nodeinfo_t *in = (nodeinfo_t *)*data;
     nodeinfo_t *ou = (nodeinfo_t *)mem;
     if (strcmp(in->mess.JVMRoute, ou->mess.JVMRoute) == 0) {

--- a/native/mod_manager/sessionid.c
+++ b/native/mod_manager/sessionid.c
@@ -75,7 +75,7 @@ static mem_t * create_attach_mem_sessionid(char *string, int *num, int type, apr
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t * /* pool */)
 {
     sessionidinfo_t *in = (sessionidinfo_t *)*data;
     sessionidinfo_t *ou = (sessionidinfo_t *)mem;
@@ -122,7 +122,7 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
  * @param sessionid sessionid to read from the shared table.
  * @return address of the read sessionid or NULL if error.
  */
-static apr_status_t loc_read_sessionid(void* mem, void **data, int id, apr_pool_t *pool) {
+static apr_status_t loc_read_sessionid(void* mem, void **data, int /* id */, apr_pool_t * /* pool */) {
     sessionidinfo_t *in = (sessionidinfo_t *)*data;
     sessionidinfo_t *ou = (sessionidinfo_t *)mem;
 

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2647,8 +2647,8 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
             int i;
             int sizew = (*balancer)->workers->elt_size;
             char *ptr = (*balancer)->workers->elts;
-            int def = ap_proxy_hashfunc(worker_name, PROXY_HASHFUNC_DEFAULT);
-            int fnv = ap_proxy_hashfunc(worker_name, PROXY_HASHFUNC_FNV);
+            unsigned int def = ap_proxy_hashfunc(worker_name, PROXY_HASHFUNC_DEFAULT);
+            unsigned int fnv = ap_proxy_hashfunc(worker_name, PROXY_HASHFUNC_FNV);
 #if HAVE_CLUSTER_EX_DEBUG
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
                          "proxy_cluster_pre_request: worker %s", worker_name);
@@ -3133,5 +3133,6 @@ module AP_MODULE_DECLARE_DATA proxy_cluster_module = {
     create_proxy_cluster_server_config, /* server config creator */
     NULL,                               /* server config merger */
     proxy_cluster_cmds,                 /* command table */
-    proxy_cluster_hooks                 /* register hooks */
+    proxy_cluster_hooks,                /* register hooks */
+    AP_MODULE_FLAG_NONE                 /* flags */
 };

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -622,7 +622,7 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
 /*
  * Remove a node from the worker conf
  */
-static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_pool_t *pool, server_rec *server)
+static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_pool_t * /* pool */, server_rec *server)
 {
     int i;
     char *pptr = (char *) node;
@@ -671,7 +671,7 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
  * NOTE: It is called from proxy_cluster_watchdog_func and other locations
  *       It shouldn't call worker_nodes_are_updated() because there may be several VirtualHosts.
  */
-static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server, int check, proxy_node_table *node_table)
+static void update_workers_node(proxy_server_conf * /* conf */, apr_pool_t *pool, server_rec *server, int check, proxy_node_table *node_table)
 {
     int i;
     unsigned int last;
@@ -909,7 +909,7 @@ static apr_status_t http_handle_cping_cpong(proxy_conn_rec *p_conn,
 
 static apr_status_t proxy_cluster_try_pingpong(request_rec *r, proxy_worker *worker,
                                                char *url, proxy_server_conf *conf,
-                                               apr_interval_time_t ping, apr_interval_time_t workertimeout)
+                                               apr_interval_time_t /* ping */, apr_interval_time_t /* workertimeout */)
 {
     apr_status_t status;
     apr_interval_time_t timeout;
@@ -1164,7 +1164,7 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
 /*
  * remove the sessionids that have timeout
  */
-static void remove_timeout_sessionid(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server)
+static void remove_timeout_sessionid(proxy_server_conf * /* conf */, apr_pool_t *pool, server_rec * /* server */)
 {
     int *id, size, i;
     apr_time_t now;
@@ -1223,7 +1223,7 @@ static void remove_timeout_domain(apr_pool_t *pool)
 /*
  * Check that the worker corresponds to a node that belongs to the same domain according to the JVMRoute.
  */ 
-static int isnode_domain_ok(request_rec *r, nodeinfo_t *node,
+static int isnode_domain_ok(request_rec * /* r */, nodeinfo_t *node,
                              const char *domain)
 {
 #if HAVE_CLUSTER_EX_DEBUG
@@ -1592,7 +1592,7 @@ static const struct balancer_method balancerhandler =
 /*
  * Remove node that have beeen marked removed for more than 10 seconds.
  */
-static void remove_removed_node(apr_pool_t *pool, server_rec *server)
+static void remove_removed_node(apr_pool_t *pool, server_rec * /* server */)
 {
     int *id, size, i;
     apr_time_t now = apr_time_now();
@@ -1798,8 +1798,8 @@ static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
     }
 }
 
-static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
-                                     apr_pool_t *ptemp, server_rec *s)
+static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t * /* plog */,
+                                     apr_pool_t * /* ptemp */, server_rec *s)
 {
     APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) *mc_watchdog_get_instance;
     APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;
@@ -2357,7 +2357,7 @@ static proxy_worker *find_session_route(proxy_balancer *balancer,
                                         request_rec *r,
                                         const char **route,
                                         const char **sticky_used,
-                                        char **url,
+                                        char ** /* url */,
                                         const char **domain,
                                         proxy_vhost_table *vhost_table,
                                         proxy_context_table *context_table,
@@ -2569,7 +2569,7 @@ static void remove_session_route(request_rec *r, const char *name)
  * Update the context active request counter
  * Note: it need to lock the whole context table
  */
-static void upd_context_count(const char *id, int val, server_rec *s)
+static void upd_context_count(const char *id, int val, server_rec * /* s */)
 {
     int ident = atoi(id);
     contextinfo_t *context;
@@ -2834,7 +2834,7 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
 static int proxy_cluster_post_request(proxy_worker *worker,
                                        proxy_balancer *balancer,
                                        request_rec *r,
-                                       proxy_server_conf *conf)
+                                       proxy_server_conf * /* conf */)
 {
 
     proxy_cluster_helper *helper;
@@ -2982,12 +2982,12 @@ static void *create_proxy_cluster_dir_config(apr_pool_t *p, char *dir)
 }
  */
 
-static void *create_proxy_cluster_server_config(apr_pool_t *p, server_rec *s)
+static void *create_proxy_cluster_server_config(apr_pool_t * /* p */, server_rec * /* s */)
 {
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_creatbal(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_proxy_cluster_creatbal(cmd_parms * /* cmd */, void * /* dummy */, const char *arg)
 {
     int val = atoi(arg);
     if (val<0 || val>2) {
@@ -2998,7 +2998,7 @@ static const char*cmd_proxy_cluster_creatbal(cmd_parms *cmd, void *dummy, const 
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_use_alias(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_proxy_cluster_use_alias(cmd_parms * /* cmd */, void * /* dummy */, const char *arg)
 {
 
    /* Cannot use AP_INIT_FLAG, to keep compatibility with versions <= 1.3.0.Final which accepted
@@ -3014,7 +3014,7 @@ static const char*cmd_proxy_cluster_use_alias(cmd_parms *cmd, void *dummy, const
    return NULL;
 }
 
-static const char*cmd_proxy_cluster_lbstatus_recalc_time(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_proxy_cluster_lbstatus_recalc_time(cmd_parms * /* cmd */, void * /* dummy */, const char *arg)
 {
     int val = atoi(arg);
     if (val<0) {
@@ -3025,7 +3025,7 @@ static const char*cmd_proxy_cluster_lbstatus_recalc_time(cmd_parms *cmd, void *d
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_wait_for_remove(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_proxy_cluster_wait_for_remove(cmd_parms * /* cmd */, void * /* dummy */, const char *arg)
 {
     int val = atoi(arg);
     if (val<10) {
@@ -3036,7 +3036,7 @@ static const char*cmd_proxy_cluster_wait_for_remove(cmd_parms *cmd, void *dummy,
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_enable_options(cmd_parms *cmd, void *dummy, const char *args)
+static const char*cmd_proxy_cluster_enable_options(cmd_parms * cmd, void * /* dummy */, const char *args)
 {
     char *val = ap_getword_conf(cmd->pool, &args);
 
@@ -3053,14 +3053,14 @@ static const char*cmd_proxy_cluster_enable_options(cmd_parms *cmd, void *dummy, 
     return NULL;
 }
 
-static const char *cmd_proxy_cluster_deterministic_failover(cmd_parms *parms, void *mconfig, int on)
+static const char *cmd_proxy_cluster_deterministic_failover(cmd_parms * /* parms */, void * /* mconfig */, int on)
 {
     deterministic_failover = on;
 
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_cache_shared_for(cmd_parms *cmd, void *dummy, const char *arg)
+static const char*cmd_proxy_cluster_cache_shared_for(cmd_parms * /* cmd */, void * /* dummy */, const char *arg)
 {
     int val = atoi(arg);
     if (val<0) {


### PR DESCRIPTION
Fix some compile warnings. Mainly those about unused arguments of functions, but also a few others such as uninitialized values or signed/unsigned comparison.