### PR TITLE
Fix double locking in mod_manager

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -1908,9 +1908,7 @@ static char * process_node_cmd(request_rec *r, int status, int *errtype, nodeinf
     if (status == REMOVE) {
         int id;
         node->mess.remove = 1;
-        loc_lock_nodes();
         insert_update_node(nodestatsmem, node, &id, 0);
-        loc_unlock_nodes();
     }
     return NULL;
 


### PR DESCRIPTION
When running tests, httpd was getting stuck. After investigating I found the cause of the deadlock – locking. This PR removes it.