### PR TITLE
Fix declaration-after-statement error

### DIFF
--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -135,9 +135,9 @@ static ma_global_data_t  *magd = NULL;
 static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy,
                                    const char *arg, const char *opt)
 {
+    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
     (void) dummy;
 
-    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
     if (mconf->ma_advertise_srvs)
         return "Duplicate ServerAdvertise directives are not allowed";
 
@@ -174,9 +174,9 @@ static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy,
 static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy,
                                    const char *arg)
 {
+    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
     (void) dummy;
 
-    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
     if (mconf->ma_advertise_port != MA_DEFAULT_ADVPORT &&
         (strcmp(mconf->ma_advertise_adrs, MA_DEFAULT_GROUP) != 0))
         return "Duplicate AdvertiseGroup directives are not allowed";
@@ -202,9 +202,9 @@ static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy,
 static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy,
                                    const char *arg)
 {
+    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
     (void) dummy;
 
-    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
     if (mconf->ma_bind_set)
         return "Duplicate AdvertiseBindAddress directives are not allowed";
 
@@ -230,12 +230,12 @@ static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy,
 static const char *cmd_advertise_f(cmd_parms *cmd, void *dummy,
                                    const char *arg)
 {
-    (void) dummy;
-
     apr_time_t s, u = 0;
     const char *p;
 
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
+    (void) dummy;
+
     if (mconf->ma_advertise_freq != MA_DEFAULT_ADV_FREQ)
         return "Duplicate AdvertiseFrequency directives are not allowed";
     if ((p = ap_strchr_c(arg, '.')) || (p = ap_strchr_c(arg, ',')))
@@ -258,9 +258,9 @@ static const char *cmd_advertise_f(cmd_parms *cmd, void *dummy,
 static const char *cmd_advertise_k(cmd_parms *cmd, void *dummy,
                                    const char *arg)
 {
+    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
    (void) dummy;
 
-    mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
     if (mconf->ma_advertise_skey != NULL)
         return "Duplicate AdvertiseSecurityKey directives are not allowed";
     mconf->ma_advertise_skey = apr_pstrdup(cmd->pool, arg);
@@ -276,9 +276,8 @@ static const char *cmd_advertise_k(cmd_parms *cmd, void *dummy,
 static const char *cmd_advertise_h(cmd_parms *cmd, void *dummy,
                                    const char *arg)
 {
-    (void) dummy;
-
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
+    (void) dummy;
 
     if (mconf->ma_advertise_srvh != NULL)
         return "Duplicate AdvertiseManagerUrl directives are not allowed";
@@ -444,14 +443,13 @@ static void ma_group_leave()
 
 static void * APR_THREAD_FUNC parent_thread(apr_thread_t *thd, void *data)
 {
-    (void) thd;
-
     static int current_status  = 0;
     int f_time = 1;
     apr_interval_time_t a_step = 0;
     server_rec *s = (server_rec *)data;
     mod_advertise_config *mconf = ap_get_module_config(s->module_config, &advertise_module);
     is_mp_created = 1;
+    (void) thd;
 
     while (is_mp_running) {
         apr_sleep(MA_TM_RESOLUTION);
@@ -485,12 +483,11 @@ static apr_status_t pconfig_cleanup(void *data);
 
 static apr_status_t process_cleanup(void *data)
 {
-    (void)data;
-
     int advertise_run = ma_advertise_run;
-
     is_mp_running     = 0;
     ma_advertise_run  = 0;
+    (void) data;
+
     if (advertise_run) {
         ma_advertise_stat = HTTP_FORBIDDEN;
         ma_advertise_server(ma_server_rec, MA_ADVERTISE_STATUS);
@@ -517,12 +514,11 @@ static apr_status_t process_cleanup(void *data)
 
 static apr_status_t pconfig_cleanup(void *data)
 {
-    (void) data;
-
     int advertise_run = ma_advertise_run;
-
     is_mp_running     = 0;
     ma_advertise_run  = 0;
+    (void) data;
+
     if (advertise_run) {
         ma_advertise_stat = HTTP_FORBIDDEN;
         ma_advertise_server(ma_server_rec, MA_ADVERTISE_STATUS);
@@ -558,8 +554,6 @@ static apr_status_t pconfig_cleanup(void *data)
 static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
                             apr_pool_t *ptemp, server_rec *s)
 {
-    (void) plog; (void) ptemp;
-
     apr_status_t rv;
     const char *pk = "advertise_init_module_tag";
     apr_pool_t *pproc = s->process->pool;
@@ -567,6 +561,7 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
     mod_advertise_config *mconf = ap_get_module_config(s->module_config, &advertise_module);
     int advertisefound = 0;
     server_rec *server = s;
+    (void) plog; (void) ptemp; /* unused variables */
 
     /* Advertise directive in more than one VirtualHost: not supported */
     while (server) {
@@ -837,9 +832,8 @@ static void register_hooks(apr_pool_t *p)
 /* Create a default conf structure */
 static void *create_advertise_server_config(apr_pool_t *p, server_rec *s)
 {
-    (void) s;
-
     mod_advertise_config *mconf = apr_pcalloc(p, sizeof(*mconf));
+    (void) s;
 
     /* Set default values */
     mconf->ma_advertise_server  = NULL;

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -233,9 +233,9 @@ static int lbmethod_cluster_trans(request_rec *r)
  */
 static void remove_removed_node(server_rec *s, apr_pool_t *pool, apr_time_t now, proxy_node_table *node_table)
 {
+    int i;
     (void) s;
 
-    int i;
     for (i=0; i<node_table->sizenode; i++) {
         nodeinfo_t *ou;
         if (node_storage->read_node(node_table->nodes[i], &ou) != APR_SUCCESS)
@@ -350,10 +350,9 @@ static apr_status_t mc_watchdog_callback(int state, void *data,
 static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
                                      apr_pool_t *ptemp, server_rec *s)
 {
-   (void) plog; (void) ptemp;
-
    APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) *mc_watchdog_get_instance;
    APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;
+   (void) plog; (void) ptemp;
 
    node_storage = ap_lookup_provider("manager" , "shared", "0");
     if (node_storage == NULL) {

--- a/native/common/common.c
+++ b/native/common/common.c
@@ -572,9 +572,9 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
 /* Given the route find the corresponding domain (if there is a domain) */
 static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, const char *balancer, proxy_node_table *node_table)
 {
+    int i;
     (void) r;
 
-    int i;
     /* XXX JFCLERE!!!! domaininfo_t *dom; */
 #if HAVE_CLUSTER_EX_DEBUG
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
@@ -616,8 +616,6 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
                                       proxy_node_table *node_table,
                                       int use_alias)
 {
-    (void) balancer_table;
-
     char *route = NULL;
     char *sessionid = NULL;
     char *sticky_used;
@@ -625,6 +623,7 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
     int i;
     char *ptr = conf->balancers->elts;
     int sizeb = conf->balancers->elt_size;
+    (void) balancer_table;
 
     for (i = 0; i < conf->balancers->nelts; i++, ptr=ptr+sizeb) {
         proxy_balancer *balancer = (proxy_balancer *) ptr;

--- a/native/mod_cluster_slotmem/mod_sharedmem.c
+++ b/native/mod_cluster_slotmem/mod_sharedmem.c
@@ -44,10 +44,9 @@
 /* make sure the shared memory is cleaned */
 static int initialize_cleanup(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
 {
-    (void) plog; (void) ptemp;
-
     void *data;
     const char *userdata_key = "mod_sharedmem_init";
+    (void) plog; (void) ptemp;
 
     apr_pool_userdata_get(&data, userdata_key, s->process->pool);
     if (!data) {
@@ -67,10 +66,9 @@ static int initialize_cleanup(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp
 static int pre_config(apr_pool_t *p, apr_pool_t *plog,
                              apr_pool_t *ptemp)
 {
-    (void) p; (void) plog; (void) ptemp;
-
     apr_pool_t *global_pool;
     apr_status_t rv;
+    (void) p; (void) plog; (void) ptemp;
 
     rv = apr_pool_create(&global_pool, NULL);
     if (rv != APR_SUCCESS) {

--- a/native/mod_cluster_slotmem/sharedmem_util.c
+++ b/native/mod_cluster_slotmem/sharedmem_util.c
@@ -525,10 +525,10 @@ static apr_status_t ap_slotmem_alloc(ap_slotmem_t *score, int *item_id, void **m
 }
 static apr_status_t ap_slotmem_free(ap_slotmem_t *score, int item_id, void *mem)
 {
-    (void) mem;
-
     int ff;
     int *ident;
+    (void) mem;
+
     if (item_id > score->num || item_id <=0) {
         return APR_EINVAL;
     } else {

--- a/native/mod_manager/balancer.c
+++ b/native/mod_manager/balancer.c
@@ -77,10 +77,10 @@ static mem_t * create_attach_mem_balancer(char *string, int *num, int type, apr_
  */
 static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
 {
-    (void) pool;
-
     balancerinfo_t *in = (balancerinfo_t *)*data;
     balancerinfo_t *ou = (balancerinfo_t *)mem;
+    (void) pool;
+
     if (strcmp(in->balancer, ou->balancer) == 0) {
         memcpy(ou, in, sizeof(balancerinfo_t));
         ou->id = id;
@@ -125,10 +125,9 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
  * @return address of the read balancer or NULL if error.
  */
 static apr_status_t loc_read_balancer(void* mem, void **data, int id, apr_pool_t *pool) {
-    (void) id; (void) pool;
-
     balancerinfo_t *in = (balancerinfo_t *)*data;
     balancerinfo_t *ou = (balancerinfo_t *)mem;
+    (void) id; (void) pool;
 
     if (strcmp(in->balancer, ou->balancer) == 0) {
         *data = ou;

--- a/native/mod_manager/context.c
+++ b/native/mod_manager/context.c
@@ -77,10 +77,10 @@ static mem_t * create_attach_mem_context(char *string, int *num, int type, apr_p
  */
 static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
 {
-    (void) pool;
-
     contextinfo_t *in = (contextinfo_t *)*data;
     contextinfo_t *ou = (contextinfo_t *)mem;
+    (void) pool;
+
     if (strcmp(in->context, ou->context) == 0 &&
                in->vhost == ou->vhost && in->node == ou->node) {
         /* We don't update nbrequests it belongs to mod_proxy_cluster logic */
@@ -128,10 +128,10 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
  * @return address of the read context or NULL if error.
  */
 static apr_status_t loc_read_context(void* mem, void **data, int id, apr_pool_t *pool) {
-    (void) id; (void) pool;
-
     contextinfo_t *in = (contextinfo_t *)*data;
     contextinfo_t *ou = (contextinfo_t *)mem;
+    (void) id; (void) pool;
+
     if (strcmp(in->context, ou->context) == 0 &&
         in->vhost == ou->vhost && ou->node == in->node) {
         *data = ou;

--- a/native/mod_manager/domain.c
+++ b/native/mod_manager/domain.c
@@ -77,10 +77,10 @@ static mem_t * create_attach_mem_domain(char *string, int *num, int type, apr_po
  */
 static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
 {
-    (void) pool;
-
     domaininfo_t *in = (domaininfo_t *)*data;
     domaininfo_t *ou = (domaininfo_t *)mem;
+    (void) pool;
+
     if (strcmp(in->JVMRoute, ou->JVMRoute) == 0 && strcmp(in->balancer, ou->balancer) == 0) {
         memcpy(ou, in, sizeof(domaininfo_t));
         ou->id = id;
@@ -125,10 +125,9 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
  * @return address of the read domain or NULL if error.
  */
 static apr_status_t loc_read_domain(void* mem, void **data, int id, apr_pool_t *pool) {
-    (void) id; (void) pool;
-
     domaininfo_t *in = (domaininfo_t *)*data;
     domaininfo_t *ou = (domaininfo_t *)mem;
+    (void) id; (void) pool;
 
     if (strcmp(in->JVMRoute, ou->JVMRoute) == 0 && strcmp(in->balancer, ou->balancer) == 0) {
         *data = ou;

--- a/native/mod_manager/host.c
+++ b/native/mod_manager/host.c
@@ -77,10 +77,10 @@ static mem_t * create_attach_mem_host(char *string, int *num, int type, apr_pool
  */
 static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
 {
-    (void) pool;
-
     hostinfo_t *in = (hostinfo_t *)*data;
     hostinfo_t *ou = (hostinfo_t *)mem;
+    (void) pool;
+
     if (strcmp(in->host, ou->host) == 0 && in->vhost == ou->vhost && in->node == ou->node) {
         memcpy(ou, in, sizeof(hostinfo_t));
         ou->id = id;
@@ -125,10 +125,9 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
  * @return address of the read host or NULL if error.
  */
 static apr_status_t loc_read_host(void* mem, void **data, int id, apr_pool_t *pool) {
-    (void) id; (void) pool;
-
     hostinfo_t *in = (hostinfo_t *)*data;
     hostinfo_t *ou = (hostinfo_t *)mem;
+    (void) id; (void) pool;
 
     if (strcmp(in->host, ou->host) == 0 && in->node == ou->node ) {
         *data = ou;

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -238,13 +238,12 @@ static void inc_version_node(void)
  */
 static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
 {
-    (void) pool;
-
     int size;
     server_rec *s = (server_rec *) data;
     unsigned int last = 0;
     version_data *base;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
+    (void) pool;
 
     size = loc_get_max_size_node();
     if (size == 0)
@@ -507,7 +506,6 @@ struct cluster_host {
  */
 static apr_status_t cleanup_manager(void *param)
 {
-    (void) param;
     /* shared memory */
     contextstatsmem = NULL;
     nodestatsmem = NULL;
@@ -515,6 +513,8 @@ static apr_status_t cleanup_manager(void *param)
     balancerstatsmem = NULL;
     sessionidstatsmem = NULL;
     domainstatsmem = NULL;
+    (void) param;
+
     if (nodes_global_lock) {
         apr_file_close(nodes_global_lock);
         nodes_global_lock = NULL;
@@ -570,8 +570,6 @@ static APR_INLINE int is_child_process(void)
 static int manager_init(apr_pool_t *p, apr_pool_t *plog,
                           apr_pool_t *ptemp, server_rec *s)
 {
-    (void) plog;
-
     char *node;
     char *context;
     char *host;
@@ -587,7 +585,9 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
     apr_status_t rv;
     apr_pool_userdata_get(&data, userdata_key, s->process->pool);
-    if (!data) {
+    (void) plog; /* unused variable */
+
+   if (!data) {
         /* first call do nothing */
         apr_pool_userdata_set((const void *)1, userdata_key, apr_pool_cleanup_null, s->process->pool);
         return OK;
@@ -1284,13 +1284,11 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
  */
 static char * process_dump(request_rec *r, int *errtype)
 {
-    (void) errtype;
-
     int size, i;
     int *id;
-
     unsigned char type;
     const char *accept_header = apr_table_get(r->headers_in, "Accept");
+    (void) errtype;
 
     if (accept_header && strstr((char *)accept_header, "text/xml") != NULL )  {
         ap_set_content_type(r, "text/xml");
@@ -1505,13 +1503,11 @@ static char * process_dump(request_rec *r, int *errtype)
  */
 static char * process_info(request_rec *r, int *errtype)
 {
-    (void) errtype;
-
     int size, i;
     int *id;
-
     unsigned char type;
     const char *accept_header = apr_table_get(r->headers_in, "Accept");
+    (void) errtype;
 
     if (accept_header && strstr((char *)accept_header, "text/xml") != NULL )  {
         ap_set_content_type(r, "text/xml");
@@ -1737,11 +1733,11 @@ static char * process_info(request_rec *r, int *errtype)
 /* Process a *-APP command that applies to the node NOTE: the node is locked */
 static char * process_node_cmd(request_rec *r, int status, int *errtype, nodeinfo_t *node)
 {
-    (void) errtype;
     /* for read the hosts */
     int i,j;
     int size = loc_get_max_size_host();
     int *id;
+    (void) errtype;
 
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
                 "process_node_cmd %d processing node: %d", status, node->mess.id);
@@ -2140,9 +2136,8 @@ static char * process_status(request_rec *r, char **ptr, int *errtype)
  */
 static char * process_version(request_rec *r, char **ptr, int *errtype)
 {
-    (void) ptr; (void) errtype;
-
     const char *accept_header = apr_table_get(r->headers_in, "Accept");
+    (void) ptr; (void) errtype;
 
     if (accept_header && strstr((char *)accept_header, "text/xml") != NULL )  {
         ap_set_content_type(r, "text/xml");
@@ -3267,10 +3262,10 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
  */
 static const char *cmd_manager_maxcontext(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3279,10 +3274,10 @@ static const char *cmd_manager_maxcontext(cmd_parms *cmd, void *mconfig, const c
 }
 static const char *cmd_manager_maxnode(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3291,10 +3286,10 @@ static const char *cmd_manager_maxnode(cmd_parms *cmd, void *mconfig, const char
 }
 static const char *cmd_manager_maxhost(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3303,10 +3298,10 @@ static const char *cmd_manager_maxhost(cmd_parms *cmd, void *mconfig, const char
 }
 static const char *cmd_manager_maxsessionid(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3315,10 +3310,10 @@ static const char *cmd_manager_maxsessionid(cmd_parms *cmd, void *mconfig, const
 }
 static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3329,19 +3324,18 @@ static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void *mconfig, con
 }
 static const char *cmd_manager_balancername(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     mconf->balancername = apr_pstrdup(cmd->pool, word);
     normalize_balancer_name(mconf->balancername, cmd->server);
+    (void) mconfig; /* unused variable */
     return NULL;
 }
 static const char*cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg)
 {
-    (void) dummy;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) dummy;
+
     if (err != NULL) {
         return err;
     }
@@ -3358,9 +3352,9 @@ static const char*cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg)
 
 static const char*cmd_manager_nonce(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     (void) dummy;
 
-    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
        mconf->nonce = 0;
     else if (strcasecmp(arg, "On") == 0)
@@ -3373,9 +3367,9 @@ static const char*cmd_manager_nonce(cmd_parms *cmd, void *dummy, const char *arg
 }
 static const char*cmd_manager_allow_display(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     (void) dummy;
 
-    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
        mconf->allow_display = 0;
     else if (strcasecmp(arg, "On") == 0)
@@ -3388,9 +3382,9 @@ static const char*cmd_manager_allow_display(cmd_parms *cmd, void *dummy, const c
 }
 static const char*cmd_manager_allow_cmd(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     (void) dummy;
 
-    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
        mconf->allow_cmd = 0;
     else if (strcasecmp(arg, "On") == 0)
@@ -3403,9 +3397,9 @@ static const char*cmd_manager_allow_cmd(cmd_parms *cmd, void *dummy, const char 
 }
 static const char*cmd_manager_reduce_display(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     (void) dummy;
 
-    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (strcasecmp(arg, "Off") == 0)
        mconf->reduce_display = 0;
     else if (strcasecmp(arg, "On") == 0)
@@ -3418,10 +3412,10 @@ static const char*cmd_manager_reduce_display(cmd_parms *cmd, void *dummy, const 
 }
 static const char*cmd_manager_maxmesssize(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3432,9 +3426,9 @@ static const char*cmd_manager_maxmesssize(cmd_parms *cmd, void *mconfig, const c
 }
 static const char*cmd_manager_enable_mcpm_receive(cmd_parms *cmd, void *dummy)
 {
+    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     (void) dummy;
 
-    mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     if (!cmd->server->is_virtual)
         return "EnableMCPMReceive must be in a VirtualHost";
     mconf->enable_mcpm_receive = -1;
@@ -3442,10 +3436,10 @@ static const char*cmd_manager_enable_mcpm_receive(cmd_parms *cmd, void *dummy)
 }
 static const char*cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void *dummy)
 {
-    (void) dummy;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) dummy;
+
     if (err != NULL) {
         return err;
     }
@@ -3459,10 +3453,10 @@ static const char*cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void *dummy)
 
 static const char*cmd_manager_ws_upgrade_header(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3481,10 +3475,10 @@ static const char*cmd_manager_ws_upgrade_header(cmd_parms *cmd, void *mconfig, c
 
 static const char*cmd_manager_ajp_secret(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }
@@ -3502,11 +3496,11 @@ static const char*cmd_manager_ajp_secret(cmd_parms *cmd, void *mconfig, const ch
 
 static const char*cmd_manager_responsefieldsize(cmd_parms *cmd, void *mconfig, const char *word)
 {
-    (void) mconfig;
-
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
     long s = atol(word);
+    (void) mconfig;
+
     if (err != NULL) {
         return err;
     }

--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -91,10 +91,10 @@ apr_status_t get_last_mem_error(mem_t *mem) {
  */
 static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
 {
-    (void) pool;
-
     nodeinfo_t *in = (nodeinfo_t *)*data;
     nodeinfo_t *ou = (nodeinfo_t *)mem;
+    (void) pool;
+
     if (strcmp(in->mess.JVMRoute, ou->mess.JVMRoute) == 0) {
         /*
          * The node information is made of several pieces:
@@ -162,10 +162,10 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id)
  * @return address of the read node or NULL if error.
  */
 static apr_status_t loc_read_node(void* mem, void **data, int id, apr_pool_t *pool) {
-    (void) id; (void) pool;
-
     nodeinfo_t *in = (nodeinfo_t *)*data;
     nodeinfo_t *ou = (nodeinfo_t *)mem;
+    (void) id; (void) pool;
+
     if (strcmp(in->mess.JVMRoute, ou->mess.JVMRoute) == 0) {
         *data = ou;
         return APR_SUCCESS;

--- a/native/mod_manager/sessionid.c
+++ b/native/mod_manager/sessionid.c
@@ -77,10 +77,10 @@ static mem_t * create_attach_mem_sessionid(char *string, int *num, int type, apr
  */
 static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
 {
-    (void) pool;
-
     sessionidinfo_t *in = (sessionidinfo_t *)*data;
     sessionidinfo_t *ou = (sessionidinfo_t *)mem;
+    (void) pool;
+
     if (strcmp(in->sessionid, ou->sessionid) == 0) {
         memcpy(ou, in, sizeof(sessionidinfo_t));
         ou->id = id;
@@ -125,10 +125,9 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
  * @return address of the read sessionid or NULL if error.
  */
 static apr_status_t loc_read_sessionid(void* mem, void **data, int id, apr_pool_t *pool) {
-    (void) id; (void) pool;
-
     sessionidinfo_t *in = (sessionidinfo_t *)*data;
     sessionidinfo_t *ou = (sessionidinfo_t *)mem;
+    (void) id; (void) pool;
 
     if (strcmp(in->sessionid, ou->sessionid) == 0) {
         *data = ou;

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -682,8 +682,6 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
  */
 static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_pool_t *pool, server_rec *server)
 {
-    (void) pool;
-
     int i;
     char *pptr = (char *) node;
     proxy_cluster_helper *helper;
@@ -691,6 +689,8 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
     pptr = pptr + node->offset;
 
     worker = get_worker_from_id_stat(conf, node->mess.id, (proxy_worker_shared *) pptr, node);
+    (void) pool;
+
     if (!worker) {
         /* XXX: Another process may use it, can't do: node_storage->remove_node(node); */
         return 0; /* Done */
@@ -740,10 +740,9 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
  */
 static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server, int check, proxy_node_table *node_table)
 {
-    (void) conf;
-
     int i;
     unsigned int last;
+    (void) conf;
 
     if (node_table == NULL)
         return;
@@ -980,8 +979,6 @@ static apr_status_t proxy_cluster_try_pingpong(request_rec *r, proxy_worker *wor
                                                char *url, proxy_server_conf *conf,
                                                apr_interval_time_t ping, apr_interval_time_t workertimeout)
 {
-    (void) ping; (void) workertimeout;
-
     apr_status_t status;
     apr_interval_time_t timeout;
     proxy_conn_rec *backend = NULL;
@@ -990,6 +987,7 @@ static apr_status_t proxy_cluster_try_pingpong(request_rec *r, proxy_worker *wor
     apr_uri_t *uri;
     char *scheme = worker->s->scheme;
     int is_ssl = 0;
+    (void) ping; (void) workertimeout;
 
     if ((strcasecmp(scheme, "HTTPS") == 0 ||
         strcasecmp(scheme, "WSS") == 0 ||
@@ -1258,10 +1256,9 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
  */
 static void remove_timeout_sessionid(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server)
 {
-    (void) conf; (void) server;
-
     int *id, size, i;
     apr_time_t now;
+    (void) conf; (void) server;
 
     now = apr_time_sec(apr_time_now());
 
@@ -1702,13 +1699,12 @@ static const struct balancer_method balancerhandler =
  */
 static void remove_removed_node(apr_pool_t *pool, server_rec *server)
 {
-    (void) server;
-
     int *id, size, i;
     apr_time_t now = apr_time_now();
-
     /* read the ident of the nodes */
     size = node_storage->get_max_size_node();
+    (void) server;
+
     if (size == 0)
         return;
     id = apr_pcalloc(pool, sizeof(int) * size);
@@ -1911,11 +1907,8 @@ static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
 static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
                                      apr_pool_t *ptemp, server_rec *main_s)
 {
-    (void) plog; (void) ptemp;
-
     APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) *mc_watchdog_get_instance;
     APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;
-
     server_rec *s = main_s;
     void *sconf = s->module_config;
     proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
@@ -1923,6 +1916,8 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
     int sizeb = conf->balancers->elt_size;
     int idx;
     int has_static_workers = 0;
+    (void) plog; (void) ptemp;
+
     if (sizew != sizeof(proxy_worker) || sizeb != sizeof(proxy_balancer)) {
         ap_version_t version;
         ap_get_server_revision(&version);
@@ -2413,8 +2408,8 @@ static proxy_worker *find_session_route(proxy_balancer *balancer,
                                         proxy_context_table *context_table,
                                         proxy_node_table *node_table)
 {
-    (void) url;
     proxy_worker *worker = NULL;
+    (void) url;
 
 #if HAVE_CLUSTER_EX_DEBUG
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
@@ -2622,11 +2617,11 @@ static void remove_session_route(request_rec *r, const char *name)
  */
 static void upd_context_count(const char *id, int val, server_rec *s)
 {
-    (void) s;
-
     int ident = atoi(id);
     contextinfo_t *context;
     context_storage->lock_contexts();
+    (void) s;
+
     if (context_storage->read_context(ident, &context) == APR_SUCCESS) {
         context->nbrequests = context->nbrequests + val;
     }
@@ -2889,8 +2884,6 @@ static int proxy_cluster_post_request(proxy_worker *worker,
                                        request_rec *r,
                                        proxy_server_conf *conf)
 {
-    (void) conf;
-
     proxy_cluster_helper *helper;
     const char *sessionid;
     const char *route;
@@ -2899,6 +2892,7 @@ static int proxy_cluster_post_request(proxy_worker *worker,
     char *oroute;
     const char *context_id = apr_table_get(r->subprocess_env, "BALANCER_CONTEXT_ID");
     apr_status_t rv;
+    (void) conf; /* unused argument */
 
     /* Ajust the context counter here too */
     if (context_id && *context_id) {
@@ -3045,9 +3039,9 @@ static void *create_proxy_cluster_server_config(apr_pool_t *p, server_rec *s)
 
 static const char*cmd_proxy_cluster_creatbal(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    int val = atoi(arg);
     (void) cmd; (void) dummy;
 
-    int val = atoi(arg);
     if (val<0 || val>2) {
         return "CreateBalancers must be one of: 0, 1 or 2";
     } else {
@@ -3075,9 +3069,9 @@ static const char*cmd_proxy_cluster_use_alias(cmd_parms *cmd, void *dummy, const
 
 static const char*cmd_proxy_cluster_lbstatus_recalc_time(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    int val = atoi(arg);
     (void) cmd; (void) dummy;
 
-    int val = atoi(arg);
     if (val<0) {
         return "LBstatusRecalTime must be greater than 0";
     } else {
@@ -3088,9 +3082,9 @@ static const char*cmd_proxy_cluster_lbstatus_recalc_time(cmd_parms *cmd, void *d
 
 static const char*cmd_proxy_cluster_wait_for_remove(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    int val = atoi(arg);
     (void) cmd; (void) dummy;
 
-    int val = atoi(arg);
     if (val<10) {
         return "WaitForRemove must be greater than 10";
     } else {
@@ -3101,9 +3095,8 @@ static const char*cmd_proxy_cluster_wait_for_remove(cmd_parms *cmd, void *dummy,
 
 static const char*cmd_proxy_cluster_enable_options(cmd_parms *cmd, void *dummy, const char *args)
 {
-    (void) dummy;
-
     char *val = ap_getword_conf(cmd->pool, &args);
+    (void) dummy;
 
     if (strcasecmp(val, "Off") == 0 || strcasecmp(val, "0") == 0) {
         /* Disables OPTIONS, overrides the default */
@@ -3120,17 +3113,17 @@ static const char*cmd_proxy_cluster_enable_options(cmd_parms *cmd, void *dummy, 
 
 static const char *cmd_proxy_cluster_deterministic_failover(cmd_parms *parms, void *mconfig, int on)
 {
-    (void) parms; (void) mconfig;
     deterministic_failover = on;
-
+    (void) parms; (void) mconfig;
+ 
     return NULL;
 }
 
 static const char *cmd_proxy_cluster_cache_shared_for(cmd_parms *cmd, void *dummy, const char *arg)
 {
+    int val = atoi(arg);
     (void) cmd; (void) dummy;
 
-    int val = atoi(arg);
     if (val<0) {
         return "CacheShareFor must be greater than 0";
     } else {


### PR DESCRIPTION
Fix an error with `-Werror=declaration-after-statement` that was introduced in the previous commit 5a42af51883c14e845c692d022f97525aaa7d2d2