### PR TITLE
Fix mod_advertise compile errors with prototypes flags

### DIFF
--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -295,7 +295,7 @@ static const char *cmd_advertise_h(cmd_parms *cmd, void *dummy,
 
 static const char *hex = "0123456789abcdef";
 
-apr_status_t ma_advertise_server(server_rec *server, int type)
+static apr_status_t ma_advertise_server(server_rec *server, int type)
 {
     char buf[MA_BSIZE];
     char dat[APR_RFC822_DATE_LEN];
@@ -431,7 +431,7 @@ static apr_status_t ma_group_join(const char *addr, apr_port_t port,
     return APR_SUCCESS;
 }
 
-static void ma_group_leave()
+static void ma_group_leave(void)
 {
     if (ma_mgroup_socket) {
         apr_mcast_leave(ma_mgroup_socket, ma_mgroup_sa,


### PR DESCRIPTION
On Fedora 36, running `sh buildconf && ./configure --with-apxs=~/apache/bin/apxs && make` in advertise directory ends with following error:

```
Creating configure ...
configure.in:33: warning: AC_OUTPUT should be used without arguments.
configure.in:33: You should run autoupdate.
checking for Apache httpd installation... APXS is ~/apache/bin/apxs
apxs_support is true
configure: creating ./config.status
config.status: creating Makefile
~/apache//build/libtool --silent --mode=compile gcc  -g -O2 -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -std=c89 -Werror -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wdeclaration-after-statement -Wpointer-arith -Wformat -Wformat-security -Wunused     -DLINUX -D_REENTRANT -D_GNU_SOURCE -DAP_DEBUG    -I~/apache//include -I. -I~/repos/httpd-github/srclib/apr/include -I/usr/include -I../include -prefer-pic -c mod_advertise.c && touch mod_advertise.slo
mod_advertise.c:298:14: error: no previous prototype for 'ma_advertise_server' [-Werror=missing-prototypes]
  298 | apr_status_t ma_advertise_server(server_rec *server, int type)
      |              ^~~~~~~~~~~~~~~~~~~
mod_advertise.c:434:13: error: function declaration isn't a prototype [-Werror=strict-prototypes]
  434 | static void ma_group_leave()
      |             ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [~/apache/build/rules.mk:213: mod_advertise.slo] Error 1
```

This commit addresses that. It should not break anything, not even Windows.