### PR TITLE
Fix wrong constant value comparison

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -174,7 +174,7 @@ static void add_hcheck(server_rec *s, proxy_server_conf *conf, proxy_worker *wor
              }
              ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_DEBUG, 0, s,
                              "hcheck %s=%s add to worker %s", key, val,
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 12
+#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                                worker->s->name_ex
 #else
                                worker->s->name


### PR DESCRIPTION
There is a typo in the value; instead of `12` there it ought to be `124`.