### PR TITLE
Fix wring usage of podman instead of docker, fix jdb usage

### DIFF
--- a/test/native/tests.sh
+++ b/test/native/tests.sh
@@ -31,7 +31,7 @@ stoptomcat() {
 #
 # Stop running all dockered tomcats
 stoptomcats() {
-    for i in `podman ps -a --format "{{.Names}}" | grep tomcat`
+    for i in `docker ps -a --format "{{.Names}}" | grep tomcat`
     do
         stoptomcat $i
     done
@@ -96,7 +96,7 @@ removetomcatname() {
 #
 # Remove all tomcat containers and images
 removetomcats() {
-    for i in `podman ps -a --format "{{.Names}}" | grep tomcat`
+    for i in `docker ps -a --format "{{.Names}}" | grep tomcat`
     do
         removetomcatname $i
     done
@@ -130,13 +130,14 @@ echotestlabel() {
     echo "***************************************************************"
 }
 
+# This should suspend the tomcat for ~ 1000 seconds ~ causing it gets removed afterwhile.
 jdbsuspend() {
     rm -f /tmp/testpipein
     mkfifo /tmp/testpipein
     rm -f /tmp/testpipeout
     mkfifo /tmp/testpipeout
     sleep 1000 > /tmp/testpipein &
-    docker exec -i tomcat8080 jdb -attach 6660 < /tmp/testpipein > /tmp/testpipeout &
+    jdb -attach 6660 < /tmp/testpipein > /tmp/testpipeout &
     echo "suspend" > /tmp/testpipein
     cat < /tmp/testpipeout &
 }


### PR DESCRIPTION
Some tweaks. Tests should be  more reliable now (e.g., running them after previously failed run, they will clean the hanging containers at first, and the `jdb` part now works properly).