### PR TITLE
Apply style guide similar to httpd's one, tweak code style

### DIFF
--- a/native/.clang-format
+++ b/native/.clang-format
@@ -1,0 +1,34 @@
+Language: Cpp
+IndentWidth: 4
+PointerAlignment: Right
+ColumnLimit: 120
+AlignConsecutiveMacros: AcrossEmptyLinesAndComments
+AllowAllArgumentsOnNextLine: true
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+  BeforeElse: true
+  AfterFunction: true
+  AfterStruct: true
+  AfterUnion: true
+IndentCaseLabels: false
+IndentExternBlock: false
+MaxEmptyLinesToKeep: 2
+QualifierAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  BeforeNonEmptyParentheses: false
+UseTab: Never
+IncludeBlocks: Preserve
+SortIncludes: Never
+SpacesBeforeTrailingComments: 8
+AllowShortFunctionsOnASingleLine: None
+TypenameMacros: ['APR_OPTIONAL_FN_TYPE']
+StatementMacros: ['AP_INIT_TAKE1', 'AP_INIT_TAKE12', 'AP_INIT_FLAG', 'AP_INIT_RAW_ARGS']
+

--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -744,7 +744,7 @@ static const command_rec cmd_table[] = {
                   NULL,                                           /* argument to include in call  */
                   RSRC_CONF,                                      /* where available              */
                   "Local adress to bind to for Multicast logic"),
-    {NULL}
+    {NULL},
 
 };
 

--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -51,7 +51,7 @@ static pid_t ma_parent_pid = -1;
 
 /* Global (really) */
 
-static int ma_advertise_run  = 0;
+static int ma_advertise_run = 0;
 static int ma_advertise_stat = 0;
 static server_rec *main_server = NULL;
 
@@ -119,13 +119,11 @@ static ma_global_data_t *magd = NULL;
 
 /* Evaluates to true if the (apr_sockaddr_t *) addr argument is the
  * IPv4 match-any-address, 0.0.0.0. */
-#define IS_INADDR_ANY(addr) ((addr)->family == APR_INET && \
-                             (addr)->sa.sin.sin_addr.s_addr == INADDR_ANY)
+#define IS_INADDR_ANY(addr)  ((addr)->family == APR_INET && (addr)->sa.sin.sin_addr.s_addr == INADDR_ANY)
 
 /* Evaluates to true if the (apr_sockaddr_t *) addr argument is the
  * IPv6 match-any-address, [::]. */
-#define IS_IN6ADDR_ANY(addr) ((addr)->family == APR_INET6 && \
-                        IN6_IS_ADDR_UNSPECIFIED(&(addr)->sa.sin6.sin6_addr))
+#define IS_IN6ADDR_ANY(addr) ((addr)->family == APR_INET6 && IN6_IS_ADDR_UNSPECIFIED(&(addr)->sa.sin6.sin6_addr))
 
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
@@ -152,10 +150,8 @@ static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy, const char *arg,
             mconf->ma_advertise_srvm = apr_pstrndup(cmd->pool, opt, p - opt);
             opt = p + 3;
         }
-        if (apr_parse_addr_port(&mconf->ma_advertise_srvs,
-                                &mconf->ma_advertise_srvi,
-                                &mconf->ma_advertise_srvp,
-                                opt, cmd->pool) != APR_SUCCESS ||
+        if (apr_parse_addr_port(&mconf->ma_advertise_srvs, &mconf->ma_advertise_srvi, &mconf->ma_advertise_srvp, opt,
+                                cmd->pool) != APR_SUCCESS ||
             !mconf->ma_advertise_srvs || !mconf->ma_advertise_srvp) {
             return "Invalid ServerAdvertise Address";
         }
@@ -178,8 +174,8 @@ static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy, const char *arg)
     if (mconf->ma_advertise_port != MA_DEFAULT_ADVPORT && strcmp(mconf->ma_advertise_adrs, MA_DEFAULT_GROUP) != 0)
         return "Duplicate AdvertiseGroup directives are not allowed";
 
-    if (apr_parse_addr_port(&mconf->ma_advertise_adrs,
-                            &mconf->ma_advertise_adsi, &mconf->ma_advertise_port, arg, cmd->pool) != APR_SUCCESS)
+    if (apr_parse_addr_port(&mconf->ma_advertise_adrs, &mconf->ma_advertise_adsi, &mconf->ma_advertise_port, arg,
+                            cmd->pool) != APR_SUCCESS)
         return "Invalid AdvertiseGroup address";
     if (!mconf->ma_advertise_adrs)
         return "Missing Ip part from AdvertiseGroup address";
@@ -202,8 +198,8 @@ static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy, const char *arg)
     if (mconf->ma_bind_set)
         return "Duplicate AdvertiseBindAddress directives are not allowed";
 
-    if (apr_parse_addr_port(&mconf->ma_bind_adrs,
-                            &mconf->ma_bind_adsi, &mconf->ma_bind_port, arg, cmd->pool) != APR_SUCCESS)
+    if (apr_parse_addr_port(&mconf->ma_bind_adrs, &mconf->ma_bind_adsi, &mconf->ma_bind_port, arg, cmd->pool) !=
+        APR_SUCCESS)
         return "Invalid AdvertiseBindAddress address";
     if (!mconf->ma_bind_adrs)
         return "Missing Ip part from AdvertiseBindAddress address";
@@ -333,33 +329,30 @@ static apr_status_t ma_advertise_server(server_rec *server, int type)
         }
         l -= n;
         n += apr_snprintf(p + n, l,
-                          "X-Manager-Address: %s:%u" CRLF
-                          "X-Manager-Url: %s" CRLF
-                          "X-Manager-Protocol: %s" CRLF
+                          "X-Manager-Address: %s:%u" CRLF "X-Manager-Url: %s" CRLF "X-Manager-Protocol: %s" CRLF
                           "X-Manager-Host: %s" CRLF,
-                          ma_advertise_srvs,
-                          mconf->ma_advertise_srvp,
-                          mconf->ma_advertise_srvh, mconf->ma_advertise_srvm, server->server_hostname);
+                          ma_advertise_srvs, mconf->ma_advertise_srvp, mconf->ma_advertise_srvh,
+                          mconf->ma_advertise_srvm, server->server_hostname);
     }
     strcat(p, CRLF);
     n += 2;
     return apr_socket_sendto(ma_mgroup_socket, ma_mgroup_sa, 0, buf, &n);
 }
 
-static apr_status_t ma_group_join(const char *addr, apr_port_t port,
-                                  const char *bindaddr, apr_port_t bindport, apr_pool_t *pool, server_rec *s)
+static apr_status_t ma_group_join(const char *addr, apr_port_t port, const char *bindaddr, apr_port_t bindport,
+                                  apr_pool_t *pool, server_rec *s)
 {
     apr_status_t rv;
 
     if ((rv = apr_sockaddr_info_get(&ma_mgroup_sa, addr, APR_UNSPEC, port, APR_UNSPEC, pool)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "mod_advertise: ma_group_join apr_sockaddr_info_get(%s:%d) failed", addr, port);
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: ma_group_join apr_sockaddr_info_get(%s:%d) failed",
+                     addr, port);
         return rv;
     }
-    if ((rv = apr_sockaddr_info_get(&ma_listen_sa, bindaddr,
-                                    ma_mgroup_sa->family, bindport, APR_UNSPEC, pool)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "mod_advertise: ma_group_join apr_sockaddr_info_get(%s:%d) failed", bindaddr, bindport);
+    if ((rv = apr_sockaddr_info_get(&ma_listen_sa, bindaddr, ma_mgroup_sa->family, bindport, APR_UNSPEC, pool)) !=
+        APR_SUCCESS) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: ma_group_join apr_sockaddr_info_get(%s:%d) failed",
+                     bindaddr, bindport);
         return rv;
     }
     if ((rv = apr_sockaddr_info_get(&ma_niface_sa, NULL, ma_mgroup_sa->family, 0, APR_UNSPEC, pool)) != APR_SUCCESS) {
@@ -367,8 +360,8 @@ static apr_status_t ma_group_join(const char *addr, apr_port_t port,
                      "mod_advertise: ma_group_join apr_sockaddr_info_get(0.0.0.0:0) failed");
         return rv;
     }
-    if ((rv = apr_socket_create(&ma_mgroup_socket,
-                                ma_mgroup_sa->family, SOCK_DGRAM, APR_PROTO_UDP, pool)) != APR_SUCCESS) {
+    if ((rv = apr_socket_create(&ma_mgroup_socket, ma_mgroup_sa->family, SOCK_DGRAM, APR_PROTO_UDP, pool)) !=
+        APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: ma_group_join apr_socket_create failed");
         return rv;
     }
@@ -412,7 +405,7 @@ static void *APR_THREAD_FUNC parent_thread(apr_thread_t *thd, void *data)
     static int current_status = 0;
     int f_time = 1;
     apr_interval_time_t a_step = 0;
-    server_rec *s = (server_rec *) data;
+    server_rec *s = (server_rec *)data;
     mod_advertise_config *mconf = ap_get_module_config(s->module_config, &advertise_module);
     is_mp_created = 1;
     (void)thd;
@@ -526,7 +519,7 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
     int advertisefound = 0;
     server_rec *server = s;
     (void)plog;
-    (void)ptemp;                /* unused variables */
+    (void)ptemp; /* unused variables */
 
     /* Advertise directive in more than one VirtualHost: not supported */
     while (server) {
@@ -567,8 +560,8 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
         if (ppid) {
             ma_parent_pid = atol(ppid);
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s,
-                         "[%" APR_PID_T_FMT " - %" APR_PID_T_FMT
-                         "] in child post config hook", getpid(), ma_parent_pid);
+                         "[%" APR_PID_T_FMT " - %" APR_PID_T_FMT "] in child post config hook", getpid(),
+                         ma_parent_pid);
             return OK;
         }
     }
@@ -594,8 +587,7 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
         rv = ma_group_join(mconf->ma_advertise_adrs, mconf->ma_advertise_port, mconf->ma_bind_adrs, mconf->ma_bind_port,
                            pconf, s);
         if (rv != APR_SUCCESS) {
-            ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                         "mod_advertise: multicast join failed for %s:%d.",
+            ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: multicast join failed for %s:%d.",
                          mconf->ma_advertise_adrs, mconf->ma_advertise_port);
             ma_advertise_run = 0;
         }
@@ -637,8 +629,8 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *pte
             }
             ptr = apr_psprintf(pproc, "%s:%u", ma_server_rec->server_hostname, port);
         }
-        rv = apr_parse_addr_port(&mconf->ma_advertise_srvs,
-                                 &mconf->ma_advertise_srvi, &mconf->ma_advertise_srvp, ptr, pproc);
+        rv = apr_parse_addr_port(&mconf->ma_advertise_srvs, &mconf->ma_advertise_srvi, &mconf->ma_advertise_srvp, ptr,
+                                 pproc);
         if (rv != APR_SUCCESS || !mconf->ma_advertise_srvs || !mconf->ma_advertise_srvp) {
             ap_log_error(APLOG_MARK, APLOG_CRIT, rv, s, "mod_advertise: Invalid ServerAdvertise Address %s", ptr);
             return rv;
@@ -697,10 +689,8 @@ static void advertise_info(request_rec *r)
         }
         if (mconf->ma_advertise_server != NULL) {
             ap_rprintf(r, " Advertising on Group %s Port %d ", mconf->ma_advertise_adrs, mconf->ma_advertise_port);
-            ap_rprintf(r, "for %s://%s:%d every %ld seconds<br/>",
-                       mconf->ma_advertise_srvm, mconf->ma_advertise_srvs,
-                       mconf->ma_advertise_srvp, apr_time_sec(mconf->ma_advertise_freq)
-                );
+            ap_rprintf(r, "for %s://%s:%d every %ld seconds<br/>", mconf->ma_advertise_srvm, mconf->ma_advertise_srvs,
+                       mconf->ma_advertise_srvp, apr_time_sec(mconf->ma_advertise_freq));
         }
         else {
             ap_rputs("<br/>", r);
@@ -716,35 +706,35 @@ static void advertise_info(request_rec *r)
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
 static const command_rec cmd_table[] = {
-    AP_INIT_TAKE12("ServerAdvertise",                             /* directive name               */
-                   cmd_advertise_m,                               /* config action routine        */
-                   NULL,                                          /* argument to include in call  */
-                   RSRC_CONF,                                     /* where available              */
+    AP_INIT_TAKE12("ServerAdvertise", /* directive name               */
+                   cmd_advertise_m,   /* config action routine        */
+                   NULL,              /* argument to include in call  */
+                   RSRC_CONF,         /* where available              */
                    "Server advertise mode: On | Off [Address]"),
-    AP_INIT_TAKE1("AdvertiseGroup",                               /* directive name               */
-                  cmd_advertise_g,                                /* config action routine        */
-                  NULL,                                           /* argument to include in call  */
-                  RSRC_CONF,                                      /* where available              */
+    AP_INIT_TAKE1("AdvertiseGroup", /* directive name               */
+                  cmd_advertise_g,  /* config action routine        */
+                  NULL,             /* argument to include in call  */
+                  RSRC_CONF,        /* where available              */
                   "Multicast group address"),
-    AP_INIT_TAKE1("AdvertiseFrequency",                           /* directive name               */
-                  cmd_advertise_f,                                /* config action routine        */
-                  NULL,                                           /* argument to include in call  */
-                  RSRC_CONF,                                      /* where available              */
+    AP_INIT_TAKE1("AdvertiseFrequency", /* directive name               */
+                  cmd_advertise_f,      /* config action routine        */
+                  NULL,                 /* argument to include in call  */
+                  RSRC_CONF,            /* where available              */
                   "Advertise frequency in seconds[.miliseconds]"),
-    AP_INIT_TAKE1("AdvertiseSecurityKey",                         /* directive name               */
-                  cmd_advertise_k,                                /* config action routine        */
-                  NULL,                                           /* argument to include in call  */
-                  RSRC_CONF,                                      /* where available              */
+    AP_INIT_TAKE1("AdvertiseSecurityKey", /* directive name               */
+                  cmd_advertise_k,        /* config action routine        */
+                  NULL,                   /* argument to include in call  */
+                  RSRC_CONF,              /* where available              */
                   "Advertise security key"),
-    AP_INIT_TAKE1("AdvertiseManagerUrl",                          /* directive name               */
-                  cmd_advertise_h,                                /* config action routine        */
-                  NULL,                                           /* argument to include in call  */
-                  RSRC_CONF,                                      /* where available              */
+    AP_INIT_TAKE1("AdvertiseManagerUrl", /* directive name               */
+                  cmd_advertise_h,       /* config action routine        */
+                  NULL,                  /* argument to include in call  */
+                  RSRC_CONF,             /* where available              */
                   "Advertise manager url"),
-    AP_INIT_TAKE1("AdvertiseBindAddress",                         /* directive name               */
-                  cmd_bindaddr,                                   /* config action routine        */
-                  NULL,                                           /* argument to include in call  */
-                  RSRC_CONF,                                      /* where available              */
+    AP_INIT_TAKE1("AdvertiseBindAddress", /* directive name               */
+                  cmd_bindaddr,           /* config action routine        */
+                  NULL,                   /* argument to include in call  */
+                  RSRC_CONF,              /* where available              */
                   "Local adress to bind to for Multicast logic"),
     {NULL},
 
@@ -764,7 +754,6 @@ static void register_hooks(apr_pool_t *p)
 
     /* Provider for the "status" page */
     ap_register_provider(p, "advertise", "info", "0", &advertise_info);
-
 }
 
 /* Create a default conf structure */
@@ -806,11 +795,11 @@ static void *create_advertise_server_config(apr_pool_t *p, server_rec *s)
 /*--------------------------------------------------------------------------*/
 module AP_MODULE_DECLARE_DATA advertise_module = {
     STANDARD20_MODULE_STUFF,
-    NULL,                               /* per-directory config creator                */
-    NULL,                               /* dir config merger                           */
-    create_advertise_server_config,     /* server config creator                       */
-    NULL,                               /* server config merger                        */
-    cmd_table,                          /* command table                               */
-    register_hooks,                     /* set up other request processing hooks       */
-    AP_MODULE_FLAG_NONE                 /* flags */
+    NULL,                           /* per-directory config creator                */
+    NULL,                           /* dir config merger                           */
+    create_advertise_server_config, /* server config creator                       */
+    NULL,                           /* server config merger                        */
+    cmd_table,                      /* command table                               */
+    register_hooks,                 /* set up other request processing hooks       */
+    AP_MODULE_FLAG_NONE             /* flags */
 };

--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -276,12 +276,14 @@ static const char *cmd_advertise_h(cmd_parms *cmd, void *dummy, const char *arg)
     return NULL;
 }
 
+// clang-format off
 #define MA_ADVERTISE_SERVER_FMT \
         "HTTP/1.0 %s" CRLF \
         "Date: %s" CRLF \
         "Sequence: %" APR_INT64_T_FMT CRLF \
         "Digest: %s" CRLF \
         "Server: %s" CRLF
+// clang-format on
 
 static const char *hex = "0123456789abcdef";
 

--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -42,18 +42,17 @@
 module AP_MODULE_DECLARE_DATA advertise_module;
 
 
-
 /*
  * Server private data
  */
 #if defined(WIN32)
-static pid_t      ma_parent_pid     = -1;
+static pid_t ma_parent_pid = -1;
 #endif
 
 /* Global (really) */
 
-static int   ma_advertise_run  = 0;
-static int   ma_advertise_stat = 0;
+static int ma_advertise_run  = 0;
+static int ma_advertise_stat = 0;
 static server_rec *main_server = NULL;
 
 /*
@@ -72,7 +71,7 @@ typedef struct mod_advertise_config
 
     char *ma_advertise_skey;
 
-    int   ma_bind_set;
+    int ma_bind_set;
     char *ma_bind_adrs;
     char *ma_bind_adsi;
     apr_port_t ma_bind_port;
@@ -85,15 +84,15 @@ typedef struct mod_advertise_config
 
 
 /* Advertise sockets */
-static apr_socket_t     *ma_mgroup_socket = NULL;
-static apr_sockaddr_t   *ma_mgroup_sa     = NULL;
-static apr_sockaddr_t   *ma_listen_sa     = NULL;
-static apr_sockaddr_t   *ma_niface_sa     = NULL;
+static apr_socket_t *ma_mgroup_socket = NULL;
+static apr_sockaddr_t *ma_mgroup_sa = NULL;
+static apr_sockaddr_t *ma_listen_sa = NULL;
+static apr_sockaddr_t *ma_niface_sa = NULL;
 
-static server_rec       *ma_server_rec    = NULL;
+static server_rec *ma_server_rec = NULL;
 
 /* Advertise sequence number */
-static volatile apr_int64_t ma_sequence   = 0;
+static volatile apr_int64_t ma_sequence = 0;
 
 
 /* Parent and child manager thread statuses */
@@ -103,19 +102,20 @@ static volatile int is_mp_created = 0;
 /*
  * Server global data
  */
-typedef struct ma_global_data_t {
+typedef struct ma_global_data_t
+{
     unsigned char ssalt[APR_MD5_DIGESTSIZE];
-    apr_uuid_t    suuid;
-    char          srvid[APR_UUID_FORMATTED_LENGTH + 2];
-    apr_pool_t   *ppool;
-    apr_pool_t   *cpool;
+    apr_uuid_t suuid;
+    char srvid[APR_UUID_FORMATTED_LENGTH + 2];
+    apr_pool_t *ppool;
+    apr_pool_t *cpool;
 } ma_global_data_t;
 
 /*
  * Global data instance
  * For parent, registered in process pool
  */
-static ma_global_data_t  *magd = NULL;
+static ma_global_data_t *magd = NULL;
 
 /* Evaluates to true if the (apr_sockaddr_t *) addr argument is the
  * IPv4 match-any-address, 0.0.0.0. */
@@ -132,11 +132,10 @@ static ma_global_data_t  *magd = NULL;
 /* ServerAdvertise directive                                                */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy,
-                                   const char *arg, const char *opt)
+static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy, const char *arg, const char *opt)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
-    (void) dummy;
+    (void)dummy;
 
     if (mconf->ma_advertise_srvs)
         return "Duplicate ServerAdvertise directives are not allowed";
@@ -157,9 +156,9 @@ static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy,
                                 &mconf->ma_advertise_srvi,
                                 &mconf->ma_advertise_srvp,
                                 opt, cmd->pool) != APR_SUCCESS ||
-                                !mconf->ma_advertise_srvs ||
-                                !mconf->ma_advertise_srvp)
+            !mconf->ma_advertise_srvs || !mconf->ma_advertise_srvp) {
             return "Invalid ServerAdvertise Address";
+        }
     }
     mconf->ma_advertise_server = cmd->server;
     return NULL;
@@ -171,20 +170,16 @@ static const char *cmd_advertise_m(cmd_parms *cmd, void *dummy,
 /* AdvertiseGroup directive                                                 */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy,
-                                   const char *arg)
+static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
-    (void) dummy;
+    (void)dummy;
 
-    if (mconf->ma_advertise_port != MA_DEFAULT_ADVPORT &&
-        (strcmp(mconf->ma_advertise_adrs, MA_DEFAULT_GROUP) != 0))
+    if (mconf->ma_advertise_port != MA_DEFAULT_ADVPORT && strcmp(mconf->ma_advertise_adrs, MA_DEFAULT_GROUP) != 0)
         return "Duplicate AdvertiseGroup directives are not allowed";
 
     if (apr_parse_addr_port(&mconf->ma_advertise_adrs,
-                            &mconf->ma_advertise_adsi,
-                            &mconf->ma_advertise_port,
-                            arg, cmd->pool) != APR_SUCCESS)
+                            &mconf->ma_advertise_adsi, &mconf->ma_advertise_port, arg, cmd->pool) != APR_SUCCESS)
         return "Invalid AdvertiseGroup address";
     if (!mconf->ma_advertise_adrs)
         return "Missing Ip part from AdvertiseGroup address";
@@ -199,19 +194,16 @@ static const char *cmd_advertise_g(cmd_parms *cmd, void *dummy,
 /* AdvertiseBindAddress directive                                           */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy,
-                                   const char *arg)
+static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
-    (void) dummy;
+    (void)dummy;
 
     if (mconf->ma_bind_set)
         return "Duplicate AdvertiseBindAddress directives are not allowed";
 
     if (apr_parse_addr_port(&mconf->ma_bind_adrs,
-                            &mconf->ma_bind_adsi,
-                            &mconf->ma_bind_port,
-                            arg, cmd->pool) != APR_SUCCESS)
+                            &mconf->ma_bind_adsi, &mconf->ma_bind_port, arg, cmd->pool) != APR_SUCCESS)
         return "Invalid AdvertiseBindAddress address";
     if (!mconf->ma_bind_adrs)
         return "Missing Ip part from AdvertiseBindAddress address";
@@ -221,20 +213,20 @@ static const char *cmd_bindaddr(cmd_parms *cmd, void *dummy,
     mconf->ma_advertise_server = cmd->server;
     return NULL;
 }
+
 /*--------------------------------------------------------------------------*/
 /*                                                                          */
 /* AdvertiseFrequency directive                                             */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
 
-static const char *cmd_advertise_f(cmd_parms *cmd, void *dummy,
-                                   const char *arg)
+static const char *cmd_advertise_f(cmd_parms *cmd, void *dummy, const char *arg)
 {
     apr_time_t s, u = 0;
     const char *p;
 
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
-    (void) dummy;
+    (void)dummy;
 
     if (mconf->ma_advertise_freq != MA_DEFAULT_ADV_FREQ)
         return "Duplicate AdvertiseFrequency directives are not allowed";
@@ -255,11 +247,10 @@ static const char *cmd_advertise_f(cmd_parms *cmd, void *dummy,
 /* AdvertiseSecurityKey directive                                           */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_k(cmd_parms *cmd, void *dummy,
-                                   const char *arg)
+static const char *cmd_advertise_k(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
-   (void) dummy;
+    (void)dummy;
 
     if (mconf->ma_advertise_skey != NULL)
         return "Duplicate AdvertiseSecurityKey directives are not allowed";
@@ -273,11 +264,10 @@ static const char *cmd_advertise_k(cmd_parms *cmd, void *dummy,
 /* AdvertiseManagerUrl directive                                            */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const char *cmd_advertise_h(cmd_parms *cmd, void *dummy,
-                                   const char *arg)
+static const char *cmd_advertise_h(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_advertise_config *mconf = ap_get_module_config(cmd->server->module_config, &advertise_module);
-    (void) dummy;
+    (void)dummy;
 
     if (mconf->ma_advertise_srvh != NULL)
         return "Duplicate AdvertiseManagerUrl directives are not allowed";
@@ -304,7 +294,7 @@ static apr_status_t ma_advertise_server(server_rec *server, int type)
     unsigned char ssig[APR_MD5_DIGESTSIZE * 2 + 1];
     const char *asl;
     char *p = buf;
-    int  i, c = 0;
+    int i, c = 0;
     apr_size_t l = MA_BSIZE - 8;
     apr_size_t n = 0;
     apr_md5_ctx_t md;
@@ -332,8 +322,7 @@ static apr_status_t ma_advertise_server(server_rec *server, int type)
         ssig[c++] = hex[msig[i] & 0x0F];
     }
     ssig[c] = '\0';
-    n = apr_snprintf(p, l, MA_ADVERTISE_SERVER_FMT,
-                     asl, dat, ma_sequence, ssig, magd->srvid + 1);
+    n = apr_snprintf(p, l, MA_ADVERTISE_SERVER_FMT, asl, dat, ma_sequence, ssig, magd->srvid + 1);
     if (type == MA_ADVERTISE_SERVER) {
         char *ma_advertise_srvs = mconf->ma_advertise_srvs;
         if (strchr(ma_advertise_srvs, ':') != NULL) {
@@ -348,83 +337,59 @@ static apr_status_t ma_advertise_server(server_rec *server, int type)
                           "X-Manager-Host: %s" CRLF,
                           ma_advertise_srvs,
                           mconf->ma_advertise_srvp,
-                          mconf->ma_advertise_srvh,
-                          mconf->ma_advertise_srvm,
-                          server->server_hostname);
-
+                          mconf->ma_advertise_srvh, mconf->ma_advertise_srvm, server->server_hostname);
     }
     strcat(p, CRLF);
     n += 2;
-    return apr_socket_sendto(ma_mgroup_socket,
-                             ma_mgroup_sa, 0, buf, &n);
+    return apr_socket_sendto(ma_mgroup_socket, ma_mgroup_sa, 0, buf, &n);
 }
 
 static apr_status_t ma_group_join(const char *addr, apr_port_t port,
-                                  const char *bindaddr, apr_port_t bindport,
-                                  apr_pool_t *pool, server_rec *s)
+                                  const char *bindaddr, apr_port_t bindport, apr_pool_t *pool, server_rec *s)
 {
     apr_status_t rv;
 
-    if ((rv = apr_sockaddr_info_get(&ma_mgroup_sa, addr,
-                                    APR_UNSPEC, port,
-                                    APR_UNSPEC, pool)) != APR_SUCCESS) {
+    if ((rv = apr_sockaddr_info_get(&ma_mgroup_sa, addr, APR_UNSPEC, port, APR_UNSPEC, pool)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "mod_advertise: ma_group_join apr_sockaddr_info_get(%s:%d) failed",
-                     addr, port);
+                     "mod_advertise: ma_group_join apr_sockaddr_info_get(%s:%d) failed", addr, port);
         return rv;
     }
     if ((rv = apr_sockaddr_info_get(&ma_listen_sa, bindaddr,
-                                    ma_mgroup_sa->family, bindport,
-                                    APR_UNSPEC, pool)) != APR_SUCCESS) {
+                                    ma_mgroup_sa->family, bindport, APR_UNSPEC, pool)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
                      "mod_advertise: ma_group_join apr_sockaddr_info_get(%s:%d) failed", bindaddr, bindport);
         return rv;
     }
-    if ((rv = apr_sockaddr_info_get(&ma_niface_sa, NULL,
-                                    ma_mgroup_sa->family, 0,
-                                    APR_UNSPEC, pool)) != APR_SUCCESS) {
+    if ((rv = apr_sockaddr_info_get(&ma_niface_sa, NULL, ma_mgroup_sa->family, 0, APR_UNSPEC, pool)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
                      "mod_advertise: ma_group_join apr_sockaddr_info_get(0.0.0.0:0) failed");
         return rv;
     }
     if ((rv = apr_socket_create(&ma_mgroup_socket,
-                                ma_mgroup_sa->family,
-                                SOCK_DGRAM,
-                                APR_PROTO_UDP,
-                                pool)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "mod_advertise: ma_group_join apr_socket_create failed");
+                                ma_mgroup_sa->family, SOCK_DGRAM, APR_PROTO_UDP, pool)) != APR_SUCCESS) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: ma_group_join apr_socket_create failed");
         return rv;
     }
-    if ((rv = apr_socket_opt_set(ma_mgroup_socket,
-                                 APR_SO_REUSEADDR, 1)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "mod_advertise: ma_group_join apr_socket_opt_set failed");
+    if ((rv = apr_socket_opt_set(ma_mgroup_socket, APR_SO_REUSEADDR, 1)) != APR_SUCCESS) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: ma_group_join apr_socket_opt_set failed");
         return rv;
     }
     if ((rv = apr_socket_bind(ma_mgroup_socket, ma_listen_sa)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "mod_advertise: ma_group_join apr_socket_bind failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: ma_group_join apr_socket_bind failed");
         return rv;
     }
-    if ((rv = apr_mcast_join(ma_mgroup_socket, ma_mgroup_sa,
-                             ma_niface_sa, NULL)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, rv, s,
-                     "mod_advertise: ma_group_join apr_mcast_join failed");
+    if ((rv = apr_mcast_join(ma_mgroup_socket, ma_mgroup_sa, ma_niface_sa, NULL)) != APR_SUCCESS) {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, rv, s, "mod_advertise: ma_group_join apr_mcast_join failed");
         if ((rv = apr_mcast_loopback(ma_mgroup_socket, 1)) != APR_SUCCESS) {
-            ap_log_error(APLOG_MARK, APLOG_WARNING, rv, s,
-                         "mod_advertise: ma_group_join apr_mcast_loopback failed");
+            ap_log_error(APLOG_MARK, APLOG_WARNING, rv, s, "mod_advertise: ma_group_join apr_mcast_loopback failed");
             apr_socket_close(ma_mgroup_socket);
             return rv;
-        }     
+        }
     }
-    if ((rv = apr_mcast_hops(ma_mgroup_socket,
-                             MA_ADVERTISE_HOPS)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
-                     "mod_advertise: ma_group_join apr_mcast_hops failed");
+    if ((rv = apr_mcast_hops(ma_mgroup_socket, MA_ADVERTISE_HOPS)) != APR_SUCCESS) {
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, s, "mod_advertise: ma_group_join apr_mcast_hops failed");
         /* Due a bug in apr (fixed by r1309332) apr_mcast_hops may fail */
-        apr_mcast_leave(ma_mgroup_socket, ma_mgroup_sa,
-                        NULL, NULL);
+        apr_mcast_leave(ma_mgroup_socket, ma_mgroup_sa, NULL, NULL);
         apr_socket_close(ma_mgroup_socket);
         return rv;
     }
@@ -434,22 +399,21 @@ static apr_status_t ma_group_join(const char *addr, apr_port_t port,
 static void ma_group_leave(void)
 {
     if (ma_mgroup_socket) {
-        apr_mcast_leave(ma_mgroup_socket, ma_mgroup_sa,
-                        NULL, NULL);
+        apr_mcast_leave(ma_mgroup_socket, ma_mgroup_sa, NULL, NULL);
         apr_socket_close(ma_mgroup_socket);
         ma_mgroup_socket = NULL;
     }
 }
 
-static void * APR_THREAD_FUNC parent_thread(apr_thread_t *thd, void *data)
+static void *APR_THREAD_FUNC parent_thread(apr_thread_t *thd, void *data)
 {
-    static int current_status  = 0;
+    static int current_status = 0;
     int f_time = 1;
     apr_interval_time_t a_step = 0;
-    server_rec *s = (server_rec *)data;
+    server_rec *s = (server_rec *) data;
     mod_advertise_config *mconf = ap_get_module_config(s->module_config, &advertise_module);
     is_mp_created = 1;
-    (void) thd;
+    (void)thd;
 
     while (is_mp_running) {
         apr_sleep(MA_TM_RESOLUTION);
@@ -484,9 +448,9 @@ static apr_status_t pconfig_cleanup(void *data);
 static apr_status_t process_cleanup(void *data)
 {
     int advertise_run = ma_advertise_run;
-    is_mp_running     = 0;
-    ma_advertise_run  = 0;
-    (void) data;
+    is_mp_running = 0;
+    ma_advertise_run = 0;
+    (void)data;
 
     if (advertise_run) {
         ma_advertise_stat = HTTP_FORBIDDEN;
@@ -504,8 +468,7 @@ static apr_status_t process_cleanup(void *data)
         ma_advertise_server(ma_server_rec, MA_ADVERTISE_STATUS);
         ma_group_leave();
     }
-    /* We don't need the post_config cleanup to run,
-     */
+    /* We don't need the post_config cleanup to run */
     apr_pool_cleanup_kill(magd->cpool, magd, pconfig_cleanup);
     magd = NULL;
 
@@ -515,9 +478,9 @@ static apr_status_t process_cleanup(void *data)
 static apr_status_t pconfig_cleanup(void *data)
 {
     int advertise_run = ma_advertise_run;
-    is_mp_running     = 0;
-    ma_advertise_run  = 0;
-    (void) data;
+    is_mp_running = 0;
+    ma_advertise_run = 0;
+    (void)data;
 
     if (advertise_run) {
         ma_advertise_stat = HTTP_FORBIDDEN;
@@ -551,8 +514,7 @@ static apr_status_t pconfig_cleanup(void *data)
 /* Create management thread in parent and initializes Manager               */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
-                            apr_pool_t *ptemp, server_rec *s)
+static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
 {
     apr_status_t rv;
     const char *pk = "advertise_init_module_tag";
@@ -561,7 +523,8 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
     mod_advertise_config *mconf = ap_get_module_config(s->module_config, &advertise_module);
     int advertisefound = 0;
     server_rec *server = s;
-    (void) plog; (void) ptemp; /* unused variables */
+    (void)plog;
+    (void)ptemp;                /* unused variables */
 
     /* Advertise directive in more than one VirtualHost: not supported */
     while (server) {
@@ -569,9 +532,10 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
         if (conf->ma_advertise_server == server) {
             if (advertisefound) {
                 ap_log_error(APLOG_MARK, APLOG_ERR, 0, s,
-                         "mod_advertise: directive in more than one VirtualHost: not supported");
+                             "mod_advertise: directive in more than one VirtualHost: not supported");
                 return !OK;
-            } else
+            }
+            else
                 advertisefound = -1;
         }
         server = server->next;
@@ -601,20 +565,20 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
         if (ppid) {
             ma_parent_pid = atol(ppid);
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s,
-                "[%" APR_PID_T_FMT " - %" APR_PID_T_FMT
-                "] in child post config hook",
-                getpid(), ma_parent_pid);
+                         "[%" APR_PID_T_FMT " - %" APR_PID_T_FMT
+                         "] in child post config hook", getpid(), ma_parent_pid);
             return OK;
         }
     }
 #endif
-    ma_server_rec = server; 
+    ma_server_rec = server;
     if (mconf->ma_advertise_skey) {
         apr_md5_ctx_t mc;
         apr_md5_init(&mc);
         apr_md5_update(&mc, mconf->ma_advertise_skey, strlen(mconf->ma_advertise_skey));
         apr_md5_final(magd->ssalt, &mc);
-    } else {
+    }
+    else {
         /* If security key is not configured, the digest is calculated from zero bytes */
         memset(magd->ssalt, '\0', APR_MD5_DIGESTSIZE);
     }
@@ -624,9 +588,9 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
     if (!mconf->ma_advertise_srvh)
         mconf->ma_advertise_srvh = magd->srvid;
     /* Check if we have advertise set */
-    if (mconf->ma_advertise_mode != ma_advertise_off &&
-        mconf->ma_advertise_adrs) {
-        rv = ma_group_join(mconf->ma_advertise_adrs, mconf->ma_advertise_port, mconf->ma_bind_adrs, mconf->ma_bind_port, pconf, s);
+    if (mconf->ma_advertise_mode != ma_advertise_off && mconf->ma_advertise_adrs) {
+        rv = ma_group_join(mconf->ma_advertise_adrs, mconf->ma_advertise_port, mconf->ma_bind_adrs, mconf->ma_bind_port,
+                           pconf, s);
         if (rv != APR_SUCCESS) {
             ap_log_error(APLOG_MARK, APLOG_ERR, rv, s,
                          "mod_advertise: multicast join failed for %s:%d.",
@@ -634,17 +598,18 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
             ma_advertise_run = 0;
         }
         else {
-            ma_advertise_run  = 1;
+            ma_advertise_run = 1;
             ma_advertise_stat = 200;
         }
     }
 
     /* Fill default values */
-    if (!mconf->ma_advertise_srvm)  {
+    if (!mconf->ma_advertise_srvm) {
         if (ma_server_rec && ma_server_rec->server_scheme) {
             /* ServerName scheme://fully-qualified-domain-name[:port] */
             mconf->ma_advertise_srvm = apr_pstrdup(pconf, ma_server_rec->server_scheme);
-        } else {
+        }
+        else {
             mconf->ma_advertise_srvm = apr_pstrdup(pconf, "http");
         }
     }
@@ -656,46 +621,40 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
          */
         char *ptr = NULL;
         int port = DEFAULT_HTTP_PORT;
-        if (ma_server_rec->addrs && ma_server_rec->addrs->host_addr &&
-            ma_server_rec->addrs->host_addr->next == NULL) {
+        if (ma_server_rec->addrs && ma_server_rec->addrs->host_addr && ma_server_rec->addrs->host_addr->next == NULL) {
             ptr = apr_psprintf(pproc, "%pI", ma_server_rec->addrs->host_addr);
         }
         /* Use don't use any as local address too */
-        if (ptr == NULL || strncmp(ptr,"0.0.0.0", 7) == 0 || strncmp(ptr,"::",2) == 0) {
-            if  ( ma_server_rec->port == 0 || ma_server_rec->port == 1) {
+        if (ptr == NULL || strncmp(ptr, "0.0.0.0", 7) == 0 || strncmp(ptr, "::", 2) == 0) {
+            if (ma_server_rec->port == 0 || ma_server_rec->port == 1) {
                 if (ma_server_rec->addrs->host_addr->port != 0)
                     port = ma_server_rec->addrs->host_addr->port;
-            } else {
+            }
+            else {
                 port = ma_server_rec->port;
-             }
+            }
             ptr = apr_psprintf(pproc, "%s:%u", ma_server_rec->server_hostname, port);
         }
         rv = apr_parse_addr_port(&mconf->ma_advertise_srvs,
-                                 &mconf->ma_advertise_srvi,
-                                 &mconf->ma_advertise_srvp,
-                                 ptr, pproc);
-        if (rv != APR_SUCCESS || !mconf->ma_advertise_srvs ||
-                                 !mconf->ma_advertise_srvp) {
-            ap_log_error(APLOG_MARK, APLOG_CRIT, rv, s,
-                         "mod_advertise: Invalid ServerAdvertise Address %s",
-                         ptr);
+                                 &mconf->ma_advertise_srvi, &mconf->ma_advertise_srvp, ptr, pproc);
+        if (rv != APR_SUCCESS || !mconf->ma_advertise_srvs || !mconf->ma_advertise_srvp) {
+            ap_log_error(APLOG_MARK, APLOG_CRIT, rv, s, "mod_advertise: Invalid ServerAdvertise Address %s", ptr);
             return rv;
         }
     }
 
     /* prevent X-Manager-Address: (null):0  */
     if (!mconf->ma_advertise_srvs || !mconf->ma_advertise_srvp) {
-            ap_log_error(APLOG_MARK, APLOG_WARNING, 0, s,
-                         "mod_advertise: ServerAdvertise Address or Port not defined, Advertise disabled!!!");
-            return OK;
+        ap_log_error(APLOG_MARK, APLOG_WARNING, 0, s,
+                     "mod_advertise: ServerAdvertise Address or Port not defined, Advertise disabled!!!");
+        return OK;
     }
 
     /* Create parent management thread */
     is_mp_running = 1;
     rv = apr_thread_create(&tp, NULL, parent_thread, server, pconf);
     if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, rv, s,
-                     "mod_advertise: parent apr_thread_create");
+        ap_log_error(APLOG_MARK, APLOG_CRIT, rv, s, "mod_advertise: parent apr_thread_create");
         return rv;
     }
     apr_thread_detach(tp);
@@ -704,24 +663,18 @@ static int post_config_hook(apr_pool_t *pconf, apr_pool_t *plog,
      * in future use new apr_pool_pre_cleanup_register from APR 1.3
      */
     apr_pool_create(&magd->cpool, pconf);
-    apr_pool_cleanup_register(magd->cpool, magd, pconfig_cleanup,
-                              apr_pool_cleanup_null);
+    apr_pool_cleanup_register(magd->cpool, magd, pconfig_cleanup, apr_pool_cleanup_null);
 
-    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s,
-                 "Advertise initialized for process %" APR_PID_T_FMT,
-                 getpid());
+    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, s, "Advertise initialized for process %" APR_PID_T_FMT, getpid());
 
-    apr_pool_cleanup_register(magd->ppool, magd, process_cleanup,
-                              apr_pool_cleanup_null);
-
-
+    apr_pool_cleanup_register(magd->ppool, magd, process_cleanup, apr_pool_cleanup_null);
 
     return OK;
 }
 
-static void  child_init_hook(apr_pool_t *p, server_rec *s)
+static void child_init_hook(apr_pool_t *p, server_rec *s)
 {
-    (void) p;
+    (void)p;
     main_server = s;
 }
 
@@ -737,17 +690,17 @@ static void advertise_info(request_rec *r)
         mod_advertise_config *mconf = ap_get_module_config(sconf, &advertise_module);
         ap_rprintf(r, "Server: %s ", s->server_hostname);
         if (s->is_virtual && s->addrs) {
-           server_addr_rec *srec = s->addrs;
-           ap_rprintf(r, "VirtualHost: %s:%d", srec->virthost, srec->host_port);
+            server_addr_rec *srec = s->addrs;
+            ap_rprintf(r, "VirtualHost: %s:%d", srec->virthost, srec->host_port);
         }
         if (mconf->ma_advertise_server != NULL) {
             ap_rprintf(r, " Advertising on Group %s Port %d ", mconf->ma_advertise_adrs, mconf->ma_advertise_port);
             ap_rprintf(r, "for %s://%s:%d every %ld seconds<br/>",
                        mconf->ma_advertise_srvm, mconf->ma_advertise_srvs,
-                       mconf->ma_advertise_srvp,
-                       apr_time_sec(mconf->ma_advertise_freq)
-                       );
-        } else {
+                       mconf->ma_advertise_srvp, apr_time_sec(mconf->ma_advertise_freq)
+                );
+        }
+        else {
             ap_rputs("<br/>", r);
         }
         s = s->next;
@@ -760,50 +713,37 @@ static void advertise_info(request_rec *r)
 /* List of directives specific to our module.                               */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-static const command_rec cmd_table[] =
-{
-    AP_INIT_TAKE12(
-        "ServerAdvertise",                  /* directive name               */
-        cmd_advertise_m,                    /* config action routine        */
-        NULL,                               /* argument to include in call  */
-        RSRC_CONF,                          /* where available              */
-        "Server advertise mode: On | Off [Address]"
-    ),
-    AP_INIT_TAKE1(
-        "AdvertiseGroup",                   /* directive name               */
-        cmd_advertise_g,                    /* config action routine        */
-        NULL,                               /* argument to include in call  */
-        RSRC_CONF,                          /* where available              */
-        "Multicast group address"
-    ),
-    AP_INIT_TAKE1(
-        "AdvertiseFrequency",               /* directive name               */
-        cmd_advertise_f,                    /* config action routine        */
-        NULL,                               /* argument to include in call  */
-        RSRC_CONF,                          /* where available              */
-        "Advertise frequency in seconds[.miliseconds]"
-    ),
-    AP_INIT_TAKE1(
-        "AdvertiseSecurityKey",             /* directive name               */
-        cmd_advertise_k,                    /* config action routine        */
-        NULL,                               /* argument to include in call  */
-        RSRC_CONF,                          /* where available              */
-        "Advertise security key"
-    ),
-    AP_INIT_TAKE1(
-        "AdvertiseManagerUrl",              /* directive name               */
-        cmd_advertise_h,                    /* config action routine        */
-        NULL,                               /* argument to include in call  */
-        RSRC_CONF,                          /* where available              */
-        "Advertise manager url"
-    ),
-    AP_INIT_TAKE1(
-        "AdvertiseBindAddress",             /* directive name               */
-        cmd_bindaddr,                       /* config action routine        */
-        NULL,                               /* argument to include in call  */
-        RSRC_CONF,                          /* where available              */
-        "Local adress to bind to for Multicast logic"
-    ),
+static const command_rec cmd_table[] = {
+    AP_INIT_TAKE12("ServerAdvertise",                             /* directive name               */
+                   cmd_advertise_m,                               /* config action routine        */
+                   NULL,                                          /* argument to include in call  */
+                   RSRC_CONF,                                     /* where available              */
+                   "Server advertise mode: On | Off [Address]"),
+    AP_INIT_TAKE1("AdvertiseGroup",                               /* directive name               */
+                  cmd_advertise_g,                                /* config action routine        */
+                  NULL,                                           /* argument to include in call  */
+                  RSRC_CONF,                                      /* where available              */
+                  "Multicast group address"),
+    AP_INIT_TAKE1("AdvertiseFrequency",                           /* directive name               */
+                  cmd_advertise_f,                                /* config action routine        */
+                  NULL,                                           /* argument to include in call  */
+                  RSRC_CONF,                                      /* where available              */
+                  "Advertise frequency in seconds[.miliseconds]"),
+    AP_INIT_TAKE1("AdvertiseSecurityKey",                         /* directive name               */
+                  cmd_advertise_k,                                /* config action routine        */
+                  NULL,                                           /* argument to include in call  */
+                  RSRC_CONF,                                      /* where available              */
+                  "Advertise security key"),
+    AP_INIT_TAKE1("AdvertiseManagerUrl",                          /* directive name               */
+                  cmd_advertise_h,                                /* config action routine        */
+                  NULL,                                           /* argument to include in call  */
+                  RSRC_CONF,                                      /* where available              */
+                  "Advertise manager url"),
+    AP_INIT_TAKE1("AdvertiseBindAddress",                         /* directive name               */
+                  cmd_bindaddr,                                   /* config action routine        */
+                  NULL,                                           /* argument to include in call  */
+                  RSRC_CONF,                                      /* where available              */
+                  "Local adress to bind to for Multicast logic"),
     {NULL}
 
 };
@@ -816,16 +756,12 @@ static const command_rec cmd_table[] =
 static void register_hooks(apr_pool_t *p)
 {
 
-    /* Post config handling
-     */
-    ap_hook_post_config(post_config_hook,
-                        NULL,
-                        NULL,
-                        APR_HOOK_LAST);
+    /* Post config handling */
+    ap_hook_post_config(post_config_hook, NULL, NULL, APR_HOOK_LAST);
     ap_hook_child_init(child_init_hook, NULL, NULL, APR_HOOK_MIDDLE);
 
     /* Provider for the "status" page */
-    ap_register_provider(p, "advertise" , "info", "0", &advertise_info);
+    ap_register_provider(p, "advertise", "info", "0", &advertise_info);
 
 }
 
@@ -833,10 +769,10 @@ static void register_hooks(apr_pool_t *p)
 static void *create_advertise_server_config(apr_pool_t *p, server_rec *s)
 {
     mod_advertise_config *mconf = apr_pcalloc(p, sizeof(*mconf));
-    (void) s;
+    (void)s;
 
     /* Set default values */
-    mconf->ma_advertise_server  = NULL;
+    mconf->ma_advertise_server = NULL;
     mconf->ma_advertise_adrs = MA_DEFAULT_GROUP;
     mconf->ma_advertise_adsi = NULL;
     mconf->ma_advertise_srvm = NULL;
@@ -847,7 +783,7 @@ static void *create_advertise_server_config(apr_pool_t *p, server_rec *s)
 
     mconf->ma_advertise_skey = NULL;
 
-    mconf->ma_bind_set  = 0;
+    mconf->ma_bind_set = 0;
     mconf->ma_bind_adrs = NULL;
     mconf->ma_bind_adsi = NULL;
     mconf->ma_bind_port = MA_DEFAULT_ADVPORT;
@@ -866,14 +802,13 @@ static void *create_advertise_server_config(apr_pool_t *p, server_rec *s)
 /* the static hooks into our module from the other parts of the server.     */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
-module AP_MODULE_DECLARE_DATA advertise_module =
-{
+module AP_MODULE_DECLARE_DATA advertise_module = {
     STANDARD20_MODULE_STUFF,
-    NULL,                    /* per-directory config creator                */
-    NULL,                    /* dir config merger                           */
-    create_advertise_server_config,                    /* server config creator                       */
-    NULL,                     /* server config merger                        */
-    cmd_table,               /* command table                               */
-    register_hooks,          /* set up other request processing hooks       */
-    AP_MODULE_FLAG_NONE      /* flags */
+    NULL,                               /* per-directory config creator                */
+    NULL,                               /* dir config merger                           */
+    create_advertise_server_config,     /* server config creator                       */
+    NULL,                               /* server config merger                        */
+    cmd_table,                          /* command table                               */
+    register_hooks,                     /* set up other request processing hooks       */
+    AP_MODULE_FLAG_NONE                 /* flags */
 };

--- a/native/advertise/mod_advertise.h
+++ b/native/advertise/mod_advertise.h
@@ -87,48 +87,47 @@ extern "C" {
 #endif
 
 
-#define MA_BSIZE                4096
-#define MA_SSIZE                1024
-#define MA_DEFAULT_ADVPORT      23364
-#define MA_DEFAULT_GROUP        "224.0.1.105"
-#define MA_TM_RESOLUTION        APR_TIME_C(100000)
-#define MA_DEFAULT_ADV_FREQ     apr_time_from_sec(10)
-#define MA_TM_MAINTAIN_STEP     10
+#define MA_BSIZE            4096
+#define MA_SSIZE            1024
+#define MA_DEFAULT_ADVPORT  23364
+#define MA_DEFAULT_GROUP    "224.0.1.105"
+#define MA_TM_RESOLUTION    APR_TIME_C(100000)
+#define MA_DEFAULT_ADV_FREQ apr_time_from_sec(10)
+#define MA_TM_MAINTAIN_STEP 10
 
 /**
  * Multicast Time to Live (ttl) for a advertise transmission.
  */
-#define MA_ADVERTISE_HOPS       10
+#define MA_ADVERTISE_HOPS   10
 
 /**
  * Advertise protocol types
  */
-#define MA_ADVERTISE_SERVER     0
-#define MA_ADVERTISE_STATUS     1
+#define MA_ADVERTISE_SERVER 0
+#define MA_ADVERTISE_STATUS 1
 
 /**
  * Advertise mode enumeration.
  */
-typedef enum {
-    ma_advertise_off,
-    ma_advertise_on
-} ma_advertise_e;
+typedef enum { ma_advertise_off, ma_advertise_on } ma_advertise_e;
 
 /**
  * Advertise header data structure
  */
 typedef struct ma_advertise_hdr_t ma_advertise_hdr_t;
-struct ma_advertise_hdr_t {
-    int          type;
+struct ma_advertise_hdr_t
+{
+    int type;
     apr_status_t status;
-    char         suuid[APR_UUID_FORMATTED_LENGTH + 1];
+    char suuid[APR_UUID_FORMATTED_LENGTH + 1];
 };
 
 /**
  * Advertise server data structure
  */
 typedef struct ma_advertise_srv_t ma_advertise_srv_t;
-struct ma_advertise_srv_t {
+struct ma_advertise_srv_t
+{
     const char *handle;
     const char *address;
     const char *protocol;

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -39,15 +39,15 @@ static struct context_storage_method *context_storage = NULL;
 static struct balancer_storage_method *balancer_storage = NULL;
 static struct domain_storage_method *domain_storage = NULL;
 
-static int use_alias = 0; /* 1 : Compare Alias with server_name */
-static apr_time_t lbstatus_recalc_time = apr_time_from_sec(5); /* recalcul the lbstatus based on number of request in the time interval */
-static apr_time_t wait_for_remove =  apr_time_from_sec(10); /* wait until that before removing a removed node */
+static int use_alias = 0;       /* 1 : Compare Alias with server_name */
+static apr_time_t lbstatus_recalc_time = apr_time_from_sec(5);  /* recalcul the lbstatus based on number of request in the time interval */
+static apr_time_t wait_for_remove = apr_time_from_sec(10);      /* wait until that before removing a removed node */
 
 module AP_MODULE_DECLARE_DATA lbmethod_cluster_module;
 
 static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balancer *balancer,
-                                         proxy_vhost_table *vhost_table,
-                                         proxy_context_table *context_table, proxy_node_table *node_table)
+                                                   proxy_vhost_table *vhost_table,
+                                                   proxy_context_table *context_table, proxy_node_table *node_table)
 {
     char *ptr = balancer->workers->elts;
     int sizew = balancer->workers->elt_size;
@@ -55,11 +55,11 @@ static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balance
     int i;
 
     for (i = 0; i < balancer->workers->nelts; i++, ptr = ptr + sizew) {
-        nodeinfo_t* node;
+        nodeinfo_t *node;
         int id;
         proxy_worker **run = (proxy_worker **) ptr;
         proxy_worker *worker = *run;
-        
+
         if (!PROXY_WORKER_IS_USABLE(worker))
             continue;
         /* read the node and check context */
@@ -70,15 +70,16 @@ static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balance
             continue;
         if (!mycandidate) {
             mycandidate = worker;
-        } else {
-            nodeinfo_t* node1;
+        }
+        else {
+            nodeinfo_t *node1;
             int id1;
             node1 = table_get_node_route(node_table, mycandidate->s->route, &id1);
             if (node1) {
                 int lbstatus, lbstatus1;
-                lbstatus1 = ((mycandidate->s->elected - node1->mess.oldelected) * 1000)/mycandidate->s->lbfactor;
-                lbstatus  = ((worker->s->elected - node->mess.oldelected) * 1000)/worker->s->lbfactor;
-                if (lbstatus1> lbstatus) {
+                lbstatus1 = ((mycandidate->s->elected - node1->mess.oldelected) * 1000) / mycandidate->s->lbfactor;
+                lbstatus = ((worker->s->elected - node->mess.oldelected) * 1000) / worker->s->lbfactor;
+                if (lbstatus1 > lbstatus) {
                     mycandidate = worker;
                 }
             }
@@ -102,9 +103,11 @@ static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balance
                         !strcmp(httpworker->s->route, mycandidate->s->route)) {
                         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                                     "proxy: byrequests balancer Using %s instead %s", httpworker->s->name_ex, mycandidate->s->name_ex);
+                                     "proxy: byrequests balancer Using %s instead %s", httpworker->s->name_ex,
+                                     mycandidate->s->name_ex);
 #else
-                                     "proxy: byrequests balancer Using %s instead %s", httpworker->s->name, mycandidate->s->name);
+                                     "proxy: byrequests balancer Using %s instead %s", httpworker->s->name,
+                                     mycandidate->s->name);
 #endif
                         return httpworker;
                     }
@@ -115,14 +118,13 @@ static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balance
     return mycandidate;
 }
 
-static proxy_worker *find_best(proxy_balancer *balancer,
-                                  request_rec *r)
+static proxy_worker *find_best(proxy_balancer *balancer, request_rec *r)
 {
     proxy_worker *mycandidate = NULL;
 
     proxy_vhost_table *vhost_table = (proxy_vhost_table *) apr_table_get(r->notes, "vhost-table");
-    proxy_context_table *context_table  = (proxy_context_table *) apr_table_get(r->notes, "context-table");
-    proxy_node_table *node_table  = (proxy_node_table *) apr_table_get(r->notes, "node-table");
+    proxy_context_table *context_table = (proxy_context_table *) apr_table_get(r->notes, "context-table");
+    proxy_node_table *node_table = (proxy_node_table *) apr_table_get(r->notes, "node-table");
 
     if (!vhost_table)
         vhost_table = read_vhost_table(r->pool, host_storage, 0);
@@ -140,24 +142,27 @@ static proxy_worker *find_best(proxy_balancer *balancer,
 
 static apr_status_t reset(proxy_balancer *balancer, server_rec *s)
 {
-    (void) balancer; (void) s;
+    (void)balancer;
+    (void)s;
     return APR_SUCCESS;
 }
 
 static apr_status_t age(proxy_balancer *balancer, server_rec *s)
 {
-    (void) balancer; (void) s;
+    (void)balancer;
+    (void)s;
     return APR_SUCCESS;
 }
 
 static apr_status_t updatelbstatus(proxy_balancer *balancer, proxy_worker *elected, server_rec *s)
 {
-    (void) balancer; (void) elected; (void) s;
+    (void)balancer;
+    (void)elected;
+    (void)s;
     return APR_SUCCESS;
 }
 
-static const proxy_balancer_method cluster = 
-{
+static const proxy_balancer_method cluster = {
     "cluster",
     &find_best,
     NULL,
@@ -180,11 +185,11 @@ static int lbmethod_cluster_trans(request_rec *r)
 
 
 #if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_DEBUG, 0, r->server,
-                "lbmethod_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s",
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server,
+                 "lbmethod_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s",
                  r->proxyreq, r->filename, r->handler, r->uri, r->args, r->unparsed_uri);
-    ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_DEBUG, 0, r->server,
-                "lbmethod_cluster_trans for %d", conf->balancers->nelts);
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server,
+                 "lbmethod_cluster_trans for %d", conf->balancers->nelts);
 #endif
 
     proxy_vhost_table *vhost_table = read_vhost_table(r->pool, host_storage, 0);
@@ -192,38 +197,36 @@ static int lbmethod_cluster_trans(request_rec *r)
     proxy_balancer_table *balancer_table = read_balancer_table(r->pool, balancer_storage, 0);
     proxy_node_table *node_table = read_node_table(r->pool, node_storage, 0);
 
-    apr_table_setn(r->notes, "vhost-table",  (char *) vhost_table);
-    apr_table_setn(r->notes, "context-table",  (char *) context_table);
-    apr_table_setn(r->notes, "balancer-table",  (char *) balancer_table);
-    apr_table_setn(r->notes, "node-table",  (char *) node_table);
+    apr_table_setn(r->notes, "vhost-table", (char *)vhost_table);
+    apr_table_setn(r->notes, "context-table", (char *)context_table);
+    apr_table_setn(r->notes, "balancer-table", (char *)balancer_table);
+    apr_table_setn(r->notes, "node-table", (char *)node_table);
 
     balancer = get_route_balancer(r, conf, vhost_table, context_table, balancer_table, node_table, use_alias);
     if (!balancer) {
         balancer = get_context_host_balancer(r, vhost_table, context_table, node_table, use_alias);
     }
-    
+
 
     if (balancer) {
 
         /* It is safer to use r->uri */
-        if (strncmp(r->uri, "balancer://",11))
-            r->filename =  apr_pstrcat(r->pool, "proxy:balancer://", balancer, r->uri, NULL);
+        if (strncmp(r->uri, "balancer://", 11))
+            r->filename = apr_pstrcat(r->pool, "proxy:balancer://", balancer, r->uri, NULL);
         else
-            r->filename =  apr_pstrcat(r->pool, "proxy:", r->uri, NULL);
+            r->filename = apr_pstrcat(r->pool, "proxy:", r->uri, NULL);
         r->handler = "proxy-server";
         r->proxyreq = PROXYREQ_REVERSE;
 #if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_DEBUG, 0, r->server,
-                    "proxy_cluster_trans using %s uri: %s",
-                     balancer, r->filename);
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server,
+                     "proxy_cluster_trans using %s uri: %s", balancer, r->filename);
 #endif
-        return OK; /* Mod_proxy will process it */
+        return OK;              /* Mod_proxy will process it */
     }
- 
+
 #if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_DEBUG, 0, r->server,
-                "proxy_cluster_trans DECLINED %s uri: %s unparsed_uri: %s",
-                 balancer, r->filename, r->unparsed_uri);
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server,
+                 "proxy_cluster_trans DECLINED %s uri: %s unparsed_uri: %s", balancer, r->filename, r->unparsed_uri);
 #endif
     return DECLINED;
 }
@@ -234,7 +237,7 @@ static int lbmethod_cluster_trans(request_rec *r)
 static void remove_removed_node(server_rec *s, apr_pool_t *pool, apr_time_t now, proxy_node_table *node_table)
 {
     int i;
-    (void) s;
+    (void)s;
 
     for (i = 0; i < node_table->sizenode; i++) {
         nodeinfo_t *ou;
@@ -249,139 +252,140 @@ static void remove_removed_node(server_rec *s, apr_pool_t *pool, apr_time_t now,
     }
 }
 
-static apr_status_t mc_watchdog_callback(int state, void *data,
-                                         apr_pool_t *pool)
+static apr_status_t mc_watchdog_callback(int state, void *data, apr_pool_t *pool)
 {
     apr_status_t rv = APR_SUCCESS;
-    server_rec *s = (server_rec *)data;
+    server_rec *s = (server_rec *) data;
     proxy_node_table *node_table;
     apr_time_t now;
     switch (state) {
-        case AP_WATCHDOG_STATE_STARTING:
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "lbmethod_cluster_watchdog_callback STARTING");
-            break;
+    case AP_WATCHDOG_STATE_STARTING:
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "lbmethod_cluster_watchdog_callback STARTING");
+        break;
 
-        case AP_WATCHDOG_STATE_RUNNING:
-            /* loop thru all workers */
-            node_table = read_node_table(pool, node_storage, 0);
-            now = apr_time_now();
-            if (s) {
-                int i;
-                void *sconf = s->module_config;
-                proxy_server_conf *conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
-                proxy_balancer *balancer = (proxy_balancer *)conf->balancers->elts;
+    case AP_WATCHDOG_STATE_RUNNING:
+        /* loop thru all workers */
+        node_table = read_node_table(pool, node_storage, 0);
+        now = apr_time_now();
+        if (s) {
+            int i;
+            void *sconf = s->module_config;
+            proxy_server_conf *conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
+            proxy_balancer *balancer = (proxy_balancer *) conf->balancers->elts;
 
-                for (i = 0; i < conf->balancers->nelts; i++, balancer++) {
-                    int n;
-                    proxy_worker **workers;
-                    proxy_worker *worker;
-                    /* Have any new balancers or workers been added dynamically? */
-                    ap_proxy_sync_balancer(balancer, s, conf);
-                    workers = (proxy_worker **)balancer->workers->elts;
-                    for (n = 0; n < balancer->workers->nelts; n++) {
-                        nodeinfo_t* node;
-                        int id;
-                        worker = *workers;
-                        node = table_get_node_route(node_table, worker->s->route, &id);
-                        if (node != NULL) {
-                            if (node->mess.remove) {
-                                /* Already marked for removal */
+            for (i = 0; i < conf->balancers->nelts; i++, balancer++) {
+                int n;
+                proxy_worker **workers;
+                proxy_worker *worker;
+                /* Have any new balancers or workers been added dynamically? */
+                ap_proxy_sync_balancer(balancer, s, conf);
+                workers = (proxy_worker **) balancer->workers->elts;
+                for (n = 0; n < balancer->workers->nelts; n++) {
+                    nodeinfo_t *node;
+                    int id;
+                    worker = *workers;
+                    node = table_get_node_route(node_table, worker->s->route, &id);
+                    if (node != NULL) {
+                        if (node->mess.remove) {
+                            /* Already marked for removal */
+                            workers++;
+                            continue;
+                        }
+                        if (node->mess.updatetimelb < (now - lbstatus_recalc_time)) {
+                            /* The lbstatus needs to be updated */
+                            nodeinfo_t *ou;
+                            int elected, oldelected;
+                            elected = worker->s->elected;
+                            oldelected = node->mess.oldelected;
+                            node_storage->lock_nodes();
+                            if (node_storage->read_node(id, &ou) != APR_SUCCESS) {
+                                node_storage->unlock_nodes();
                                 workers++;
-                               continue;
+                                continue;
                             }
-                            if (node->mess.updatetimelb < (now - lbstatus_recalc_time)) {
-                                /* The lbstatus needs to be updated */
-                                nodeinfo_t *ou; 
-                                int elected, oldelected;
-                                elected = worker->s->elected;
-                                oldelected = node->mess.oldelected;
-                                node_storage->lock_nodes();
-                                if (node_storage->read_node(id, &ou) != APR_SUCCESS) {
-                                    node_storage->unlock_nodes();
-                                    workers++;
-                                    continue;
-                                }
-                                if (ou->mess.remove) {
-                                    /* the stored node is already marked for removal */
-                                    node_storage->unlock_nodes();
-                                    workers++;
-                                   continue;
-                                }
-                                ou->mess.updatetimelb = now;
-                                node->mess.updatetimelb = now;
-                                node->mess.oldelected = elected;
-                                ou->mess.oldelected = elected;
-                                if (worker->s->lbfactor > 0)
-                                    worker->s->lbstatus = ((elected - oldelected) * 1000) / worker->s->lbfactor;
-                                if (elected == oldelected) {
-                                    /* lbstatus_recalc_time without changes: test for broken nodes */
-                                    if (PROXY_WORKER_IS(worker, PROXY_WORKER_HC_FAIL)) {
-                                        ou->mess.num_failure_idle++;
-                                        if (ou->mess.num_failure_idle > 60) {
-                                            /* Failing for 5 minutes: time to mark it removed */
-                                            ou->mess.remove = 1;
-                                            ou->updatetime = now;
-                                        }
-                                    } else {
-                                        ou->mess.num_failure_idle = 0;
+                            if (ou->mess.remove) {
+                                /* the stored node is already marked for removal */
+                                node_storage->unlock_nodes();
+                                workers++;
+                                continue;
+                            }
+                            ou->mess.updatetimelb = now;
+                            node->mess.updatetimelb = now;
+                            node->mess.oldelected = elected;
+                            ou->mess.oldelected = elected;
+                            if (worker->s->lbfactor > 0)
+                                worker->s->lbstatus = ((elected - oldelected) * 1000) / worker->s->lbfactor;
+                            if (elected == oldelected) {
+                                /* lbstatus_recalc_time without changes: test for broken nodes */
+                                if (PROXY_WORKER_IS(worker, PROXY_WORKER_HC_FAIL)) {
+                                    ou->mess.num_failure_idle++;
+                                    if (ou->mess.num_failure_idle > 60) {
+                                        /* Failing for 5 minutes: time to mark it removed */
+                                        ou->mess.remove = 1;
+                                        ou->updatetime = now;
                                     }
-                                } else {
+                                }
+                                else {
                                     ou->mess.num_failure_idle = 0;
                                 }
-                                node_storage->unlock_nodes();
                             }
+                            else {
+                                ou->mess.num_failure_idle = 0;
+                            }
+                            node_storage->unlock_nodes();
                         }
-                        workers++;
                     }
+                    workers++;
                 }
-
-                /* cleanup removed node in shared memory */
-                remove_removed_node(s, pool, now, node_table);
             }
-            break;
 
-        case AP_WATCHDOG_STATE_STOPPING:
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "lbmethod_cluster_watchdog_callback STOPPING");
-            break;
+            /* cleanup removed node in shared memory */
+            remove_removed_node(s, pool, now, node_table);
+        }
+        break;
+
+    case AP_WATCHDOG_STATE_STOPPING:
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "lbmethod_cluster_watchdog_callback STOPPING");
+        break;
     }
     return rv;
 }
 
-static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
-                                     apr_pool_t *ptemp, server_rec *s)
+static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
 {
-   APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) *mc_watchdog_get_instance;
-   APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;
-   (void) plog; (void) ptemp;
+    APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) * mc_watchdog_get_instance;
+    APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) * mc_watchdog_register_callback;
+    (void)plog;
+    (void)ptemp;
 
-   node_storage = ap_lookup_provider("manager" , "shared", "0");
+    node_storage = ap_lookup_provider("manager", "shared", "0");
     if (node_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for nodes");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for nodes");
         return !OK;
     }
-    host_storage = ap_lookup_provider("manager" , "shared", "1");
+    host_storage = ap_lookup_provider("manager", "shared", "1");
     if (host_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for hosts");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for hosts");
         return !OK;
     }
-    context_storage = ap_lookup_provider("manager" , "shared", "2");
+    context_storage = ap_lookup_provider("manager", "shared", "2");
     if (context_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for contexts");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for contexts");
         return !OK;
     }
-    balancer_storage = ap_lookup_provider("manager" , "shared", "3");
+    balancer_storage = ap_lookup_provider("manager", "shared", "3");
     if (balancer_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for balancers");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for balancers");
         return !OK;
     }
-    domain_storage = ap_lookup_provider("manager" , "shared", "5");
+    domain_storage = ap_lookup_provider("manager", "shared", "5");
     if (domain_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for domains");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for domains");
         return !OK;
     }
 
@@ -400,22 +404,15 @@ static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
                      "mod_watchdog is required");
         return !OK;
     }
-    if (mc_watchdog_get_instance(&watchdog,
-                                  LB_CLUSTER_WATHCHDOG_NAME,
-                                  0, 1, p)) {
+    if (mc_watchdog_get_instance(&watchdog, LB_CLUSTER_WATHCHDOG_NAME, 0, 1, p)) {
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03263)
-                     "Failed to create watchdog instance (%s)",
-                     LB_CLUSTER_WATHCHDOG_NAME);
+                     "Failed to create watchdog instance (%s)", LB_CLUSTER_WATHCHDOG_NAME);
         return !OK;
     }
     while (s) {
-        if (mc_watchdog_register_callback(watchdog,
-                AP_WD_TM_SLICE,
-                s,
-                mc_watchdog_callback)) {
+        if (mc_watchdog_register_callback(watchdog, AP_WD_TM_SLICE, s, mc_watchdog_callback)) {
             ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03264)
-                         "Failed to register watchdog callback (%s)",
-                         LB_CLUSTER_WATHCHDOG_NAME);
+                         "Failed to register watchdog callback (%s)", LB_CLUSTER_WATHCHDOG_NAME);
             return !OK;
         }
         s = s->next;
@@ -425,8 +422,8 @@ static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
 
 static void register_hooks(apr_pool_t *p)
 {
-    static const char * const aszPre[]  = { "mod_manager.c", "mod_rewrite.c", NULL };
-    static const char * const aszSucc[] = { "mod_proxy.c", NULL };
+    static const char *const aszPre[] = { "mod_manager.c", "mod_rewrite.c", NULL };
+    static const char *const aszSucc[] = { "mod_proxy.c", NULL };
 
     ap_register_provider(p, PROXY_LBMETHOD, "cluster", "0", &cluster);
 
@@ -439,8 +436,8 @@ AP_DECLARE_MODULE(lbmethod_cluster) = {
     STANDARD20_MODULE_STUFF,
     NULL,                       /* create per-directory config structure */
     NULL,                       /* merge per-directory config structures */
-    NULL,        /* create per-server config structure */
-    NULL,         /* merge per-server config structures */
+    NULL,                       /* create per-server config structure */
+    NULL,                       /* merge per-server config structures */
     NULL,                       /* command apr_table_t */
     register_hooks,             /* register hooks */
     AP_MODULE_FLAG_NONE         /* flags */

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -39,15 +39,16 @@ static struct context_storage_method *context_storage = NULL;
 static struct balancer_storage_method *balancer_storage = NULL;
 static struct domain_storage_method *domain_storage = NULL;
 
-static int use_alias = 0;       /* 1 : Compare Alias with server_name */
-static apr_time_t lbstatus_recalc_time = apr_time_from_sec(5);  /* recalcul the lbstatus based on number of request in the time interval */
-static apr_time_t wait_for_remove = apr_time_from_sec(10);      /* wait until that before removing a removed node */
+static int use_alias = 0; /* 1 : Compare Alias with server_name */
+static apr_time_t lbstatus_recalc_time =
+    apr_time_from_sec(5); /* recalcul the lbstatus based on number of request in the time interval */
+static apr_time_t wait_for_remove = apr_time_from_sec(10); /* wait until that before removing a removed node */
 
 module AP_MODULE_DECLARE_DATA lbmethod_cluster_module;
 
 static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balancer *balancer,
-                                                   proxy_vhost_table *vhost_table,
-                                                   proxy_context_table *context_table, proxy_node_table *node_table)
+                                                   proxy_vhost_table *vhost_table, proxy_context_table *context_table,
+                                                   proxy_node_table *node_table)
 {
     char *ptr = balancer->workers->elts;
     int sizew = balancer->workers->elt_size;
@@ -57,7 +58,7 @@ static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balance
     for (i = 0; i < balancer->workers->nelts; i++, ptr = ptr + sizew) {
         nodeinfo_t *node;
         int id;
-        proxy_worker **run = (proxy_worker **) ptr;
+        proxy_worker **run = (proxy_worker **)ptr;
         proxy_worker *worker = *run;
 
         if (!PROXY_WORKER_IS_USABLE(worker))
@@ -94,12 +95,11 @@ static proxy_worker *internal_find_best_byrequests(request_rec *r, proxy_balance
             char *ptr = balancer->workers->elts;
             int sizew = balancer->workers->elt_size;
             for (i = 0; i < balancer->workers->nelts; i++, ptr = ptr + sizew) {
-                proxy_worker **run = (proxy_worker **) ptr;
+                proxy_worker **run = (proxy_worker **)ptr;
                 proxy_worker *httpworker = *run;
                 if (!strcmp(httpworker->s->hostname, mycandidate->s->hostname)) {
                     /* They don't the shared memory another test is needed... */
-                    if (!memcmp(httpworker->s->scheme, "http", 4) &&
-                        httpworker->s->port == mycandidate->s->port &&
+                    if (!memcmp(httpworker->s->scheme, "http", 4) && httpworker->s->port == mycandidate->s->port &&
                         !strcmp(httpworker->s->route, mycandidate->s->route)) {
                         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
@@ -122,9 +122,9 @@ static proxy_worker *find_best(proxy_balancer *balancer, request_rec *r)
 {
     proxy_worker *mycandidate = NULL;
 
-    proxy_vhost_table *vhost_table = (proxy_vhost_table *) apr_table_get(r->notes, "vhost-table");
-    proxy_context_table *context_table = (proxy_context_table *) apr_table_get(r->notes, "context-table");
-    proxy_node_table *node_table = (proxy_node_table *) apr_table_get(r->notes, "node-table");
+    proxy_vhost_table *vhost_table = (proxy_vhost_table *)apr_table_get(r->notes, "vhost-table");
+    proxy_context_table *context_table = (proxy_context_table *)apr_table_get(r->notes, "context-table");
+    proxy_node_table *node_table = (proxy_node_table *)apr_table_get(r->notes, "node-table");
 
     if (!vhost_table)
         vhost_table = read_vhost_table(r->pool, host_storage, 0);
@@ -162,14 +162,7 @@ static apr_status_t updatelbstatus(proxy_balancer *balancer, proxy_worker *elect
     return APR_SUCCESS;
 }
 
-static const proxy_balancer_method cluster = {
-    "cluster",
-    &find_best,
-    NULL,
-    &reset,
-    &age,
-    &updatelbstatus
-};
+static const proxy_balancer_method cluster = {"cluster", &find_best, NULL, &reset, &age, &updatelbstatus};
 
 /*
  * See if we could map the request.
@@ -180,16 +173,15 @@ static int lbmethod_cluster_trans(request_rec *r)
 {
     const char *balancer;
     void *sconf = r->server->module_config;
-    proxy_server_conf *conf = (proxy_server_conf *)
-        ap_get_module_config(sconf, &proxy_module);
+    proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
 
 
 #if HAVE_CLUSTER_EX_DEBUG
     ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server,
-                 "lbmethod_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s",
-                 r->proxyreq, r->filename, r->handler, r->uri, r->args, r->unparsed_uri);
-    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server,
-                 "lbmethod_cluster_trans for %d", conf->balancers->nelts);
+                 "lbmethod_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s", r->proxyreq, r->filename,
+                 r->handler, r->uri, r->args, r->unparsed_uri);
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server, "lbmethod_cluster_trans for %d",
+                 conf->balancers->nelts);
 #endif
 
     proxy_vhost_table *vhost_table = read_vhost_table(r->pool, host_storage, 0);
@@ -218,10 +210,10 @@ static int lbmethod_cluster_trans(request_rec *r)
         r->handler = "proxy-server";
         r->proxyreq = PROXYREQ_REVERSE;
 #if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server,
-                     "proxy_cluster_trans using %s uri: %s", balancer, r->filename);
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server, "proxy_cluster_trans using %s uri: %s",
+                     balancer, r->filename);
 #endif
-        return OK;              /* Mod_proxy will process it */
+        return OK; /* Mod_proxy will process it */
     }
 
 #if HAVE_CLUSTER_EX_DEBUG
@@ -255,7 +247,7 @@ static void remove_removed_node(server_rec *s, apr_pool_t *pool, apr_time_t now,
 static apr_status_t mc_watchdog_callback(int state, void *data, apr_pool_t *pool)
 {
     apr_status_t rv = APR_SUCCESS;
-    server_rec *s = (server_rec *) data;
+    server_rec *s = (server_rec *)data;
     proxy_node_table *node_table;
     apr_time_t now;
     switch (state) {
@@ -270,8 +262,8 @@ static apr_status_t mc_watchdog_callback(int state, void *data, apr_pool_t *pool
         if (s) {
             int i;
             void *sconf = s->module_config;
-            proxy_server_conf *conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
-            proxy_balancer *balancer = (proxy_balancer *) conf->balancers->elts;
+            proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
+            proxy_balancer *balancer = (proxy_balancer *)conf->balancers->elts;
 
             for (i = 0; i < conf->balancers->nelts; i++, balancer++) {
                 int n;
@@ -279,7 +271,7 @@ static apr_status_t mc_watchdog_callback(int state, void *data, apr_pool_t *pool
                 proxy_worker *worker;
                 /* Have any new balancers or workers been added dynamically? */
                 ap_proxy_sync_balancer(balancer, s, conf);
-                workers = (proxy_worker **) balancer->workers->elts;
+                workers = (proxy_worker **)balancer->workers->elts;
                 for (n = 0; n < balancer->workers->nelts; n++) {
                     nodeinfo_t *node;
                     int id;
@@ -353,8 +345,8 @@ static apr_status_t mc_watchdog_callback(int state, void *data, apr_pool_t *pool
 
 static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
 {
-    APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) * mc_watchdog_get_instance;
-    APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) * mc_watchdog_register_callback;
+    APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) *mc_watchdog_get_instance;
+    APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;
     (void)plog;
     (void)ptemp;
 
@@ -400,19 +392,18 @@ static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_poo
     mc_watchdog_get_instance = APR_RETRIEVE_OPTIONAL_FN(ap_watchdog_get_instance);
     mc_watchdog_register_callback = APR_RETRIEVE_OPTIONAL_FN(ap_watchdog_register_callback);
     if (!mc_watchdog_get_instance || !mc_watchdog_register_callback) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03262)
-                     "mod_watchdog is required");
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03262) "mod_watchdog is required");
         return !OK;
     }
     if (mc_watchdog_get_instance(&watchdog, LB_CLUSTER_WATHCHDOG_NAME, 0, 1, p)) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03263)
-                     "Failed to create watchdog instance (%s)", LB_CLUSTER_WATHCHDOG_NAME);
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03263) "Failed to create watchdog instance (%s)",
+                     LB_CLUSTER_WATHCHDOG_NAME);
         return !OK;
     }
     while (s) {
         if (mc_watchdog_register_callback(watchdog, AP_WD_TM_SLICE, s, mc_watchdog_callback)) {
-            ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03264)
-                         "Failed to register watchdog callback (%s)", LB_CLUSTER_WATHCHDOG_NAME);
+            ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03264) "Failed to register watchdog callback (%s)",
+                         LB_CLUSTER_WATHCHDOG_NAME);
             return !OK;
         }
         s = s->next;
@@ -422,8 +413,8 @@ static int lbmethod_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_poo
 
 static void register_hooks(apr_pool_t *p)
 {
-    static const char *const aszPre[] = { "mod_manager.c", "mod_rewrite.c", NULL };
-    static const char *const aszSucc[] = { "mod_proxy.c", NULL };
+    static const char *const aszPre[] = {"mod_manager.c", "mod_rewrite.c", NULL};
+    static const char *const aszSucc[] = {"mod_proxy.c", NULL};
 
     ap_register_provider(p, PROXY_LBMETHOD, "cluster", "0", &cluster);
 
@@ -434,11 +425,11 @@ static void register_hooks(apr_pool_t *p)
 
 AP_DECLARE_MODULE(lbmethod_cluster) = {
     STANDARD20_MODULE_STUFF,
-    NULL,                       /* create per-directory config structure */
-    NULL,                       /* merge per-directory config structures */
-    NULL,                       /* create per-server config structure */
-    NULL,                       /* merge per-server config structures */
-    NULL,                       /* command apr_table_t */
-    register_hooks,             /* register hooks */
-    AP_MODULE_FLAG_NONE         /* flags */
+    NULL,               /* create per-directory config structure */
+    NULL,               /* merge per-directory config structures */
+    NULL,               /* create per-server config structure */
+    NULL,               /* merge per-server config structures */
+    NULL,               /* command apr_table_t */
+    register_hooks,     /* register hooks */
+    AP_MODULE_FLAG_NONE /* flags */
 };

--- a/native/common/common.c
+++ b/native/common/common.c
@@ -33,20 +33,21 @@ proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method
         return vhost_table;
     }
 
-    vhost_table->vhosts =  apr_palloc(pool, sizeof(int) * host_storage->get_max_size_host());
+    vhost_table->vhosts = apr_palloc(pool, sizeof(int) * host_storage->get_max_size_host());
     vhost_table->sizevhost = host_storage->get_ids_used_host(vhost_table->vhosts);
     if (for_cache)
         vhost_table->vhost_info = apr_palloc(pool, sizeof(hostinfo_t) * size);
     else
         vhost_table->vhost_info = apr_palloc(pool, sizeof(hostinfo_t) * vhost_table->sizevhost);
     for (i = 0; i < vhost_table->sizevhost; i++) {
-        hostinfo_t* h;
+        hostinfo_t *h;
         int host_index = vhost_table->vhosts[i];
         host_storage->read_host(host_index, &h);
         vhost_table->vhost_info[i] = *h;
     }
     return vhost_table;
 }
+
 /* Update the virtual host table from shared memory to populate a cached table */
 proxy_vhost_table *update_vhost_table_cached(proxy_vhost_table *vhost_table, struct host_storage_method *host_storage)
 {
@@ -62,7 +63,7 @@ proxy_vhost_table *update_vhost_table_cached(proxy_vhost_table *vhost_table, str
 
     vhost_table->sizevhost = host_storage->get_ids_used_host(vhost_table->vhosts);
     for (i = 0; i < vhost_table->sizevhost; i++) {
-        hostinfo_t* h;
+        hostinfo_t *h;
         int host_index = vhost_table->vhosts[i];
         host_storage->read_host(host_index, &h);
         vhost_table->vhost_info[i] = *h;
@@ -77,20 +78,20 @@ proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage
     int size;
     proxy_context_table *context_table = apr_palloc(pool, sizeof(proxy_context_table));
     size = context_storage->get_max_size_context();
-    if (size == 0) { 
+    if (size == 0) {
         context_table->sizecontext = 0;
         context_table->contexts = NULL;
         context_table->context_info = NULL;
         return context_table;
     }
-    context_table->contexts =  apr_palloc(pool, sizeof(int) * size);
+    context_table->contexts = apr_palloc(pool, sizeof(int) * size);
     context_table->sizecontext = context_storage->get_ids_used_context(context_table->contexts);
     if (for_cache)
         context_table->context_info = apr_palloc(pool, sizeof(contextinfo_t) * size);
     else
         context_table->context_info = apr_palloc(pool, sizeof(contextinfo_t) * context_table->sizecontext);
     for (i = 0; i < context_table->sizecontext; i++) {
-        contextinfo_t* h;
+        contextinfo_t *h;
         int context_index = context_table->contexts[i];
         context_storage->read_context(context_index, &h);
         context_table->context_info[i] = *h;
@@ -99,7 +100,8 @@ proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage
 }
 
 /* Update the context table from shared memory to populate a cached table */
-proxy_context_table *update_context_table_cached(proxy_context_table *context_table, struct context_storage_method *context_storage)
+proxy_context_table *update_context_table_cached(proxy_context_table *context_table,
+                                                 struct context_storage_method *context_storage)
 {
     int i;
     int size;
@@ -112,7 +114,7 @@ proxy_context_table *update_context_table_cached(proxy_context_table *context_ta
     }
     context_table->sizecontext = context_storage->get_ids_used_context(context_table->contexts);
     for (i = 0; i < context_table->sizecontext; i++) {
-        contextinfo_t* h;
+        contextinfo_t *h;
         int context_index = context_table->contexts[i];
         context_storage->read_context(context_index, &h);
         context_table->context_info[i] = *h;
@@ -121,26 +123,27 @@ proxy_context_table *update_context_table_cached(proxy_context_table *context_ta
 }
 
 /* Read the balancer table from shared memory */
-proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage, int for_cache)
+proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage,
+                                          int for_cache)
 {
     int i;
     int size;
     proxy_balancer_table *balancer_table = apr_palloc(pool, sizeof(proxy_balancer_table));
     size = balancer_storage->get_max_size_balancer();
-    if (size == 0) { 
+    if (size == 0) {
         balancer_table->sizebalancer = 0;
         balancer_table->balancers = NULL;
         balancer_table->balancer_info = NULL;
         return balancer_table;
     }
-    balancer_table->balancers =  apr_palloc(pool, sizeof(int) * size);
+    balancer_table->balancers = apr_palloc(pool, sizeof(int) * size);
     balancer_table->sizebalancer = balancer_storage->get_ids_used_balancer(balancer_table->balancers);
     if (for_cache)
         balancer_table->balancer_info = apr_palloc(pool, sizeof(balancerinfo_t) * size);
     else
         balancer_table->balancer_info = apr_palloc(pool, sizeof(balancerinfo_t) * balancer_table->sizebalancer);
     for (i = 0; i < balancer_table->sizebalancer; i++) {
-        balancerinfo_t* h;
+        balancerinfo_t *h;
         int balancer_index = balancer_table->balancers[i];
         balancer_storage->read_balancer(balancer_index, &h);
         balancer_table->balancer_info[i] = *h;
@@ -149,7 +152,8 @@ proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_stor
 }
 
 /* Update the balancer table from shared memory to populate a cached table */
-proxy_balancer_table *update_balancer_table_cached(proxy_balancer_table *balancer_table, struct balancer_storage_method *balancer_storage)
+proxy_balancer_table *update_balancer_table_cached(proxy_balancer_table *balancer_table,
+                                                   struct balancer_storage_method *balancer_storage)
 {
     int i;
     int size;
@@ -162,7 +166,7 @@ proxy_balancer_table *update_balancer_table_cached(proxy_balancer_table *balance
     }
     balancer_table->sizebalancer = balancer_storage->get_ids_used_balancer(balancer_table->balancers);
     for (i = 0; i < balancer_table->sizebalancer; i++) {
-        balancerinfo_t* h;
+        balancerinfo_t *h;
         int balancer_index = balancer_table->balancers[i];
         balancer_storage->read_balancer(balancer_index, &h);
         balancer_table->balancer_info[i] = *h;
@@ -175,31 +179,33 @@ proxy_node_table *read_node_table(apr_pool_t *pool, struct node_storage_method *
 {
     int i;
     int size;
-    proxy_node_table *node_table =  apr_palloc(pool, sizeof(proxy_node_table));
+    proxy_node_table *node_table = apr_palloc(pool, sizeof(proxy_node_table));
     size = node_storage->get_max_size_node();
-    if (size == 0) { 
+    if (size == 0) {
         node_table->sizenode = 0;
         node_table->nodes = NULL;
         node_table->node_info = NULL;
         return node_table;
     }
-    node_table->nodes =  apr_palloc(pool, sizeof(int) * size);
+    node_table->nodes = apr_palloc(pool, sizeof(int) * size);
     node_table->sizenode = node_storage->get_ids_used_node(node_table->nodes);
     if (for_cache) {
         node_table->node_info = apr_palloc(pool, sizeof(nodeinfo_t) * size);
         node_table->ptr_node = apr_palloc(pool, sizeof(char *) * size);
-    } else {
+    }
+    else {
         node_table->node_info = apr_palloc(pool, sizeof(nodeinfo_t) * node_table->sizenode);
         node_table->ptr_node = apr_palloc(pool, sizeof(char *) * node_table->sizenode);
     }
     for (i = 0; i < node_table->sizenode; i++) {
-        nodeinfo_t* h;
+        nodeinfo_t *h;
         int node_index = node_table->nodes[i];
         apr_status_t rv = node_storage->read_node(node_index, &h);
         if (rv == APR_SUCCESS) {
             node_table->node_info[i] = *h;
-            node_table->ptr_node[i] = (char *) h;
-        } else {
+            node_table->ptr_node[i] = (char *)h;
+        }
+        else {
             /* we can't read the node! */
             node_table->ptr_node[i] = NULL;
             memset(&node_table->node_info[i], 0, sizeof(nodeinfo_t));
@@ -222,13 +228,14 @@ proxy_node_table *update_node_table_cached(proxy_node_table *node_table, struct 
     }
     node_table->sizenode = node_storage->get_ids_used_node(node_table->nodes);
     for (i = 0; i < node_table->sizenode; i++) {
-        nodeinfo_t* h;
+        nodeinfo_t *h;
         int node_index = node_table->nodes[i];
         apr_status_t rv = node_storage->read_node(node_index, &h);
         if (rv == APR_SUCCESS) {
             node_table->node_info[i] = *h;
-            node_table->ptr_node[i] = (char *) h;
-        } else {
+            node_table->ptr_node[i] = (char *)h;
+        }
+        else {
             /* we can't read the node! */
             node_table->ptr_node[i] = NULL;
             memset(&node_table->node_info[i], 0, sizeof(nodeinfo_t));
@@ -257,9 +264,7 @@ char *get_cookie_param(request_rec *r, const char *name, int in)
         for (start_cookie = ap_strstr_c(cookies, name); start_cookie;
              start_cookie = ap_strstr_c(start_cookie + 1, name)) {
             if (start_cookie == cookies ||
-                start_cookie[-1] == ';' ||
-                start_cookie[-1] == ',' ||
-                isspace(start_cookie[-1])) {
+                start_cookie[-1] == ';' || start_cookie[-1] == ',' || isspace(start_cookie[-1])) {
 
                 start_cookie += strlen(name);
                 while (*start_cookie && isspace(*start_cookie))
@@ -295,8 +300,7 @@ char *get_cookie_param(request_rec *r, const char *name, int in)
  *
  * TODO: Should use the mod_proxy_balancer one
  */
-char *get_path_param(apr_pool_t *pool, char *url,
-                            const char *name)
+char *get_path_param(apr_pool_t *pool, char *url, const char *name)
 {
     char *path = NULL;
     char *pathdelims = ";?&";
@@ -339,7 +343,7 @@ char *cluster_get_sessionid(request_rec *r, const char *stickyval, char *uri, ch
     sticky = sticky_path = apr_pstrdup(r->pool, stickyval);
     if ((path = strchr(sticky, '|'))) {
         *path++ = '\0';
-         sticky_path = path;
+        sticky_path = path;
     }
     *sticky_used = sticky_path;
     route = get_cookie_param(r, sticky, 1);
@@ -377,7 +381,7 @@ int hassession_byname(request_rec *r, int nodeid, const char *route, proxy_node_
     /* read the node */
     node = table_get_node(node_table, nodeid);
     if (node == NULL)
-        return 0; /* failed */
+        return 0;               /* failed */
 
     conf = (proxy_server_conf *) ap_get_module_config(r->server->module_config, &proxy_module);
     sizeb = conf->balancers->elt_size;
@@ -408,8 +412,7 @@ int hassession_byname(request_rec *r, int nodeid, const char *route, proxy_node_
     sessionid = cluster_get_sessionid(r, sticky, uri, &sticky_used);
     if (sessionid) {
 #if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "mod_proxy_cluster: found sessionid %s", sessionid);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "mod_proxy_cluster: found sessionid %s", sessionid);
 #endif
         return 1;
     }
@@ -424,7 +427,9 @@ int hassession_byname(request_rec *r, int nodeid, const char *route, proxy_node_
  * @param use_alias compare alias with server_name
  * @return a pointer to a list of nodes.
  */
-node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, const char *route, int use_alias, proxy_vhost_table* vhost_table, proxy_context_table* context_table, proxy_node_table *node_table)
+node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, const char *route, int use_alias,
+                                     proxy_vhost_table *vhost_table, proxy_context_table *context_table,
+                                     proxy_node_table *node_table)
 {
     int sizecontext = context_table->sizecontext;
     int *contexts;
@@ -443,35 +448,34 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
             luri = ap_strchr_c(scheme + 3, '/');
     }
     if (!luri)
-       luri = r->uri;
+        luri = r->uri;
     uri = ap_strchr_c(luri, '?');
     if (uri)
-       uri = apr_pstrndup(r->pool, luri, uri - luri);
+        uri = apr_pstrndup(r->pool, luri, uri - luri);
     else {
-       uri = ap_strchr_c(luri, ';');
-       if (uri)
-          uri = apr_pstrndup(r->pool, luri, uri - luri);
-       else
-          uri = luri;
+        uri = ap_strchr_c(luri, ';');
+        if (uri)
+            uri = apr_pstrndup(r->pool, luri, uri - luri);
+        else
+            uri = luri;
     }
 
     /* read the contexts */
     if (sizecontext == 0)
         return NULL;
-    contexts =  apr_palloc(r->pool, sizeof(int)*sizecontext);
+    contexts = apr_palloc(r->pool, sizeof(int) * sizecontext);
     for (i = 0; i < sizecontext; i++)
         contexts[i] = i;
-    length =  apr_pcalloc(r->pool, sizeof(int)*sizecontext);
-    status =  apr_palloc(r->pool, sizeof(int)*sizecontext);
+    length = apr_pcalloc(r->pool, sizeof(int) * sizecontext);
+    status = apr_palloc(r->pool, sizeof(int) * sizecontext);
     /* Check the virtual host */
     if (use_alias) {
         /* read the hosts */
         int sizevhost;
-        int *contextsok = apr_pcalloc(r->pool, sizeof(int)*sizecontext);
+        int *contextsok = apr_pcalloc(r->pool, sizeof(int) * sizecontext);
         const char *hostname = ap_get_server_name(r);
 #if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "find_node_context_host: Host: %s", hostname);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_node_context_host: Host: %s", hostname);
 #endif
         sizevhost = vhost_table->sizevhost;
         for (i = 0; i < sizevhost; i++) {
@@ -493,11 +497,12 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
 #if HAVE_CLUSTER_EX_DEBUG
     for (j = 0; j < sizecontext; j++) {
         contextinfo_t *context;
-        if (contexts[j] == -1) continue;
-        context = &context_table->context_info[j]; 
+        if (contexts[j] == -1)
+            continue;
+        context = &context_table->context_info[j];
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "find_node_context_host: %s node: %d vhost: %d context: %s",
-                          uri, context->node, context->vhost, context->context);
+                     "find_node_context_host: %s node: %d vhost: %d context: %s",
+                     uri, context->node, context->vhost, context->context);
     }
 #endif
 
@@ -506,13 +511,14 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
     for (j = 0; j < sizecontext; j++) {
         contextinfo_t *context;
         int len;
-        if (contexts[j] == -1) continue;
+        if (contexts[j] == -1)
+            continue;
         context = &context_table->context_info[j];
 
         /* keep only the contexts corresponding to our balancer */
         if (balancer != NULL) {
 
-            nodeinfo_t *node =  table_get_node(node_table, context->node);
+            nodeinfo_t *node = table_get_node(node_table, context->node);
             if (node == NULL)
                 continue;
             if (strlen(balancer->s->name) > 11 && strcasecmp(&balancer->s->name[11], node->mess.balancer) != 0)
@@ -525,7 +531,7 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
                 length[j] = len;
                 if (len > max) {
                     max = len;
-                } 
+                }
             }
         }
     }
@@ -538,7 +544,7 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
     for (j = 0; j < sizecontext; j++)
         if (length[j] == max)
             nbest++;
-    best  = apr_palloc(r->pool, sizeof(node_context) * nbest);
+    best = apr_palloc(r->pool, sizeof(node_context) * nbest);
     nbest = 0;
     for (j = 0; j < sizecontext; j++)
         if (length[j] == max) {
@@ -547,15 +553,15 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
             context = &context_table->context_info[j];
             /* Check status */
             switch (status[j]) {
-                case ENABLED:
+            case ENABLED:
+                ok = -1;
+                break;
+            case DISABLED:
+                /* Only the request with sessionid ok for it */
+                if (hassession_byname(r, context->node, route, node_table)) {
                     ok = -1;
-                    break;
-                case DISABLED:
-                    /* Only the request with sessionid ok for it */
-                    if (hassession_byname(r, context->node, route, node_table)) {
-                        ok = -1;
-                    }
-                    break;
+                }
+                break;
             }
             if (ok) {
                 best[nbest].node = context->node;
@@ -566,23 +572,23 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
     if (nbest == 0)
         return NULL;
     best[nbest].node = -1;
-    return best; 
+    return best;
 }
 
 /* Given the route find the corresponding domain (if there is a domain) */
-static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, const char *balancer, proxy_node_table *node_table)
+static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, const char *balancer,
+                                    proxy_node_table *node_table)
 {
     int i;
-    (void) r;
+    (void)r;
 
     /* XXX JFCLERE!!!! domaininfo_t *dom; */
 #if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "find_nodedomain: finding node for %s: %s", route, balancer);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_nodedomain: finding node for %s: %s", route, balancer);
 #endif
     for (i = 0; i < node_table->sizenode; i++) {
         if (strcmp(node_table->node_info[i].mess.JVMRoute, route) == 0) {
-            nodeinfo_t* ou = &node_table->node_info[i];
+            nodeinfo_t *ou = &node_table->node_info[i];
             if (!strcasecmp(balancer, ou->mess.balancer)) {
                 if (ou->mess.Domain[0] != '\0') {
                     *domain = ou->mess.Domain;
@@ -593,16 +599,15 @@ static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, 
     }
 
 #if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "find_nodedomain: finding domain for %s: %s", route, balancer);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_nodedomain: finding domain for %s: %s", route, balancer);
 #endif
     /* We can't find the node, because it was removed... */
     /* XXX: we need a proxy_node_domain for that too!!!
-    if (domain_storage->find_domain(&dom, route, balancer ) == APR_SUCCESS) {
-        *domain = dom->domain;
-        return APR_SUCCESS;
-    }
-    */
+       if (domain_storage->find_domain(&dom, route, balancer ) == APR_SUCCESS) {
+       *domain = dom->domain;
+       return APR_SUCCESS;
+       }
+     */
     return APR_NOTFOUND;
 }
 
@@ -610,11 +615,9 @@ static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, 
  * Find the balancer corresponding to the node information
  */
 const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
-                                      proxy_vhost_table *vhost_table,
-                                      proxy_context_table *context_table,
-                                      proxy_balancer_table *balancer_table,
-                                      proxy_node_table *node_table,
-                                      int use_alias)
+                               proxy_vhost_table *vhost_table,
+                               proxy_context_table *context_table,
+                               proxy_balancer_table *balancer_table, proxy_node_table *node_table, int use_alias)
 {
     char *route = NULL;
     char *sessionid = NULL;
@@ -623,14 +626,14 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
     int i;
     char *ptr = conf->balancers->elts;
     int sizeb = conf->balancers->elt_size;
-    (void) balancer_table;
+    (void)balancer_table;
 
-    for (i = 0; i < conf->balancers->nelts; i++, ptr= ptr + sizeb) {
+    for (i = 0; i < conf->balancers->nelts; i++, ptr = ptr + sizeb) {
         proxy_balancer *balancer = (proxy_balancer *) ptr;
 
         if (balancer->s->sticky[0] == '\0' || balancer->s->sticky_path[0] == '\0')
             continue;
-        if (strlen(balancer->s->name)<=11)
+        if (strlen(balancer->s->name) <= 11)
             continue;
         sticky = apr_psprintf(r->pool, "%s|%s", balancer->s->sticky, balancer->s->sticky_path);
         /* XXX ; that looks fishy, lb needs to start with MC? */
@@ -640,29 +643,26 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
         sessionid = cluster_get_sessionid(r, sticky, r->uri, &sticky_used);
         if (sessionid) {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "cluster: %s Found value %s for "
-                         "stickysession %s",
-                         balancer->s->name, sessionid, sticky);
+                         "cluster: %s Found value %s for " "stickysession %s", balancer->s->name, sessionid, sticky);
             apr_table_setn(r->notes, "session-id", sessionid);
-            if ((route = strchr(sessionid, '.')) != NULL )
+            if ((route = strchr(sessionid, '.')) != NULL)
                 route++;
             if (route && *route) {
                 /* Nice we have a route, but make sure we have to serve it */
-                node_context *nodes = find_node_context_host(r, balancer, route, use_alias, vhost_table, context_table, node_table);
+                node_context *nodes =
+                    find_node_context_host(r, balancer, route, use_alias, vhost_table, context_table, node_table);
                 if (nodes == NULL)
-                    continue; /* we can't serve context/host for the request with this balancer*/
+                    continue;   /* we can't serve context/host for the request with this balancer */
             }
             if (route && *route) {
                 char *domain = NULL;
 #if HAVE_CLUSTER_EX_DEBUG
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                          "cluster: Found route %s", route);
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster: Found route %s", route);
 #endif
                 if (find_nodedomain(r, &domain, route, &balancer->s->name[11], node_table) == APR_SUCCESS) {
 #if HAVE_CLUSTER_EX_DEBUG
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                "cluster: Found balancer %s for %s",
-                                 &balancer->s->name[11], route);
+                                 "cluster: Found balancer %s for %s", &balancer->s->name[11], route);
 #endif
                     /* here we have the route and domain for find_session_route ... */
                     apr_table_setn(r->notes, "session-sticky", sticky_used);
@@ -673,7 +673,7 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
                     if (domain) {
 #if HAVE_CLUSTER_EX_DEBUG
                         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                    "cluster: Found domain %s for %s", domain, route);
+                                     "cluster: Found domain %s for %s", domain, route);
 #endif
                         apr_table_setn(r->notes, "CLUSTER_DOMAIN", domain);
                     }
@@ -686,7 +686,7 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
 }
 
 /* Read a node from the table using its it */
-nodeinfo_t* table_get_node(proxy_node_table *node_table, int id)
+nodeinfo_t *table_get_node(proxy_node_table *node_table, int id)
 {
     int i;
     for (i = 0; i < node_table->sizenode; i++) {
@@ -695,8 +695,9 @@ nodeinfo_t* table_get_node(proxy_node_table *node_table, int id)
     }
     return NULL;
 }
+
 /* Read a node from the table using the route */
-nodeinfo_t* table_get_node_route(proxy_node_table *node_table, char *route, int *id)
+nodeinfo_t *table_get_node_route(proxy_node_table *node_table, char *route, int *id)
 {
     int i;
     for (i = 0; i < node_table->sizenode; i++) {
@@ -714,20 +715,21 @@ nodeinfo_t* table_get_node_route(proxy_node_table *node_table, char *route, int 
  * @vhost_table table of host virtual hosts.
  * @context_table table of contexts.
  * @return the balancer name or NULL if not found.
- */ 
+ */
 const char *get_context_host_balancer(request_rec *r,
-        proxy_vhost_table *vhost_table, proxy_context_table *context_table, proxy_node_table *node_table, int use_alias)
+                                      proxy_vhost_table *vhost_table, proxy_context_table *context_table,
+                                      proxy_node_table *node_table, int use_alias)
 {
     void *sconf = r->server->module_config;
     proxy_server_conf *conf = (proxy_server_conf *)
         ap_get_module_config(sconf, &proxy_module);
 
-    node_context *nodes =  find_node_context_host(r, NULL, NULL, use_alias, vhost_table, context_table, node_table);
+    node_context *nodes = find_node_context_host(r, NULL, NULL, use_alias, vhost_table, context_table, node_table);
     if (nodes == NULL)
         return NULL;
-    while ((*nodes).node != -1) {
+    while (nodes->node != -1) {
         /* look for the node information */
-        nodeinfo_t *node = table_get_node(node_table, (*nodes).node);
+        nodeinfo_t *node = table_get_node(node_table, nodes->node);
         if (node != NULL) {
             if (node->mess.balancer[0] != '\0') {
                 /* Check that it is in our proxy_server_conf */
@@ -736,7 +738,7 @@ const char *get_context_host_balancer(request_rec *r,
                 if (balancer)
                     return node->mess.balancer;
                 else
-                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
                                  "get_context_host_balancer: balancer %s not found", name);
             }
         }
@@ -752,9 +754,10 @@ const char *get_context_host_balancer(request_rec *r,
  * The id of the worker is used to find the (slot) node in the shared
  * memory.
  * (See get_context_host_balancer too).
- */ 
+ */
 node_context *context_host_ok(request_rec *r, proxy_balancer *balancer, int node, int use_alias,
-                             proxy_vhost_table *vhost_table, proxy_context_table *context_table, proxy_node_table *node_table)
+                              proxy_vhost_table *vhost_table, proxy_context_table *context_table,
+                              proxy_node_table *node_table)
 {
     const char *route;
     node_context *best;
@@ -762,11 +765,12 @@ node_context *context_host_ok(request_rec *r, proxy_balancer *balancer, int node
     best = find_node_context_host(r, balancer, route, use_alias, vhost_table, context_table, node_table);
     if (best == NULL)
         return NULL;
-    while ((*best).node != -1) {
-        if ((*best).node == node) break;
+    while (best->node != -1) {
+        if (best->node == node)
+            break;
         best++;
     }
-    if ((*best).node == -1)
-        return NULL; /* not found */
+    if (best->node == -1)
+        return NULL;            /* not found */
     return best;
 }

--- a/native/common/common.c
+++ b/native/common/common.c
@@ -263,8 +263,8 @@ char *get_cookie_param(request_rec *r, const char *name, int in)
     if (cookies) {
         for (start_cookie = ap_strstr_c(cookies, name); start_cookie;
              start_cookie = ap_strstr_c(start_cookie + 1, name)) {
-            if (start_cookie == cookies ||
-                start_cookie[-1] == ';' || start_cookie[-1] == ',' || isspace(start_cookie[-1])) {
+            if (start_cookie == cookies || start_cookie[-1] == ';' || start_cookie[-1] == ',' ||
+                isspace(start_cookie[-1])) {
 
                 start_cookie += strlen(name);
                 while (*start_cookie && isspace(*start_cookie))
@@ -381,13 +381,13 @@ int hassession_byname(request_rec *r, int nodeid, const char *route, proxy_node_
     /* read the node */
     node = table_get_node(node_table, nodeid);
     if (node == NULL)
-        return 0;               /* failed */
+        return 0; /* failed */
 
-    conf = (proxy_server_conf *) ap_get_module_config(r->server->module_config, &proxy_module);
+    conf = (proxy_server_conf *)ap_get_module_config(r->server->module_config, &proxy_module);
     sizeb = conf->balancers->elt_size;
     ptr = conf->balancers->elts;
     for (i = 0; i < conf->balancers->nelts; i++, ptr = ptr + sizeb) {
-        balancer = (proxy_balancer *) ptr;
+        balancer = (proxy_balancer *)ptr;
         if (strlen(balancer->s->name) > 11 && strcasecmp(&balancer->s->name[11], node->mess.balancer) == 0)
             break;
     }
@@ -500,8 +500,7 @@ node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, c
         if (contexts[j] == -1)
             continue;
         context = &context_table->context_info[j];
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "find_node_context_host: %s node: %d vhost: %d context: %s",
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_node_context_host: %s node: %d vhost: %d context: %s",
                      uri, context->node, context->vhost, context->context);
     }
 #endif
@@ -614,10 +613,9 @@ static apr_status_t find_nodedomain(request_rec *r, char **domain, char *route, 
 /**
  * Find the balancer corresponding to the node information
  */
-const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
-                               proxy_vhost_table *vhost_table,
-                               proxy_context_table *context_table,
-                               proxy_balancer_table *balancer_table, proxy_node_table *node_table, int use_alias)
+const char *get_route_balancer(request_rec *r, proxy_server_conf *conf, proxy_vhost_table *vhost_table,
+                               proxy_context_table *context_table, proxy_balancer_table *balancer_table,
+                               proxy_node_table *node_table, int use_alias)
 {
     char *route = NULL;
     char *sessionid = NULL;
@@ -629,7 +627,7 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
     (void)balancer_table;
 
     for (i = 0; i < conf->balancers->nelts; i++, ptr = ptr + sizeb) {
-        proxy_balancer *balancer = (proxy_balancer *) ptr;
+        proxy_balancer *balancer = (proxy_balancer *)ptr;
 
         if (balancer->s->sticky[0] == '\0' || balancer->s->sticky_path[0] == '\0')
             continue;
@@ -643,7 +641,9 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
         sessionid = cluster_get_sessionid(r, sticky, r->uri, &sticky_used);
         if (sessionid) {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "cluster: %s Found value %s for " "stickysession %s", balancer->s->name, sessionid, sticky);
+                         "cluster: %s Found value %s for "
+                         "stickysession %s",
+                         balancer->s->name, sessionid, sticky);
             apr_table_setn(r->notes, "session-id", sessionid);
             if ((route = strchr(sessionid, '.')) != NULL)
                 route++;
@@ -652,7 +652,7 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
                 node_context *nodes =
                     find_node_context_host(r, balancer, route, use_alias, vhost_table, context_table, node_table);
                 if (nodes == NULL)
-                    continue;   /* we can't serve context/host for the request with this balancer */
+                    continue; /* we can't serve context/host for the request with this balancer */
             }
             if (route && *route) {
                 char *domain = NULL;
@@ -661,8 +661,8 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
 #endif
                 if (find_nodedomain(r, &domain, route, &balancer->s->name[11], node_table) == APR_SUCCESS) {
 #if HAVE_CLUSTER_EX_DEBUG
-                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "cluster: Found balancer %s for %s", &balancer->s->name[11], route);
+                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster: Found balancer %s for %s",
+                                 &balancer->s->name[11], route);
 #endif
                     /* here we have the route and domain for find_session_route ... */
                     apr_table_setn(r->notes, "session-sticky", sticky_used);
@@ -672,8 +672,8 @@ const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
                     apr_table_setn(r->subprocess_env, "BALANCER_SESSION_STICKY", sticky_used);
                     if (domain) {
 #if HAVE_CLUSTER_EX_DEBUG
-                        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                     "cluster: Found domain %s for %s", domain, route);
+                        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster: Found domain %s for %s", domain,
+                                     route);
 #endif
                         apr_table_setn(r->notes, "CLUSTER_DOMAIN", domain);
                     }
@@ -716,13 +716,11 @@ nodeinfo_t *table_get_node_route(proxy_node_table *node_table, char *route, int 
  * @context_table table of contexts.
  * @return the balancer name or NULL if not found.
  */
-const char *get_context_host_balancer(request_rec *r,
-                                      proxy_vhost_table *vhost_table, proxy_context_table *context_table,
-                                      proxy_node_table *node_table, int use_alias)
+const char *get_context_host_balancer(request_rec *r, proxy_vhost_table *vhost_table,
+                                      proxy_context_table *context_table, proxy_node_table *node_table, int use_alias)
 {
     void *sconf = r->server->module_config;
-    proxy_server_conf *conf = (proxy_server_conf *)
-        ap_get_module_config(sconf, &proxy_module);
+    proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
 
     node_context *nodes = find_node_context_host(r, NULL, NULL, use_alias, vhost_table, context_table, node_table);
     if (nodes == NULL)
@@ -771,6 +769,6 @@ node_context *context_host_ok(request_rec *r, proxy_balancer *balancer, int node
         best++;
     }
     if (best->node == -1)
-        return NULL;            /* not found */
+        return NULL; /* not found */
     return best;
 }

--- a/native/include/balancer.h
+++ b/native/include/balancer.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -40,27 +40,28 @@
 #define BALANCEREXE ".balancers"
 
 #ifndef MEM_T
-typedef struct mem mem_t; 
+typedef struct mem mem_t;
 #define MEM_T
 #endif
 
 #include "mod_clustersize.h"
 
 /* status of the balancer as read/store in httpd. */
-struct balancerinfo {
+struct balancerinfo
+{
     char balancer[BALANCERSZ]; /* Name of the balancer */
-    int StickySession; /* 0 : Don't use, 1: Use it */
+    int StickySession;         /* 0 : Don't use, 1: Use it */
     char StickySessionCookie[COOKNAMESZ];
     char StickySessionPath[PATHNAMESZ];
     int StickySessionRemove; /* 0 : Don't remove, 1: Remove it */
     int StickySessionForce;  /* 0: Don't force, 1: return error */
     int Timeout;
-    int	Maxattempts;
+    int Maxattempts;
 
     apr_time_t updatetime; /* time of last received message */
-    int id;           /* id in table */
+    int id;                /* id in table */
 };
-typedef struct balancerinfo balancerinfo_t; 
+typedef struct balancerinfo balancerinfo_t;
 
 
 /**
@@ -78,7 +79,7 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer);
  * @param balancer balancer to read from the shared table.
  * @return address of the read balancer or NULL if error.
  */
-balancerinfo_t * read_balancer(mem_t *s, balancerinfo_t *balancer);
+balancerinfo_t *read_balancer(mem_t *s, balancerinfo_t *balancer);
 
 /**
  * get a balancer record from the shared table
@@ -118,7 +119,7 @@ int get_max_size_balancer(mem_t *s);
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_balancer(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *get_mem_balancer(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
 /**
  * create a shared balancer table
  * @param name to use to create the table.
@@ -127,28 +128,29 @@ mem_t * get_mem_balancer(char *string, int *num, apr_pool_t *p, slotmem_storage_
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_balancer(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *create_mem_balancer(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
 
 /**
  * provider for the mod_proxy_cluster or mod_jk modules.
  */
-struct balancer_storage_method {
-/**
- * the balancer corresponding to the ident
- * @param ids ident of the balancer to read.
- * @param balancer address of pointer to return the balancer.
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* read_balancer)(int ids, balancerinfo_t **balancer);
-/**
- * read the list of ident of used balancers.
- * @param ids address to store the idents.
- * @return APR_SUCCESS if all went well
- */
-int (* get_ids_used_balancer)(int *ids);
-/**
- * read the max number of balancers in the shared table
- */
-int (*get_max_size_balancer)(void);
+struct balancer_storage_method
+{
+    /**
+     * the balancer corresponding to the ident
+     * @param ids ident of the balancer to read.
+     * @param balancer address of pointer to return the balancer.
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*read_balancer)(int ids, balancerinfo_t **balancer);
+    /**
+     * read the list of ident of used balancers.
+     * @param ids address to store the idents.
+     * @return APR_SUCCESS if all went well
+     */
+    int (*get_ids_used_balancer)(int *ids);
+    /**
+     * read the max number of balancers in the shared table
+     */
+    int (*get_max_size_balancer)(void);
 };
 #endif /*BALANCER_H*/

--- a/native/include/context.h
+++ b/native/include/context.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -40,7 +40,7 @@
 #define CONTEXTEXE ".contexts"
 
 #ifndef MEM_T
-typedef struct mem mem_t; 
+typedef struct mem mem_t;
 #define MEM_T
 #endif
 
@@ -53,17 +53,18 @@ typedef struct mem mem_t;
 #include "mod_clustersize.h"
 
 /* status of the context as read/store in httpd. */
-struct contextinfo {
-    char context[CONTEXTSZ+1]; /* Context where the application is mapped. */
-    int vhost;        /* id of the correspond virtual host in hosts table */
-    int node;         /* id of the correspond node in nodes table */
-    int status;       /* status: ENABLED/DISABLED/STOPPED */
-    int nbrequests;   /* number of request been processed */
+struct contextinfo
+{
+    char context[CONTEXTSZ + 1]; /* Context where the application is mapped. */
+    int vhost;                   /* id of the correspond virtual host in hosts table */
+    int node;                    /* id of the correspond node in nodes table */
+    int status;                  /* status: ENABLED/DISABLED/STOPPED */
+    int nbrequests;              /* number of request been processed */
 
-    apr_time_t updatetime; /* time of last received message */ 
-    int id;           /* id in table */
+    apr_time_t updatetime; /* time of last received message */
+    int id;                /* id in table */
 };
-typedef struct contextinfo contextinfo_t; 
+typedef struct contextinfo contextinfo_t;
 
 
 /**
@@ -81,7 +82,7 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context);
  * @param context context to read from the shared table.
  * @return address of the read context or NULL if error.
  */
-contextinfo_t * read_context(mem_t *s, contextinfo_t *context);
+contextinfo_t *read_context(mem_t *s, contextinfo_t *context);
 
 /**
  * get a context record from the shared table
@@ -121,7 +122,7 @@ int get_max_size_context(mem_t *s);
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_context(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *get_mem_context(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
 /**
  * create a shared context table
  * @param name to use to create the table.
@@ -130,37 +131,37 @@ mem_t * get_mem_context(char *string, int *num, apr_pool_t *p, slotmem_storage_m
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_context(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *create_mem_context(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
 
 /**
  * provider for the mod_proxy_cluster or mod_jk modules.
  */
-struct context_storage_method {
-/**
- * the context corresponding to the ident
- * @param ids ident of the context to read.
- * @param context address of pointer to return the context.
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* read_context)(int ids, contextinfo_t **context);
-/**
- * read the list of ident of used contexts.
- * @param ids address to store the idents.
- * @return APR_SUCCESS if all went well
- */
-int (* get_ids_used_context)(int *ids);
-/**
- * read the max number of contexts in the shared table
- */
-int (*get_max_size_context)(void);
-/*
- * lock the context table
- */
-apr_status_t (*lock_contexts)(void);
-/*
- * unlock the context table
- */
-apr_status_t (*unlock_contexts)(void);
-
+struct context_storage_method
+{
+    /**
+     * the context corresponding to the ident
+     * @param ids ident of the context to read.
+     * @param context address of pointer to return the context.
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*read_context)(int ids, contextinfo_t **context);
+    /**
+     * read the list of ident of used contexts.
+     * @param ids address to store the idents.
+     * @return APR_SUCCESS if all went well
+     */
+    int (*get_ids_used_context)(int *ids);
+    /**
+     * read the max number of contexts in the shared table
+     */
+    int (*get_max_size_context)(void);
+    /*
+     * lock the context table
+     */
+    apr_status_t (*lock_contexts)(void);
+    /*
+     * unlock the context table
+     */
+    apr_status_t (*unlock_contexts)(void);
 };
 #endif /*CONTEXT_H*/

--- a/native/include/domain.h
+++ b/native/include/domain.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2009 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -40,22 +40,23 @@
 #define DOMAINEXE ".domain"
 
 #ifndef MEM_T
-typedef struct mem mem_t; 
+typedef struct mem mem_t;
 #define MEM_T
 #endif
 
 #include "mod_clustersize.h"
 
 /* status of the domain as read/store in httpd. */
-struct domaininfo {
-    char domain[DOMAINNDSZ];     /* domain value */
-    char JVMRoute[JVMROUTESZ];   /* corresponding node */
-    char balancer[BALANCERSZ];   /* name of the balancer */
+struct domaininfo
+{
+    char domain[DOMAINNDSZ];   /* domain value */
+    char JVMRoute[JVMROUTESZ]; /* corresponding node */
+    char balancer[BALANCERSZ]; /* name of the balancer */
 
-    apr_time_t updatetime;    /* time of last received message */
-    int id;                      /* id in table */
+    apr_time_t updatetime; /* time of last received message */
+    int id;                /* id in table */
 };
-typedef struct domaininfo domaininfo_t; 
+typedef struct domaininfo domaininfo_t;
 
 
 /**
@@ -73,7 +74,7 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain);
  * @param domain domain to read from the shared table.
  * @return address of the read domain or NULL if error.
  */
-domaininfo_t * read_domain(mem_t *s, domaininfo_t *domain);
+domaininfo_t *read_domain(mem_t *s, domaininfo_t *domain);
 
 /**
  * get a domain record from the shared table
@@ -122,7 +123,7 @@ int get_max_size_domain(mem_t *s);
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_domain(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *get_mem_domain(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
 /**
  * create a shared domain table
  * @param name to use to create the table.
@@ -131,40 +132,41 @@ mem_t * get_mem_domain(char *string, int *num, apr_pool_t *p, slotmem_storage_me
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_domain(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *create_mem_domain(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
 
 /**
  * provider for the mod_proxy_cluster or mod_jk modules.
  */
-struct domain_storage_method {
-/**
- * the domain corresponding to the ident
- * @param ids ident of the domain to read.
- * @param domain address of pointer to return the domain.
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* read_domain)(int ids, domaininfo_t **domain);
-/**
- * read the list of ident of used domains.
- * @param ids address to store the idents.
- * @return APR_SUCCESS if all went well
- */
-int (* get_ids_used_domain)(int *ids);
-/**
- * read the max number of domains in the shared table
- */
-int (*get_max_size_domain)(void);
-/*
- * Remove the domain from shared memory (free the slotmem)
- */
-apr_status_t (*remove_domain)(domaininfo_t *domain);
-/*
- * Insert a new domain or update existing one.
- */
-apr_status_t (*insert_update_domain)(domaininfo_t *domain);
-/*
- * Find the domain using the JVMRoute and balancer information
- */
-apr_status_t (*find_domain)(domaininfo_t **node, const char *route, const char *balancer);
+struct domain_storage_method
+{
+    /**
+     * the domain corresponding to the ident
+     * @param ids ident of the domain to read.
+     * @param domain address of pointer to return the domain.
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*read_domain)(int ids, domaininfo_t **domain);
+    /**
+     * read the list of ident of used domains.
+     * @param ids address to store the idents.
+     * @return APR_SUCCESS if all went well
+     */
+    int (*get_ids_used_domain)(int *ids);
+    /**
+     * read the max number of domains in the shared table
+     */
+    int (*get_max_size_domain)(void);
+    /*
+     * Remove the domain from shared memory (free the slotmem)
+     */
+    apr_status_t (*remove_domain)(domaininfo_t *domain);
+    /*
+     * Insert a new domain or update existing one.
+     */
+    apr_status_t (*insert_update_domain)(domaininfo_t *domain);
+    /*
+     * Find the domain using the JVMRoute and balancer information
+     */
+    apr_status_t (*find_domain)(domaininfo_t **node, const char *route, const char *balancer);
 };
 #endif /*DOMAIN_H*/

--- a/native/include/host.h
+++ b/native/include/host.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -40,22 +40,23 @@
 #define HOSTEXE ".hosts"
 
 #ifndef MEM_T
-typedef struct mem mem_t; 
+typedef struct mem mem_t;
 #define MEM_T
 #endif
 
 #include "mod_clustersize.h"
 
 /* status of the host as read/store in httpd. */
-struct hostinfo {
-    char host[HOSTALIASZ+1]; /* Alias element of the virtual host */
-    int vhost;             /* id of the correspond virtual host */
-    int node;              /* id of the node containing the virtual host */
+struct hostinfo
+{
+    char host[HOSTALIASZ + 1]; /* Alias element of the virtual host */
+    int vhost;                 /* id of the correspond virtual host */
+    int node;                  /* id of the node containing the virtual host */
 
     apr_time_t updatetime; /* time of last received message */
-    int id;           /* id in table */
+    int id;                /* id in table */
 };
-typedef struct hostinfo hostinfo_t; 
+typedef struct hostinfo hostinfo_t;
 
 
 /**
@@ -73,7 +74,7 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host);
  * @param host host to read from the shared table.
  * @return address of the read host or NULL if error.
  */
-hostinfo_t * read_host(mem_t *s, hostinfo_t *host);
+hostinfo_t *read_host(mem_t *s, hostinfo_t *host);
 
 /**
  * get a host record from the shared table
@@ -113,7 +114,7 @@ int get_max_size_host(mem_t *s);
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_host(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *get_mem_host(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
 /**
  * create a shared host table
  * @param name to use to create the table.
@@ -122,28 +123,29 @@ mem_t * get_mem_host(char *string, int *num, apr_pool_t *p, slotmem_storage_meth
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_host(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *create_mem_host(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
 
 /**
  * provider for the mod_proxy_cluster or mod_jk modules.
  */
-struct host_storage_method {
-/**
- * the host corresponding to the ident
- * @param ids ident of the host to read.
- * @param host address of pointer to return the host.
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* read_host)(int ids, hostinfo_t **host);
-/**
- * read the list of ident of used hosts.
- * @param ids address to store the idents.
- * @return APR_SUCCESS if all went well
- */
-int (* get_ids_used_host)(int *ids);
-/**
- * read the max number of hosts in the shared table
- */
-int (*get_max_size_host)(void);
+struct host_storage_method
+{
+    /**
+     * the host corresponding to the ident
+     * @param ids ident of the host to read.
+     * @param host address of pointer to return the host.
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*read_host)(int ids, hostinfo_t **host);
+    /**
+     * read the list of ident of used hosts.
+     * @param ids address to store the idents.
+     * @return APR_SUCCESS if all went well
+     */
+    int (*get_ids_used_host)(int *ids);
+    /**
+     * read the max number of hosts in the shared table
+     */
+    int (*get_max_size_host)(void);
 };
 #endif /*HOST_H*/

--- a/native/include/mod_clustersize.h
+++ b/native/include/mod_clustersize.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -28,23 +28,23 @@
 #define MOD_CLUSTERSIZE_H
 
 /* For host.h */
-#define HOSTALIASZ 100
+#define HOSTALIASZ  100
 
 /* For context.h */
-#define CONTEXTSZ 80
+#define CONTEXTSZ   80
 
 /* For node.h */
-#define BALANCERSZ 40
-#define JVMROUTESZ 64
-#define DOMAINNDSZ 20
-#define HOSTNODESZ 64
-#define PORTNODESZ 7
-#define SCHEMENDSZ 16
+#define BALANCERSZ  40
+#define JVMROUTESZ  64
+#define DOMAINNDSZ  20
+#define HOSTNODESZ  64
+#define PORTNODESZ  7
+#define SCHEMENDSZ  16
 #define AJPSECRETSZ 64
 
 /* For balancer.h */
-#define COOKNAMESZ 30
-#define PATHNAMESZ 30
+#define COOKNAMESZ  30
+#define PATHNAMESZ  30
 
 /* For sessionid.h */
 #define SESSIONIDSZ 128

--- a/native/include/mod_proxy_cluster.h
+++ b/native/include/mod_proxy_cluster.h
@@ -30,53 +30,56 @@
 
 #define MOD_CLUSTER_EXPOSED_VERSION "mod_cluster/2.0.0.Alpha1-SNAPSHOT"
 
-APR_DECLARE_OPTIONAL_FN(apr_status_t, balancer_manage, (request_rec *r, apr_table_t *params));
+APR_DECLARE_OPTIONAL_FN(apr_status_t, balancer_manage, (request_rec * r, apr_table_t *params));
 
-struct balancer_method {
-/**
- * Check that the node is responding
- * @param r request_rec structure.
- * @param id ident of the worker.
- * @param load load factor to set if test is ok.
- * @return 0: All OK 500 : Error
- */ 
-int (* proxy_node_isup)(request_rec *r, int id, int load);
-/**
- * Check that the node is responding
- * @param r request_rec structure.
- * @param scheme something like ajp, http or https.
- * @param host the hostname.
- * @param port the port on which the node connector is running
- * @return 0: All OK 500 : Error
- */ 
-int (* proxy_host_isup)(request_rec *r, char *scheme, char *host, char *port);
-/**
- * Check if a worker already exists and return the corresponding id
- * @param r request_rec structure.
- * @param balancername, the balancer name.
- * @param scheme something like ajp, http or https.
- * @param host the hostname.
- * @param port the port on which the node connector is running
- * @param id the address to store the index that was previously used.
- * @param the_conf adress to store the proxy_server_conf the worker is using.
- * @return the worker or NULL if not existing.
- */
-proxy_worker *(* proxy_node_getid)(request_rec *r, char *balancername, char *scheme, char *host, char *port, int *id, proxy_server_conf **the_conf);
+struct balancer_method
+{
+    /**
+     * Check that the node is responding
+     * @param r request_rec structure.
+     * @param id ident of the worker.
+     * @param load load factor to set if test is ok.
+     * @return 0: All OK 500 : Error
+     */
+    int (*proxy_node_isup)(request_rec *r, int id, int load);
+    /**
+     * Check that the node is responding
+     * @param r request_rec structure.
+     * @param scheme something like ajp, http or https.
+     * @param host the hostname.
+     * @param port the port on which the node connector is running
+     * @return 0: All OK 500 : Error
+     */
+    int (*proxy_host_isup)(request_rec *r, char *scheme, char *host, char *port);
+    /**
+     * Check if a worker already exists and return the corresponding id
+     * @param r request_rec structure.
+     * @param balancername, the balancer name.
+     * @param scheme something like ajp, http or https.
+     * @param host the hostname.
+     * @param port the port on which the node connector is running
+     * @param id the address to store the index that was previously used.
+     * @param the_conf adress to store the proxy_server_conf the worker is using.
+     * @return the worker or NULL if not existing.
+     */
+    proxy_worker *(*proxy_node_getid)(request_rec *r, char *balancername, char *scheme, char *host, char *port, int *id,
+                                      proxy_server_conf **the_conf);
 
-/**
- * Re enable the proxy_worker
- * @param r request_rec structure.
- * @param node pointer to node structure we have created.
- * @param worker the proxy_worker to re enable
- * @param nodeinfo pointer to node structure we are creating
- * @param the_conf the proxy_server_conf from proxy_node_getid()
- */
-void (* reenable_proxy_worker)(server_rec *s, nodeinfo_t*  node, proxy_worker *worker, nodeinfo_t* nodeinfo, proxy_server_conf *the_conf);
+    /**
+     * Re enable the proxy_worker
+     * @param r request_rec structure.
+     * @param node pointer to node structure we have created.
+     * @param worker the proxy_worker to re enable
+     * @param nodeinfo pointer to node structure we are creating
+     * @param the_conf the proxy_server_conf from proxy_node_getid()
+     */
+    void (*reenable_proxy_worker)(server_rec *s, nodeinfo_t *node, proxy_worker *worker, nodeinfo_t *nodeinfo,
+                                  proxy_server_conf *the_conf);
 
-/**
- * return the first free id to insert in node table
- */
-int (*proxy_node_get_free_id)(request_rec *r, int node_table_size);
+    /**
+     * return the first free id to insert in node table
+     */
+    int (*proxy_node_get_free_id)(request_rec *r, int node_table_size);
 };
 
 typedef struct balancer_method balancer_method;
@@ -84,9 +87,9 @@ typedef struct balancer_method balancer_method;
 /* Context table copy for local use */
 struct proxy_context_table
 {
-	int sizecontext;
-	int* contexts;
-	contextinfo_t* context_info;
+    int sizecontext;
+    int *contexts;
+    contextinfo_t *context_info;
 };
 typedef struct proxy_context_table proxy_context_table;
 
@@ -94,75 +97,75 @@ typedef struct proxy_context_table proxy_context_table;
 /* VHost table copy for local use */
 struct proxy_vhost_table
 {
-	int sizevhost;
-	int* vhosts;
-	hostinfo_t* vhost_info;
+    int sizevhost;
+    int *vhosts;
+    hostinfo_t *vhost_info;
 };
 typedef struct proxy_vhost_table proxy_vhost_table;
 
 /* Balancer table copy for local use */
 struct proxy_balancer_table
 {
-	int sizebalancer;
-	int* balancers;
-	balancerinfo_t* balancer_info;
+    int sizebalancer;
+    int *balancers;
+    balancerinfo_t *balancer_info;
 };
 typedef struct proxy_balancer_table proxy_balancer_table;
 
 /* Node table copy for local use, the ptr_node is the shared memory address (slotmem address) */
 struct proxy_node_table
 {
-	int sizenode;
-	int* nodes;
-	nodeinfo_t*  node_info;
-        char **ptr_node;
+    int sizenode;
+    int *nodes;
+    nodeinfo_t *node_info;
+    char **ptr_node;
 };
 typedef struct proxy_node_table proxy_node_table;
 
 /* table of node and context selected by find_node_context_host() */
 struct node_context
 {
-        int node;
-        int context;
+    int node;
+    int context;
 };
 typedef struct node_context node_context;
 
 /* common routines */
 proxy_vhost_table *read_vhost_table(apr_pool_t *pool, struct host_storage_method *host_storage, int for_cache);
-proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage_method *context_storage, int for_cache);
-proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage, int for_cache);
+proxy_context_table *read_context_table(apr_pool_t *pool, struct context_storage_method *context_storage,
+                                        int for_cache);
+proxy_balancer_table *read_balancer_table(apr_pool_t *pool, struct balancer_storage_method *balancer_storage,
+                                          int for_cache);
 proxy_node_table *read_node_table(apr_pool_t *pool, struct node_storage_method *node_storage, int for_cache);
-proxy_vhost_table *update_vhost_table_cached(proxy_vhost_table *proxy_vhost_table, struct host_storage_method *host_storage);
-proxy_context_table *update_context_table_cached(proxy_context_table *context_table, struct context_storage_method *context_storage);
-proxy_balancer_table *update_balancer_table_cached(proxy_balancer_table *balancer_table, struct balancer_storage_method *balancer_storage);
+proxy_vhost_table *update_vhost_table_cached(proxy_vhost_table *proxy_vhost_table,
+                                             struct host_storage_method *host_storage);
+proxy_context_table *update_context_table_cached(proxy_context_table *context_table,
+                                                 struct context_storage_method *context_storage);
+proxy_balancer_table *update_balancer_table_cached(proxy_balancer_table *balancer_table,
+                                                   struct balancer_storage_method *balancer_storage);
 proxy_node_table *update_node_table_cached(proxy_node_table *node_table, struct node_storage_method *node_storage);
 
-const char *get_route_balancer(request_rec *r, proxy_server_conf *conf,
-                                      proxy_vhost_table *vhost_table,
-                                      proxy_context_table *context_table,
-                                      proxy_balancer_table *balancer_table,
-                                      proxy_node_table *node_table,
-                                      int use_alias);
+const char *get_route_balancer(request_rec *r, proxy_server_conf *conf, proxy_vhost_table *vhost_table,
+                               proxy_context_table *context_table, proxy_balancer_table *balancer_table,
+                               proxy_node_table *node_table, int use_alias);
 
-const char *get_context_host_balancer(request_rec *r,
-                proxy_vhost_table *vhost_table,
-                proxy_context_table *context_table,
-                proxy_node_table *node_table,
-                int use_alias);
+const char *get_context_host_balancer(request_rec *r, proxy_vhost_table *vhost_table,
+                                      proxy_context_table *context_table, proxy_node_table *node_table, int use_alias);
 
-nodeinfo_t* table_get_node(proxy_node_table *node_table, int id);
+nodeinfo_t *table_get_node(proxy_node_table *node_table, int id);
 char *cluster_get_sessionid(request_rec *r, const char *stickyval, char *uri, char **sticky_used);
 char *get_cookie_param(request_rec *r, const char *name, int in);
-char *get_path_param(apr_pool_t *pool, char *url,
-                            const char *name);
+char *get_path_param(apr_pool_t *pool, char *url, const char *name);
 node_context *find_node_context_host(request_rec *r, proxy_balancer *balancer, const char *route, int use_alias,
-                                     proxy_vhost_table* vhost_table, proxy_context_table* context_table, proxy_node_table *node_table);
+                                     proxy_vhost_table *vhost_table, proxy_context_table *context_table,
+                                     proxy_node_table *node_table);
 int hassession_byname(request_rec *r, int nodeid, const char *route, proxy_node_table *node_table);
 
-nodeinfo_t* table_get_node_route(proxy_node_table *node_table, char *route, int *id);
+nodeinfo_t *table_get_node_route(proxy_node_table *node_table, char *route, int *id);
 
 node_context *context_host_ok(request_rec *r, proxy_balancer *balancer, int node, int use_alias,
-                             proxy_vhost_table *vhost_table, proxy_context_table *context_table, proxy_node_table *node_table);
+                              proxy_vhost_table *vhost_table, proxy_context_table *context_table,
+                              proxy_node_table *node_table);
 
 
 #endif /*MOD_PROXY_CLUSTER_H*/

--- a/native/include/node.h
+++ b/native/include/node.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2007 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -40,7 +40,7 @@
 #define NODEEXE ".nodes"
 
 #ifndef MEM_T
-typedef struct mem mem_t; 
+typedef struct mem mem_t;
 #define MEM_T
 #endif
 
@@ -49,8 +49,9 @@ typedef struct mem mem_t;
 #include "ap_mmn.h"
 
 /* configuration of the node received from jboss cluster. */
-struct nodemess {
-    char balancer[BALANCERSZ];        /* name of the balancer */
+struct nodemess
+{
+    char balancer[BALANCERSZ]; /* name of the balancer */
     char JVMRoute[JVMROUTESZ];
     char Domain[DOMAINNDSZ];
     char Host[HOSTNODESZ];
@@ -58,41 +59,42 @@ struct nodemess {
     char Type[SCHEMENDSZ];
     char Upgrade[SCHEMENDSZ];
     char AJPSecret[AJPSECRETSZ];
-    int  reversed; /* 1 : reversed... 0 : normal */
-    int  remove;   /* 1 : removed     0 : normal */
+    int reversed; /* 1 : reversed... 0 : normal */
+    int remove;   /* 1 : removed     0 : normal */
     long ResponseFieldSize;
 
     /* node conf part */
     int flushpackets;
-    int	flushwait;
-    apr_time_t	ping;
-    int	smax;
+    int flushwait;
+    apr_time_t ping;
+    int smax;
     apr_time_t ttl;
     apr_time_t timeout;
 
     /* part updated in httpd */
-    int id;                   /* id in table and worker id */
+    int id;                  /* id in table and worker id */
     apr_time_t updatetimelb; /* time of last update of the lbstatus value */
     int num_failure_idle;    /* number of time the cping/cpong failed while calculating the lbstatus value */
     apr_size_t oldelected;   /* value of s->elected when calculating the lbstatus */
-    apr_off_t  oldread;      /* Number of bytes read from remote when calculating the lbstatus */
+    apr_off_t oldread;       /* Number of bytes read from remote when calculating the lbstatus */
     apr_time_t lastcleantry; /* time of last unsuccessful try to clean the worker in proxy part */
     int num_remove_check;    /* number of tries to remove a REMOVED node */
 };
-typedef struct nodemess nodemess_t; 
+typedef struct nodemess nodemess_t;
 
 #define SIZEOFSCORE 1700 /* at least size of the proxy_worker_stat structure */
 
 /* status of the node as read/store in httpd. */
-struct nodeinfo {
+struct nodeinfo
+{
     /* config from jboss/tomcat */
     nodemess_t mess;
     /* filled by httpd */
-    apr_time_t updatetime;   /* time of last received message */
-    unsigned long offset;    /* offset to the proxy_worker_stat structure */
-    char stat[SIZEOFSCORE];  /* to store the status */ 
+    apr_time_t updatetime;  /* time of last received message */
+    unsigned long offset;   /* offset to the proxy_worker_stat structure */
+    char stat[SIZEOFSCORE]; /* to store the status */
 };
-typedef struct nodeinfo nodeinfo_t; 
+typedef struct nodeinfo nodeinfo_t;
 
 /**
  * return the last stored in the mem structure
@@ -119,7 +121,7 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id, int clean);
  * @param node node to read from the shared table.
  * @return address of the read node or NULL if error.
  */
-nodeinfo_t * read_node(mem_t *s, nodeinfo_t *node);
+nodeinfo_t *read_node(mem_t *s, nodeinfo_t *node);
 
 /**
  * get a node record from the shared table
@@ -195,7 +197,7 @@ unsigned int get_version_node(mem_t *s);
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_node(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *get_mem_node(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
 /**
  * create a shared node table
  * @param name to use to create the table.
@@ -204,60 +206,60 @@ mem_t * get_mem_node(char *string, int *num, apr_pool_t *p, slotmem_storage_meth
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_node(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *create_mem_node(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
 
 /**
  * provider for the mod_proxy_cluster or mod_jk modules.
  */
-struct node_storage_method {
-/**
- * the node corresponding to the ident
- * @param ids ident of the node to read.
- * @param node address of pointer to return the node.
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* read_node)(int ids, nodeinfo_t **node);
-/**
- * read the list of ident of used nodes.
- * @param ids address to store the idents.
- * @return APR_SUCCESS if all went well
- */
-int (* get_ids_used_node)(int *ids);
-/**
- * read the max number of nodes in the shared table
- */
-int (*get_max_size_node)(void);
-/**
- * check the nodes for modifications.
- * XXX: void *data is server_rec *s in fact.
- */
-unsigned int (*worker_nodes_need_update)(void *data, apr_pool_t *pool);
-/*
- * mark that the worker node are now up to date.
- */
-int (*worker_nodes_are_updated)(void *data, unsigned int version);
-/*
- * Remove the node from shared memory (free the slotmem)
- */
-int (*remove_node)(int node);
-/*
- * Find the node using the JVMRoute information
- */
-apr_status_t (*find_node)(nodeinfo_t **node, const char *route);
-/*
- * Remove the virtual hosts and contexts corresponding the node.
- */
-void (*remove_host_context)(int node, apr_pool_t *pool);
+struct node_storage_method
+{
+    /**
+     * the node corresponding to the ident
+     * @param ids ident of the node to read.
+     * @param node address of pointer to return the node.
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*read_node)(int ids, nodeinfo_t **node);
+    /**
+     * read the list of ident of used nodes.
+     * @param ids address to store the idents.
+     * @return APR_SUCCESS if all went well
+     */
+    int (*get_ids_used_node)(int *ids);
+    /**
+     * read the max number of nodes in the shared table
+     */
+    int (*get_max_size_node)(void);
+    /**
+     * check the nodes for modifications.
+     * XXX: void *data is server_rec *s in fact.
+     */
+    unsigned int (*worker_nodes_need_update)(void *data, apr_pool_t *pool);
+    /*
+     * mark that the worker node are now up to date.
+     */
+    int (*worker_nodes_are_updated)(void *data, unsigned int version);
+    /*
+     * Remove the node from shared memory (free the slotmem)
+     */
+    int (*remove_node)(int node);
+    /*
+     * Find the node using the JVMRoute information
+     */
+    apr_status_t (*find_node)(nodeinfo_t **node, const char *route);
+    /*
+     * Remove the virtual hosts and contexts corresponding the node.
+     */
+    void (*remove_host_context)(int node, apr_pool_t *pool);
 
-/*
- * lock the nodes table
- */
-apr_status_t (*lock_nodes)(void);
+    /*
+     * lock the nodes table
+     */
+    apr_status_t (*lock_nodes)(void);
 
-/*
- * unlock the nodes table
- */
-apr_status_t (*unlock_nodes)(void);
-
+    /*
+     * unlock the nodes table
+     */
+    apr_status_t (*unlock_nodes)(void);
 };
 #endif /*NODE_H*/

--- a/native/include/sessionid.h
+++ b/native/include/sessionid.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2009 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -40,21 +40,22 @@
 #define SESSIONIDEXE ".sessionid"
 
 #ifndef MEM_T
-typedef struct mem mem_t; 
+typedef struct mem mem_t;
 #define MEM_T
 #endif
 
 #include "mod_clustersize.h"
 
 /* status of the sessionid as read/store in httpd. */
-struct sessionidinfo {
-    char sessionid[SESSIONIDSZ+1]; /* Sessionid value */
-    char JVMRoute[JVMROUTESZ+1];   /* corresponding node */
+struct sessionidinfo
+{
+    char sessionid[SESSIONIDSZ + 1]; /* Sessionid value */
+    char JVMRoute[JVMROUTESZ + 1];   /* corresponding node */
 
-    apr_time_t updatetime;    /* time of last received message */
-    int id;                      /* id in table */
+    apr_time_t updatetime; /* time of last received message */
+    int id;                /* id in table */
 };
-typedef struct sessionidinfo sessionidinfo_t; 
+typedef struct sessionidinfo sessionidinfo_t;
 
 
 /**
@@ -72,7 +73,7 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid);
  * @param sessionid sessionid to read from the shared table.
  * @return address of the read sessionid or NULL if error.
  */
-sessionidinfo_t * read_sessionid(mem_t *s, sessionidinfo_t *sessionid);
+sessionidinfo_t *read_sessionid(mem_t *s, sessionidinfo_t *sessionid);
 
 /**
  * get a sessionid record from the shared table
@@ -112,7 +113,7 @@ int get_max_size_sessionid(mem_t *s);
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_sessionid(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *get_mem_sessionid(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage);
 /**
  * create a shared sessionid table
  * @param name to use to create the table.
@@ -121,36 +122,37 @@ mem_t * get_mem_sessionid(char *string, int *num, apr_pool_t *p, slotmem_storage
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_sessionid(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
+mem_t *create_mem_sessionid(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage);
 
 /**
  * provider for the mod_proxy_cluster or mod_jk modules.
  */
-struct sessionid_storage_method {
-/**
- * the sessionid corresponding to the ident
- * @param ids ident of the sessionid to read.
- * @param sessionid address of pointer to return the sessionid.
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* read_sessionid)(int ids, sessionidinfo_t **sessionid);
-/**
- * read the list of ident of used sessionids.
- * @param ids address to store the idents.
- * @return APR_SUCCESS if all went well
- */
-int (* get_ids_used_sessionid)(int *ids);
-/**
- * read the max number of sessionids in the shared table
- */
-int (*get_max_size_sessionid)(void);
-/*
- * Remove the sessionid from shared memory (free the slotmem)
- */
-apr_status_t (*remove_sessionid)(sessionidinfo_t *sessionid);
-/*
- * Insert a new sessionid or update existing one.
- */
-apr_status_t (*insert_update_sessionid)(sessionidinfo_t *sessionid);
+struct sessionid_storage_method
+{
+    /**
+     * the sessionid corresponding to the ident
+     * @param ids ident of the sessionid to read.
+     * @param sessionid address of pointer to return the sessionid.
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*read_sessionid)(int ids, sessionidinfo_t **sessionid);
+    /**
+     * read the list of ident of used sessionids.
+     * @param ids address to store the idents.
+     * @return APR_SUCCESS if all went well
+     */
+    int (*get_ids_used_sessionid)(int *ids);
+    /**
+     * read the max number of sessionids in the shared table
+     */
+    int (*get_max_size_sessionid)(void);
+    /*
+     * Remove the sessionid from shared memory (free the slotmem)
+     */
+    apr_status_t (*remove_sessionid)(sessionidinfo_t *sessionid);
+    /*
+     * Insert a new sessionid or update existing one.
+     */
+    apr_status_t (*insert_update_sessionid)(sessionidinfo_t *sessionid);
 };
 #endif /*SESSIONID_H*/

--- a/native/include/slotmem.h
+++ b/native/include/slotmem.h
@@ -4,7 +4,7 @@
  *  Copyright(c) 2006 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -46,11 +46,11 @@
 
 #define SLOTMEM_STORAGE "mod_cluster_slotmem"
 
-#define ATTACH_SLOTMEM 0 /* Attach to existing slotmem */
-#define CREATE_SLOTMEM 1 /* create a not persistent slotmem */
-#define CREPER_SLOTMEM 2 /* create a persisitent slotmem */
+#define ATTACH_SLOTMEM  0 /* Attach to existing slotmem */
+#define CREATE_SLOTMEM  1 /* create a not persistent slotmem */
+#define CREPER_SLOTMEM  2 /* create a persisitent slotmem */
 
-typedef struct ap_slotmem ap_slotmem_t; 
+typedef struct ap_slotmem ap_slotmem_t;
 
 /**
  * callback function used for slotmem.
@@ -60,90 +60,93 @@ typedef struct ap_slotmem ap_slotmem_t;
  * @param pool is pool used to create scoreboard
  * @return APR_SUCCESS if all went well
  */
-typedef apr_status_t mc_slotmem_callback_fn_t(void* mem, void **data, int ident, apr_pool_t *pool);
+typedef apr_status_t mc_slotmem_callback_fn_t(void *mem, void **data, int ident, apr_pool_t *pool);
 
-struct slotmem_storage_method {
-/**
- * call the callback on all worker slots
- * @param s ap_slotmem_t to use.
- * @param funct callback function to call for each element.
- * @param data parameter for the callback function.
- * @param pool is pool used to create scoreboard
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* ap_slotmem_do)(ap_slotmem_t *s, mc_slotmem_callback_fn_t *func, void *data, apr_pool_t *pool);
+struct slotmem_storage_method
+{
+    /**
+     * call the callback on all worker slots
+     * @param s ap_slotmem_t to use.
+     * @param funct callback function to call for each element.
+     * @param data parameter for the callback function.
+     * @param pool is pool used to create scoreboard
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*ap_slotmem_do)(ap_slotmem_t *s, mc_slotmem_callback_fn_t *func, void *data, apr_pool_t *pool);
 
-/**
- * create a new slotmem with each item size is item_size.
- * This would create shared memory, basically.
- * @param pointer to store the address of the scoreboard.
- * @param name is a key used for debugging and in mod_status output or allow another process to share this space.
- * @param item_size size of each item
- * @param item_num number of item to create.
- * @param persistent indicator to know if the data should be persisted or not.
- * @param pool is pool used to create scoreboard
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* ap_slotmem_create)(ap_slotmem_t **new, const char *name, apr_size_t item_size, int item_num, int persistent, apr_pool_t *pool);
+    /**
+     * create a new slotmem with each item size is item_size.
+     * This would create shared memory, basically.
+     * @param pointer to store the address of the scoreboard.
+     * @param name is a key used for debugging and in mod_status output or allow another process to share this space.
+     * @param item_size size of each item
+     * @param item_num number of item to create.
+     * @param persistent indicator to know if the data should be persisted or not.
+     * @param pool is pool used to create scoreboard
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*ap_slotmem_create)(ap_slotmem_t **new, const char *name, apr_size_t item_size, int item_num,
+                                      int persistent, apr_pool_t *pool);
 
-/**
- * attach to an existing slotmem.
- * This would attach to  shared memory, basically.
- * @param pointer to store the address of the scoreboard.
- * @param name is a key used for debugging and in mod_status output or allow another process to share this space.
- * @param item_size size of each item
- * @param item_num max number of item.
- * @param pool is pool to memory allocate.
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* ap_slotmem_attach)(ap_slotmem_t **new, const char *name, apr_size_t *item_size, int *item_num, apr_pool_t *pool);
-/**
- * get the memory associated with this worker slot.
- * @param s ap_slotmem_t to use.
- * @param item_id item to return for 0 to item_num
- * @param mem address to store the pointer to the slot
- * @return APR_SUCCESS if all went well (the slot must be an allocated slot).
- */
-apr_status_t (* ap_slotmem_mem)(ap_slotmem_t *s, int item_id, void**mem);
-/**
- * alloc a slot from the slotmem free idems.
- * @param s ap_slotmem_t to use.
- * @param item_id address to return the id of the slot allocates.
- * @param mem address to store the pointer to the slot
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* ap_slotmem_alloc)(ap_slotmem_t *s, int *item_id, void**mem); 
-/**
- * free a slot (return it to the free list).
- * @param s ap_slotmem_t to use.
- * @param item_id the id of the slot in the slotmem.
- * @param mem pointer to the slot
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* ap_slotmem_free)(ap_slotmem_t *s, int item_id, void*mem); 
-/**
- * Return the used id in the slotmem table.
- * @param s ap_slotmem_t to use.
- * @param ids array of int where to store the free idents.
- * @return number of slotmem in use.
- */
-int (*ap_slotmem_get_used)(ap_slotmem_t *s, int *ids);
-/**
- * Return the size of the slotmem table.
- * @param s ap_slotmem_t to use.
- * @return number of slotmem that cant be stored in the slotmem table.
- */
-int (*ap_slotmem_get_max_size)(ap_slotmem_t *s);
-/**
- * Lock the slotmem
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* ap_slotmem_lock)(ap_slotmem_t *s);
-/**
- * Unlock the slotmem
- * @return APR_SUCCESS if all went well
- */
-apr_status_t (* ap_slotmem_unlock)(ap_slotmem_t *s);
+    /**
+     * attach to an existing slotmem.
+     * This would attach to  shared memory, basically.
+     * @param pointer to store the address of the scoreboard.
+     * @param name is a key used for debugging and in mod_status output or allow another process to share this space.
+     * @param item_size size of each item
+     * @param item_num max number of item.
+     * @param pool is pool to memory allocate.
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*ap_slotmem_attach)(ap_slotmem_t **new, const char *name, apr_size_t *item_size, int *item_num,
+                                      apr_pool_t *pool);
+    /**
+     * get the memory associated with this worker slot.
+     * @param s ap_slotmem_t to use.
+     * @param item_id item to return for 0 to item_num
+     * @param mem address to store the pointer to the slot
+     * @return APR_SUCCESS if all went well (the slot must be an allocated slot).
+     */
+    apr_status_t (*ap_slotmem_mem)(ap_slotmem_t *s, int item_id, void **mem);
+    /**
+     * alloc a slot from the slotmem free idems.
+     * @param s ap_slotmem_t to use.
+     * @param item_id address to return the id of the slot allocates.
+     * @param mem address to store the pointer to the slot
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*ap_slotmem_alloc)(ap_slotmem_t *s, int *item_id, void **mem);
+    /**
+     * free a slot (return it to the free list).
+     * @param s ap_slotmem_t to use.
+     * @param item_id the id of the slot in the slotmem.
+     * @param mem pointer to the slot
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*ap_slotmem_free)(ap_slotmem_t *s, int item_id, void *mem);
+    /**
+     * Return the used id in the slotmem table.
+     * @param s ap_slotmem_t to use.
+     * @param ids array of int where to store the free idents.
+     * @return number of slotmem in use.
+     */
+    int (*ap_slotmem_get_used)(ap_slotmem_t *s, int *ids);
+    /**
+     * Return the size of the slotmem table.
+     * @param s ap_slotmem_t to use.
+     * @return number of slotmem that cant be stored in the slotmem table.
+     */
+    int (*ap_slotmem_get_max_size)(ap_slotmem_t *s);
+    /**
+     * Lock the slotmem
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*ap_slotmem_lock)(ap_slotmem_t *s);
+    /**
+     * Unlock the slotmem
+     * @return APR_SUCCESS if all went well
+     */
+    apr_status_t (*ap_slotmem_unlock)(ap_slotmem_t *s);
 };
 
 typedef struct slotmem_storage_method slotmem_storage_method;

--- a/native/mod_cluster_slotmem/mod_sharedmem.c
+++ b/native/mod_cluster_slotmem/mod_sharedmem.c
@@ -46,12 +46,12 @@ static int initialize_cleanup(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp
 {
     void *data;
     const char *userdata_key = "mod_sharedmem_init";
-    (void) plog; (void) ptemp;
+    (void)plog;
+    (void)ptemp;
 
     apr_pool_userdata_get(&data, userdata_key, s->process->pool);
     if (!data) {
-        apr_pool_userdata_set((const void *)1, userdata_key,
-                               apr_pool_cleanup_null, s->process->pool);
+        apr_pool_userdata_set((const void *)1, userdata_key, apr_pool_cleanup_null, s->process->pool);
         return OK;
     }
 
@@ -63,17 +63,17 @@ static int initialize_cleanup(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp
  * that is to allow the resize the shared memory area using a graceful start
  * No sure that is a very good idea...
  */
-static int pre_config(apr_pool_t *p, apr_pool_t *plog,
-                             apr_pool_t *ptemp)
+static int pre_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp)
 {
     apr_pool_t *global_pool;
     apr_status_t rv;
-    (void) p; (void) plog; (void) ptemp;
+    (void)p;
+    (void)plog;
+    (void)ptemp;
 
     rv = apr_pool_create(&global_pool, NULL);
     if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, rv, NULL,
-                     "Fatal error: unable to create global pool for shared slotmem");
+        ap_log_error(APLOG_MARK, APLOG_CRIT, rv, NULL, "Fatal error: unable to create global pool for shared slotmem");
         return rv;
     }
     mem_getstorage(global_pool, "");
@@ -85,7 +85,7 @@ static int pre_config(apr_pool_t *p, apr_pool_t *plog,
  */
 static void child_init(apr_pool_t *p, server_rec *s)
 {
-    (void) s;
+    (void)s;
     sharedmem_initialize_child(p);
 }
 
@@ -101,11 +101,11 @@ static void ap_sharedmem_register_hook(apr_pool_t *p)
 
 module AP_MODULE_DECLARE_DATA cluster_slotmem_module = {
     STANDARD20_MODULE_STUFF,
-    NULL,       /* create per-directory config structure */
-    NULL,       /* merge per-directory config structures */
-    NULL,       /* create per-server config structure */
-    NULL,       /* merge per-server config structures */
-    NULL,       /* command apr_table_t */
+    NULL,                       /* create per-directory config structure */
+    NULL,                       /* merge per-directory config structures */
+    NULL,                       /* create per-server config structure */
+    NULL,                       /* merge per-server config structures */
+    NULL,                       /* command apr_table_t */
     ap_sharedmem_register_hook, /* register hooks */
     AP_MODULE_FLAG_NONE         /* flags */
 };

--- a/native/mod_cluster_slotmem/mod_sharedmem.c
+++ b/native/mod_cluster_slotmem/mod_sharedmem.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -39,7 +39,7 @@
 #include "http_log.h"
 #include "ap_provider.h"
 
-#include  "slotmem.h"
+#include "slotmem.h"
 
 /* make sure the shared memory is cleaned */
 static int initialize_cleanup(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)

--- a/native/mod_cluster_slotmem/sharedmem_util.c
+++ b/native/mod_cluster_slotmem/sharedmem_util.c
@@ -595,6 +595,7 @@ static int ap_slotmem_get_max_size(ap_slotmem_t *score)
     return score->num;
 }
 
+// clang-format off
 static const slotmem_storage_method storage = {
     &ap_slotmem_do,
     &ap_slotmem_create,
@@ -605,8 +606,9 @@ static const slotmem_storage_method storage = {
     &ap_slotmem_get_used,
     &ap_slotmem_get_max_size,
     &ap_slotmem_lock,
-    &ap_slotmem_unlock
+    &ap_slotmem_unlock,
 };
+// clang-format on
 
 /* make the storage usuable from outside
  * and initialise the global pool */

--- a/native/mod_cluster_slotmem/sharedmem_util.c
+++ b/native/mod_cluster_slotmem/sharedmem_util.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -43,7 +43,7 @@
 #endif
 
 #if APR_HAVE_UNISTD_H
-#include <unistd.h>             /* for getpid() */
+#include <unistd.h> /* for getpid() */
 #endif
 
 #if HAVE_SYS_SEM_H
@@ -61,20 +61,20 @@ struct sharedslotdesc
 {
     apr_size_t item_size;
     int item_num;
-    unsigned int version;       /* integer updated each time we make a change through the API */
+    unsigned int version; /* integer updated each time we make a change through the API */
 };
 
 struct ap_slotmem
 {
     char *name;
     apr_shm_t *shm;
-    int *ident;                 /* integer table to process a fast alloc/free */
-    unsigned int *version;      /* address of version */
+    int *ident;            /* integer table to process a fast alloc/free */
+    unsigned int *version; /* address of version */
     void *base;
     apr_size_t size;
     int num;
     apr_pool_t *globalpool;
-    apr_file_t *global_lock;    /* file used for the locks */
+    apr_file_t *global_lock; /* file used for the locks */
     struct ap_slotmem *next;
 };
 
@@ -94,7 +94,7 @@ static apr_status_t unixd_set_shm_perms(const char *fname)
     int shmid;
 
     shmkey = ftok(fname, 1);
-    if (shmkey == (key_t) - 1) {
+    if (shmkey == (key_t)-1) {
         return errno;
     }
     if ((shmid = shmget(shmkey, 0, SHM_R | SHM_W)) == -1) {
@@ -172,7 +172,7 @@ static void restore_slotmem(void *ptr, const char *name, apr_size_t item_size, i
     if (rv == APR_SUCCESS) {
         apr_finfo_t fi;
         if (apr_file_info_get(&fi, APR_FINFO_SIZE, fp) == APR_SUCCESS) {
-            if (fi.size == (apr_off_t) nbytes) {
+            if (fi.size == (apr_off_t)nbytes) {
                 apr_file_read(fp, ptr, &nbytes);
             }
             else {
@@ -299,7 +299,7 @@ static apr_status_t ap_slotmem_create(ap_slotmem_t **new, const char *name, apr_
     }
 
     /* create the lock file and the global mutex */
-    res = (ap_slotmem_t *) apr_pcalloc(globalpool, sizeof(ap_slotmem_t));
+    res = (ap_slotmem_t *)apr_pcalloc(globalpool, sizeof(ap_slotmem_t));
     filename = apr_pstrcat(pool, fname, ".lock", NULL);
     rv = apr_file_open(&res->global_lock, filename, APR_WRITE | APR_CREATE, APR_OS_DEFAULT, globalpool);
     if (rv != APR_SUCCESS) {
@@ -444,7 +444,7 @@ static apr_status_t ap_slotmem_attach(ap_slotmem_t **new, const char *name, apr_
     }
 
     /* first try to attach to existing shared memory */
-    res = (ap_slotmem_t *) apr_pcalloc(globalpool, sizeof(ap_slotmem_t));
+    res = (ap_slotmem_t *)apr_pcalloc(globalpool, sizeof(ap_slotmem_t));
     rv = apr_shm_attach(&res->shm, fname, globalpool);
     if (rv != APR_SUCCESS) {
         return rv;
@@ -528,7 +528,7 @@ static apr_status_t ap_slotmem_alloc(ap_slotmem_t *score, int *item_id, void **m
             ff = ident[id];
         }
         if (ff != *item_id)
-            return APR_ENOMEM;  /* already in use!!! */
+            return APR_ENOMEM; /* already in use!!! */
     }
     ff = ident[id];
     if (ff > score->num) {

--- a/native/mod_manager/balancer.c
+++ b/native/mod_manager/balancer.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -80,8 +80,8 @@ static mem_t *create_attach_mem_balancer(char *string, int *num, int type, apr_p
  */
 static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    balancerinfo_t *in = (balancerinfo_t *) *data;
-    balancerinfo_t *ou = (balancerinfo_t *) mem;
+    balancerinfo_t *in = (balancerinfo_t *)*data;
+    balancerinfo_t *ou = (balancerinfo_t *)mem;
     (void)pool;
 
     if (strcmp(in->balancer, ou->balancer) == 0) {
@@ -103,7 +103,7 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
     balancer->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &balancer, s->p);
     if (balancer->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS;     /* updated */
+        return APR_SUCCESS; /* updated */
     }
 
     /* we have to insert it */
@@ -126,8 +126,8 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
  */
 static apr_status_t loc_read_balancer(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    balancerinfo_t *in = (balancerinfo_t *) *data;
-    balancerinfo_t *ou = (balancerinfo_t *) mem;
+    balancerinfo_t *in = (balancerinfo_t *)*data;
+    balancerinfo_t *ou = (balancerinfo_t *)mem;
     (void)id;
     (void)pool;
 

--- a/native/mod_manager/balancer.c
+++ b/native/mod_manager/balancer.c
@@ -44,7 +44,9 @@
 
 #include "mod_manager.h"
 
-static mem_t * create_attach_mem_balancer(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage) {
+static mem_t *create_attach_mem_balancer(char *string, int *num, int type, apr_pool_t *p,
+                                         slotmem_storage_method *storage)
+{
     mem_t *ptr;
     const char *storename;
     apr_status_t rv;
@@ -53,8 +55,8 @@ static mem_t * create_attach_mem_balancer(char *string, int *num, int type, apr_
     if (!ptr) {
         return NULL;
     }
-    ptr->storage =  storage;
-    storename = apr_pstrcat(p, string, BALANCEREXE, NULL); 
+    ptr->storage = storage;
+    storename = apr_pstrcat(p, string, BALANCEREXE, NULL);
     if (type)
         rv = ptr->storage->ap_slotmem_create(&ptr->slotmem, storename, sizeof(balancerinfo_t), *num, type, p);
     else {
@@ -68,6 +70,7 @@ static mem_t * create_attach_mem_balancer(char *string, int *num, int type, apr_
     ptr->p = p;
     return ptr;
 }
+
 /**
  * Insert(alloc) and update a balancer record in the shared table
  * @param pointer to the shared table.
@@ -75,11 +78,11 @@ static mem_t * create_attach_mem_balancer(char *string, int *num, int type, apr_
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    balancerinfo_t *in = (balancerinfo_t *)*data;
-    balancerinfo_t *ou = (balancerinfo_t *)mem;
-    (void) pool;
+    balancerinfo_t *in = (balancerinfo_t *) *data;
+    balancerinfo_t *ou = (balancerinfo_t *) mem;
+    (void)pool;
 
     if (strcmp(in->balancer, ou->balancer) == 0) {
         memcpy(ou, in, sizeof(balancerinfo_t));
@@ -90,6 +93,7 @@ static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *po
     }
     return APR_NOTFOUND;
 }
+
 apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
 {
     apr_status_t rv;
@@ -99,11 +103,11 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
     balancer->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &balancer, s->p);
     if (balancer->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS; /* updated */
+        return APR_SUCCESS;     /* updated */
     }
 
     /* we have to insert it */
-    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **) &ou);
+    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **)&ou);
     if (rv != APR_SUCCESS) {
         return rv;
     }
@@ -120,10 +124,12 @@ apr_status_t insert_update_balancer(mem_t *s, balancerinfo_t *balancer)
  * @param balancer balancer to read from the shared table.
  * @return address of the read balancer or NULL if error.
  */
-static apr_status_t loc_read_balancer(void* mem, void **data, int id, apr_pool_t *pool) {
-    balancerinfo_t *in = (balancerinfo_t *)*data;
-    balancerinfo_t *ou = (balancerinfo_t *)mem;
-    (void) id; (void) pool;
+static apr_status_t loc_read_balancer(void *mem, void **data, int id, apr_pool_t *pool)
+{
+    balancerinfo_t *in = (balancerinfo_t *) *data;
+    balancerinfo_t *ou = (balancerinfo_t *) mem;
+    (void)id;
+    (void)pool;
 
     if (strcmp(in->balancer, ou->balancer) == 0) {
         *data = ou;
@@ -131,13 +137,14 @@ static apr_status_t loc_read_balancer(void* mem, void **data, int id, apr_pool_t
     }
     return APR_NOTFOUND;
 }
-balancerinfo_t * read_balancer(mem_t *s, balancerinfo_t *balancer)
+
+balancerinfo_t *read_balancer(mem_t *s, balancerinfo_t *balancer)
 {
     apr_status_t rv;
     balancerinfo_t *ou = balancer;
 
     if (balancer->id)
-        rv = s->storage->ap_slotmem_mem(s->slotmem, balancer->id, (void **) &ou);
+        rv = s->storage->ap_slotmem_mem(s->slotmem, balancer->id, (void **)&ou);
     else {
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_balancer, &ou, s->p);
     }
@@ -145,6 +152,7 @@ balancerinfo_t * read_balancer(mem_t *s, balancerinfo_t *balancer)
         return ou;
     return NULL;
 }
+
 /**
  * get a balancer record from the shared table
  * @param pointer to the shared table.
@@ -154,7 +162,7 @@ balancerinfo_t * read_balancer(mem_t *s, balancerinfo_t *balancer)
  */
 apr_status_t get_balancer(mem_t *s, balancerinfo_t **balancer, int ids)
 {
-  return(s->storage->ap_slotmem_mem(s->slotmem, ids, (void **) balancer));
+    return s->storage->ap_slotmem_mem(s->slotmem, ids, (void **)balancer);
 }
 
 /**
@@ -169,7 +177,8 @@ apr_status_t remove_balancer(mem_t *s, balancerinfo_t *balancer)
     balancerinfo_t *ou = balancer;
     if (balancer->id) {
         rv = s->storage->ap_slotmem_free(s->slotmem, balancer->id, balancer);
-    } else {
+    }
+    else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_balancer, &ou, s->p);
         if (rv == APR_SUCCESS)
@@ -186,7 +195,7 @@ apr_status_t remove_balancer(mem_t *s, balancerinfo_t *balancer)
  */
 int get_ids_used_balancer(mem_t *s, int *ids)
 {
-    return (s->storage->ap_slotmem_get_used(s->slotmem, ids));
+    return s->storage->ap_slotmem_get_used(s->slotmem, ids);
 }
 
 /*
@@ -196,7 +205,7 @@ int get_ids_used_balancer(mem_t *s, int *ids)
  */
 int get_max_size_balancer(mem_t *s)
 {
-    return (s->storage->ap_slotmem_get_max_size(s->slotmem));
+    return s->storage->ap_slotmem_get_max_size(s->slotmem);
 }
 
 /**
@@ -207,10 +216,11 @@ int get_max_size_balancer(mem_t *s)
  * @param storage slotmem logic provider.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_balancer(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *get_mem_balancer(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_balancer(string, num, 0, p, storage));
+    return create_attach_mem_balancer(string, num, 0, p, storage);
 }
+
 /**
  * create a shared balancer table
  * @param name to use to create the table.
@@ -220,7 +230,7 @@ mem_t * get_mem_balancer(char *string, int *num, apr_pool_t *p, slotmem_storage_
  * @param storage slotmem logic provider.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_balancer(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *create_mem_balancer(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_balancer(string, num, CREATE_SLOTMEM|persist, p, storage));
+    return create_attach_mem_balancer(string, num, CREATE_SLOTMEM | persist, p, storage);
 }

--- a/native/mod_manager/context.c
+++ b/native/mod_manager/context.c
@@ -44,7 +44,9 @@
 
 #include "mod_manager.h"
 
-static mem_t * create_attach_mem_context(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage) {
+static mem_t *create_attach_mem_context(char *string, int *num, int type, apr_pool_t *p,
+                                        slotmem_storage_method *storage)
+{
     mem_t *ptr;
     const char *storename;
     apr_status_t rv;
@@ -53,8 +55,8 @@ static mem_t * create_attach_mem_context(char *string, int *num, int type, apr_p
     if (!ptr) {
         return NULL;
     }
-    ptr->storage =  storage;
-    storename = apr_pstrcat(p, string, CONTEXTEXE, NULL); 
+    ptr->storage = storage;
+    storename = apr_pstrcat(p, string, CONTEXTEXE, NULL);
     if (type)
         rv = ptr->storage->ap_slotmem_create(&ptr->slotmem, storename, sizeof(contextinfo_t), *num, type, p);
     else {
@@ -68,6 +70,7 @@ static mem_t * create_attach_mem_context(char *string, int *num, int type, apr_p
     ptr->p = p;
     return ptr;
 }
+
 /**
  * Insert(alloc) and update a context record in the shared table
  * @param pointer to the shared table.
@@ -75,14 +78,13 @@ static mem_t * create_attach_mem_context(char *string, int *num, int type, apr_p
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    contextinfo_t *in = (contextinfo_t *)*data;
-    contextinfo_t *ou = (contextinfo_t *)mem;
-    (void) pool;
+    contextinfo_t *in = (contextinfo_t *) *data;
+    contextinfo_t *ou = (contextinfo_t *) mem;
+    (void)pool;
 
-    if (strcmp(in->context, ou->context) == 0 &&
-               in->vhost == ou->vhost && in->node == ou->node) {
+    if (strcmp(in->context, ou->context) == 0 && in->vhost == ou->vhost && in->node == ou->node) {
         /* We don't update nbrequests it belongs to mod_proxy_cluster logic */
         ou->status = in->status;
         ou->id = id;
@@ -92,6 +94,7 @@ static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *po
     }
     return APR_NOTFOUND;
 }
+
 apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
 {
     apr_status_t rv;
@@ -101,11 +104,11 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
     context->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &context, s->p);
     if (context->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS; /* updated */
+        return APR_SUCCESS;     /* updated */
     }
 
     /* we have to insert it */
-    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **) &ou);
+    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **)&ou);
     if (rv != APR_SUCCESS) {
         return rv;
     }
@@ -123,25 +126,27 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
  * @param context context to read from the shared table.
  * @return address of the read context or NULL if error.
  */
-static apr_status_t loc_read_context(void* mem, void **data, int id, apr_pool_t *pool) {
-    contextinfo_t *in = (contextinfo_t *)*data;
-    contextinfo_t *ou = (contextinfo_t *)mem;
-    (void) id; (void) pool;
+static apr_status_t loc_read_context(void *mem, void **data, int id, apr_pool_t *pool)
+{
+    contextinfo_t *in = (contextinfo_t *) *data;
+    contextinfo_t *ou = (contextinfo_t *) mem;
+    (void)id;
+    (void)pool;
 
-    if (strcmp(in->context, ou->context) == 0 &&
-        in->vhost == ou->vhost && ou->node == in->node) {
+    if (strcmp(in->context, ou->context) == 0 && in->vhost == ou->vhost && ou->node == in->node) {
         *data = ou;
         return APR_SUCCESS;
     }
     return APR_NOTFOUND;
 }
-contextinfo_t * read_context(mem_t *s, contextinfo_t *context)
+
+contextinfo_t *read_context(mem_t *s, contextinfo_t *context)
 {
     apr_status_t rv;
     contextinfo_t *ou = context;
 
     if (context->id)
-        rv = s->storage->ap_slotmem_mem(s->slotmem, context->id, (void **) &ou);
+        rv = s->storage->ap_slotmem_mem(s->slotmem, context->id, (void **)&ou);
     else {
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_context, &ou, s->p);
     }
@@ -149,6 +154,7 @@ contextinfo_t * read_context(mem_t *s, contextinfo_t *context)
         return ou;
     return NULL;
 }
+
 /**
  * get a context record from the shared table
  * @param pointer to the shared table.
@@ -158,7 +164,7 @@ contextinfo_t * read_context(mem_t *s, contextinfo_t *context)
  */
 apr_status_t get_context(mem_t *s, contextinfo_t **context, int ids)
 {
-  return(s->storage->ap_slotmem_mem(s->slotmem, ids, (void **) context));
+    return s->storage->ap_slotmem_mem(s->slotmem, ids, (void **)context);
 }
 
 /**
@@ -173,7 +179,8 @@ apr_status_t remove_context(mem_t *s, contextinfo_t *context)
     contextinfo_t *ou = context;
     if (context->id) {
         rv = s->storage->ap_slotmem_free(s->slotmem, context->id, context);
-    } else {
+    }
+    else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_context, &ou, s->p);
         if (rv == APR_SUCCESS)
@@ -190,7 +197,7 @@ apr_status_t remove_context(mem_t *s, contextinfo_t *context)
  */
 int get_ids_used_context(mem_t *s, int *ids)
 {
-    return (s->storage->ap_slotmem_get_used(s->slotmem, ids));
+    return s->storage->ap_slotmem_get_used(s->slotmem, ids);
 }
 
 /*
@@ -200,7 +207,7 @@ int get_ids_used_context(mem_t *s, int *ids)
  */
 int get_max_size_context(mem_t *s)
 {
-    return (s->storage->ap_slotmem_get_max_size(s->slotmem));
+    return s->storage->ap_slotmem_get_max_size(s->slotmem);
 }
 
 /**
@@ -211,10 +218,11 @@ int get_max_size_context(mem_t *s)
  * @param storage slotmem logic provider.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_context(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *get_mem_context(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_context(string, num, 0, p, storage));
+    return create_attach_mem_context(string, num, 0, p, storage);
 }
+
 /**
  * create a shared context table
  * @param name to use to create the table.
@@ -224,7 +232,7 @@ mem_t * get_mem_context(char *string, int *num, apr_pool_t *p, slotmem_storage_m
  * @param storage slotmem logic provider.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_context(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *create_mem_context(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_context(string, num, CREATE_SLOTMEM|persist, p, storage));
+    return create_attach_mem_context(string, num, CREATE_SLOTMEM | persist, p, storage);
 }

--- a/native/mod_manager/context.c
+++ b/native/mod_manager/context.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -80,8 +80,8 @@ static mem_t *create_attach_mem_context(char *string, int *num, int type, apr_po
  */
 static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    contextinfo_t *in = (contextinfo_t *) *data;
-    contextinfo_t *ou = (contextinfo_t *) mem;
+    contextinfo_t *in = (contextinfo_t *)*data;
+    contextinfo_t *ou = (contextinfo_t *)mem;
     (void)pool;
 
     if (strcmp(in->context, ou->context) == 0 && in->vhost == ou->vhost && in->node == ou->node) {
@@ -104,7 +104,7 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
     context->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &context, s->p);
     if (context->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS;     /* updated */
+        return APR_SUCCESS; /* updated */
     }
 
     /* we have to insert it */
@@ -128,8 +128,8 @@ apr_status_t insert_update_context(mem_t *s, contextinfo_t *context)
  */
 static apr_status_t loc_read_context(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    contextinfo_t *in = (contextinfo_t *) *data;
-    contextinfo_t *ou = (contextinfo_t *) mem;
+    contextinfo_t *in = (contextinfo_t *)*data;
+    contextinfo_t *ou = (contextinfo_t *)mem;
     (void)id;
     (void)pool;
 

--- a/native/mod_manager/domain.c
+++ b/native/mod_manager/domain.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2009 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -79,8 +79,8 @@ static mem_t *create_attach_mem_domain(char *string, int *num, int type, apr_poo
  */
 static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    domaininfo_t *in = (domaininfo_t *) *data;
-    domaininfo_t *ou = (domaininfo_t *) mem;
+    domaininfo_t *in = (domaininfo_t *)*data;
+    domaininfo_t *ou = (domaininfo_t *)mem;
     (void)pool;
 
     if (strcmp(in->JVMRoute, ou->JVMRoute) == 0 && strcmp(in->balancer, ou->balancer) == 0) {
@@ -102,7 +102,7 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
     domain->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &domain, s->p);
     if (domain->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS;     /* updated */
+        return APR_SUCCESS; /* updated */
     }
 
     /* we have to insert it */
@@ -125,8 +125,8 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
  */
 static apr_status_t loc_read_domain(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    domaininfo_t *in = (domaininfo_t *) *data;
-    domaininfo_t *ou = (domaininfo_t *) mem;
+    domaininfo_t *in = (domaininfo_t *)*data;
+    domaininfo_t *ou = (domaininfo_t *)mem;
     (void)id;
     (void)pool;
 

--- a/native/mod_manager/domain.c
+++ b/native/mod_manager/domain.c
@@ -44,7 +44,8 @@
 
 #include "mod_manager.h"
 
-static mem_t * create_attach_mem_domain(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage) {
+static mem_t *create_attach_mem_domain(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage)
+{
     mem_t *ptr;
     const char *storename;
     apr_status_t rv;
@@ -53,8 +54,8 @@ static mem_t * create_attach_mem_domain(char *string, int *num, int type, apr_po
     if (!ptr) {
         return NULL;
     }
-    ptr->storage =  storage;
-    storename = apr_pstrcat(p, string, DOMAINEXE, NULL); 
+    ptr->storage = storage;
+    storename = apr_pstrcat(p, string, DOMAINEXE, NULL);
     if (type)
         rv = ptr->storage->ap_slotmem_create(&ptr->slotmem, storename, sizeof(domaininfo_t), *num, type, p);
     else {
@@ -68,6 +69,7 @@ static mem_t * create_attach_mem_domain(char *string, int *num, int type, apr_po
     ptr->p = p;
     return ptr;
 }
+
 /**
  * Insert(alloc) and update a domain record in the shared table
  * @param pointer to the shared table.
@@ -75,11 +77,11 @@ static mem_t * create_attach_mem_domain(char *string, int *num, int type, apr_po
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    domaininfo_t *in = (domaininfo_t *)*data;
-    domaininfo_t *ou = (domaininfo_t *)mem;
-    (void) pool;
+    domaininfo_t *in = (domaininfo_t *) *data;
+    domaininfo_t *ou = (domaininfo_t *) mem;
+    (void)pool;
 
     if (strcmp(in->JVMRoute, ou->JVMRoute) == 0 && strcmp(in->balancer, ou->balancer) == 0) {
         memcpy(ou, in, sizeof(domaininfo_t));
@@ -90,6 +92,7 @@ static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *po
     }
     return APR_NOTFOUND;
 }
+
 apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
 {
     apr_status_t rv;
@@ -99,11 +102,11 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
     domain->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &domain, s->p);
     if (domain->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS; /* updated */
+        return APR_SUCCESS;     /* updated */
     }
 
     /* we have to insert it */
-    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **) &ou);
+    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **)&ou);
     if (rv != APR_SUCCESS) {
         return rv;
     }
@@ -120,10 +123,12 @@ apr_status_t insert_update_domain(mem_t *s, domaininfo_t *domain)
  * @param domain domain to read from the shared table.
  * @return address of the read domain or NULL if error.
  */
-static apr_status_t loc_read_domain(void* mem, void **data, int id, apr_pool_t *pool) {
-    domaininfo_t *in = (domaininfo_t *)*data;
-    domaininfo_t *ou = (domaininfo_t *)mem;
-    (void) id; (void) pool;
+static apr_status_t loc_read_domain(void *mem, void **data, int id, apr_pool_t *pool)
+{
+    domaininfo_t *in = (domaininfo_t *) *data;
+    domaininfo_t *ou = (domaininfo_t *) mem;
+    (void)id;
+    (void)pool;
 
     if (strcmp(in->JVMRoute, ou->JVMRoute) == 0 && strcmp(in->balancer, ou->balancer) == 0) {
         *data = ou;
@@ -131,13 +136,14 @@ static apr_status_t loc_read_domain(void* mem, void **data, int id, apr_pool_t *
     }
     return APR_NOTFOUND;
 }
-domaininfo_t * read_domain(mem_t *s, domaininfo_t *domain)
+
+domaininfo_t *read_domain(mem_t *s, domaininfo_t *domain)
 {
     apr_status_t rv;
     domaininfo_t *ou = domain;
 
     if (domain->id)
-        rv = s->storage->ap_slotmem_mem(s->slotmem, domain->id, (void **) &ou);
+        rv = s->storage->ap_slotmem_mem(s->slotmem, domain->id, (void **)&ou);
     else {
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, &ou, s->p);
     }
@@ -145,6 +151,7 @@ domaininfo_t * read_domain(mem_t *s, domaininfo_t *domain)
         return ou;
     return NULL;
 }
+
 /**
  * get a domain record from the shared table
  * @param pointer to the shared table.
@@ -154,7 +161,7 @@ domaininfo_t * read_domain(mem_t *s, domaininfo_t *domain)
  */
 apr_status_t get_domain(mem_t *s, domaininfo_t **domain, int ids)
 {
-  return(s->storage->ap_slotmem_mem(s->slotmem, ids, (void **) domain));
+    return s->storage->ap_slotmem_mem(s->slotmem, ids, (void **)domain);
 }
 
 /**
@@ -169,7 +176,8 @@ apr_status_t remove_domain(mem_t *s, domaininfo_t *domain)
     domaininfo_t *ou = domain;
     if (domain->id) {
         rv = s->storage->ap_slotmem_free(s->slotmem, domain->id, domain);
-    } else {
+    }
+    else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_domain, &ou, s->p);
         if (rv == APR_SUCCESS)
@@ -208,7 +216,7 @@ apr_status_t find_domain(mem_t *s, domaininfo_t **domain, const char *route, con
  */
 int get_ids_used_domain(mem_t *s, int *ids)
 {
-    return (s->storage->ap_slotmem_get_used(s->slotmem, ids));
+    return s->storage->ap_slotmem_get_used(s->slotmem, ids);
 }
 
 /*
@@ -218,7 +226,7 @@ int get_ids_used_domain(mem_t *s, int *ids)
  */
 int get_max_size_domain(mem_t *s)
 {
-    return (s->storage->ap_slotmem_get_max_size(s->slotmem));
+    return s->storage->ap_slotmem_get_max_size(s->slotmem);
 }
 
 /**
@@ -228,10 +236,11 @@ int get_max_size_domain(mem_t *s)
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_domain(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *get_mem_domain(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_domain(string, num, 0, p, storage));
+    return create_attach_mem_domain(string, num, 0, p, storage);
 }
+
 /**
  * create a shared domain table
  * @param name to use to create the table.
@@ -240,7 +249,7 @@ mem_t * get_mem_domain(char *string, int *num, apr_pool_t *p, slotmem_storage_me
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_domain(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *create_mem_domain(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_domain(string, num, CREATE_SLOTMEM|persist, p, storage));
+    return create_attach_mem_domain(string, num, CREATE_SLOTMEM | persist, p, storage);
 }

--- a/native/mod_manager/host.c
+++ b/native/mod_manager/host.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -79,8 +79,8 @@ static mem_t *create_attach_mem_host(char *string, int *num, int type, apr_pool_
  */
 static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    hostinfo_t *in = (hostinfo_t *) *data;
-    hostinfo_t *ou = (hostinfo_t *) mem;
+    hostinfo_t *in = (hostinfo_t *)*data;
+    hostinfo_t *ou = (hostinfo_t *)mem;
     (void)pool;
 
     if (strcmp(in->host, ou->host) == 0 && in->vhost == ou->vhost && in->node == ou->node) {
@@ -102,7 +102,7 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
     host->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &host, s->p);
     if (host->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS;     /* updated */
+        return APR_SUCCESS; /* updated */
     }
 
     /* we have to insert it */
@@ -125,8 +125,8 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
  */
 static apr_status_t loc_read_host(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    hostinfo_t *in = (hostinfo_t *) *data;
-    hostinfo_t *ou = (hostinfo_t *) mem;
+    hostinfo_t *in = (hostinfo_t *)*data;
+    hostinfo_t *ou = (hostinfo_t *)mem;
     (void)id;
     (void)pool;
 

--- a/native/mod_manager/host.c
+++ b/native/mod_manager/host.c
@@ -44,7 +44,8 @@
 
 #include "mod_manager.h"
 
-static mem_t * create_attach_mem_host(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage) {
+static mem_t *create_attach_mem_host(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage)
+{
     mem_t *ptr;
     const char *storename;
     apr_status_t rv;
@@ -53,8 +54,8 @@ static mem_t * create_attach_mem_host(char *string, int *num, int type, apr_pool
     if (!ptr) {
         return NULL;
     }
-    ptr->storage =  storage;
-    storename = apr_pstrcat(p, string, HOSTEXE, NULL); 
+    ptr->storage = storage;
+    storename = apr_pstrcat(p, string, HOSTEXE, NULL);
     if (type)
         rv = ptr->storage->ap_slotmem_create(&ptr->slotmem, storename, sizeof(hostinfo_t), *num, type, p);
     else {
@@ -68,6 +69,7 @@ static mem_t * create_attach_mem_host(char *string, int *num, int type, apr_pool
     ptr->p = p;
     return ptr;
 }
+
 /**
  * Insert(alloc) and update a host record in the shared table
  * @param pointer to the shared table.
@@ -75,11 +77,11 @@ static mem_t * create_attach_mem_host(char *string, int *num, int type, apr_pool
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    hostinfo_t *in = (hostinfo_t *)*data;
-    hostinfo_t *ou = (hostinfo_t *)mem;
-    (void) pool;
+    hostinfo_t *in = (hostinfo_t *) *data;
+    hostinfo_t *ou = (hostinfo_t *) mem;
+    (void)pool;
 
     if (strcmp(in->host, ou->host) == 0 && in->vhost == ou->vhost && in->node == ou->node) {
         memcpy(ou, in, sizeof(hostinfo_t));
@@ -90,6 +92,7 @@ static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *po
     }
     return APR_NOTFOUND;
 }
+
 apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
 {
     apr_status_t rv;
@@ -99,11 +102,11 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
     host->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &host, s->p);
     if (host->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS; /* updated */
+        return APR_SUCCESS;     /* updated */
     }
 
     /* we have to insert it */
-    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **) &ou);
+    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **)&ou);
     if (rv != APR_SUCCESS) {
         return rv;
     }
@@ -120,24 +123,27 @@ apr_status_t insert_update_host(mem_t *s, hostinfo_t *host)
  * @param host host to read from the shared table.
  * @return address of the read host or NULL if error.
  */
-static apr_status_t loc_read_host(void* mem, void **data, int id, apr_pool_t *pool) {
-    hostinfo_t *in = (hostinfo_t *)*data;
-    hostinfo_t *ou = (hostinfo_t *)mem;
-    (void) id; (void) pool;
+static apr_status_t loc_read_host(void *mem, void **data, int id, apr_pool_t *pool)
+{
+    hostinfo_t *in = (hostinfo_t *) *data;
+    hostinfo_t *ou = (hostinfo_t *) mem;
+    (void)id;
+    (void)pool;
 
-    if (strcmp(in->host, ou->host) == 0 && in->node == ou->node ) {
+    if (strcmp(in->host, ou->host) == 0 && in->node == ou->node) {
         *data = ou;
         return APR_SUCCESS;
     }
     return APR_NOTFOUND;
 }
-hostinfo_t * read_host(mem_t *s, hostinfo_t *host)
+
+hostinfo_t *read_host(mem_t *s, hostinfo_t *host)
 {
     apr_status_t rv;
     hostinfo_t *ou = host;
 
     if (host->id)
-        rv = s->storage->ap_slotmem_mem(s->slotmem, host->id, (void **) &ou);
+        rv = s->storage->ap_slotmem_mem(s->slotmem, host->id, (void **)&ou);
     else {
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_host, &ou, s->p);
     }
@@ -145,6 +151,7 @@ hostinfo_t * read_host(mem_t *s, hostinfo_t *host)
         return ou;
     return NULL;
 }
+
 /**
  * get a host record from the shared table
  * @param pointer to the shared table.
@@ -154,7 +161,7 @@ hostinfo_t * read_host(mem_t *s, hostinfo_t *host)
  */
 apr_status_t get_host(mem_t *s, hostinfo_t **host, int ids)
 {
-  return(s->storage->ap_slotmem_mem(s->slotmem, ids, (void **) host));
+    return s->storage->ap_slotmem_mem(s->slotmem, ids, (void **)host);
 }
 
 /**
@@ -169,7 +176,8 @@ apr_status_t remove_host(mem_t *s, hostinfo_t *host)
     hostinfo_t *ou = host;
     if (host->id) {
         rv = s->storage->ap_slotmem_free(s->slotmem, host->id, host);
-    } else {
+    }
+    else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_host, &ou, s->p);
         if (rv == APR_SUCCESS)
@@ -186,7 +194,7 @@ apr_status_t remove_host(mem_t *s, hostinfo_t *host)
  */
 int get_ids_used_host(mem_t *s, int *ids)
 {
-    return (s->storage->ap_slotmem_get_used(s->slotmem, ids));
+    return s->storage->ap_slotmem_get_used(s->slotmem, ids);
 }
 
 /*
@@ -196,7 +204,7 @@ int get_ids_used_host(mem_t *s, int *ids)
  */
 int get_max_size_host(mem_t *s)
 {
-    return (s->storage->ap_slotmem_get_max_size(s->slotmem));
+    return s->storage->ap_slotmem_get_max_size(s->slotmem);
 }
 
 /**
@@ -206,10 +214,11 @@ int get_max_size_host(mem_t *s)
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_host(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *get_mem_host(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_host(string, num, 0, p, storage));
+    return create_attach_mem_host(string, num, 0, p, storage);
 }
+
 /**
  * create a shared host table
  * @param name to use to create the table.
@@ -218,7 +227,7 @@ mem_t * get_mem_host(char *string, int *num, apr_pool_t *p, slotmem_storage_meth
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_host(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *create_mem_host(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_host(string, num, CREATE_SLOTMEM|persist, p, storage));
+    return create_attach_mem_host(string, num, CREATE_SLOTMEM | persist, p, storage);
 }

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -330,7 +330,7 @@ static const struct node_storage_method node_storage = {
     loc_find_node,
     loc_remove_host_context,
     loc_lock_nodes,
-    loc_unlock_nodes
+    loc_unlock_nodes,
 };
 
 /*
@@ -356,6 +356,7 @@ static apr_status_t loc_unlock_contexts(void)
     return apr_global_mutex_unlock(context_mutex);
 }
 
+// clang-format off
 static const struct context_storage_method context_storage = {
     loc_read_context,
     loc_get_ids_used_context,
@@ -363,6 +364,7 @@ static const struct context_storage_method context_storage = {
     loc_lock_contexts,
     loc_unlock_contexts
 };
+// clang-format on
 
 /*
  * routines for the host_storage_method
@@ -380,7 +382,7 @@ static int loc_get_ids_used_host(int *ids)
 static const struct host_storage_method host_storage = {
     loc_read_host,
     loc_get_ids_used_host,
-    loc_get_max_size_host
+    loc_get_max_size_host,
 };
 
 /*
@@ -404,7 +406,7 @@ static int loc_get_max_size_balancer(void)
 static const struct balancer_storage_method balancer_storage = {
     loc_read_balancer,
     loc_get_ids_used_balancer,
-    loc_get_max_size_balancer
+    loc_get_max_size_balancer,
 };
 
 /*
@@ -440,7 +442,7 @@ static const struct sessionid_storage_method sessionid_storage = {
     loc_get_ids_used_sessionid,
     loc_get_max_size_sessionid,
     loc_remove_sessionid,
-    loc_insert_update_sessionid
+    loc_insert_update_sessionid,
 };
 
 /*
@@ -476,14 +478,16 @@ static apr_status_t loc_find_domain(domaininfo_t **domain, const char *route, co
     return find_domain(domainstatsmem, domain, route, balancer);
 }
 
+// clang-format off
 static const struct domain_storage_method domain_storage = {
     loc_read_domain,
     loc_get_ids_used_domain,
     loc_get_max_size_domain,
     loc_remove_domain,
     loc_insert_update_domain,
-    loc_find_domain
+    loc_find_domain,
 };
+// clang-format on
 
 /* helper for the handling of the Alias: host1,... Context: context1,... */
 struct cluster_host
@@ -1328,10 +1332,10 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
             clean = 0;
             ap_assert(worker->s->port != 0);
             pptr = (char *)&nodeinfo;
-            offset = sizeof(nodemess_t) + sizeof(apr_time_t) + sizeof(int);     /* nodeinfo.offset doesn't contain the information */
+            offset = sizeof(nodemess_t) + sizeof(apr_time_t) + sizeof(int); /* nodeinfo.offset doesn't contain the information */
             offset = APR_ALIGN_DEFAULT(offset);
             pptr = pptr + offset;
-            memcpy(pptr, worker->s, sizeof(proxy_worker_shared));       /* restore the information we are going to reuse */
+            memcpy(pptr, worker->s, sizeof(proxy_worker_shared));   /* restore the information we are going to reuse */
             ap_assert(the_conf);
         }
     }
@@ -2871,7 +2875,7 @@ static char *process_domain(request_rec *r, char **ptr, int *errtype, const char
     id = apr_palloc(r->pool, sizeof(int) * size);
     size = get_ids_used_node(nodestatsmem, id);
 
-    for (pos = 0; ptr[pos] != NULL && ptr[pos + 1] != NULL; pos = pos + 2);
+    for (pos = 0; ptr[pos] != NULL && ptr[pos + 1] != NULL; pos = pos + 2) {}
 
     ptr[pos] = apr_pstrdup(r->pool, "JVMRoute");
     ptr[pos + 2] = NULL;
@@ -3744,7 +3748,7 @@ static const command_rec manager_cmds[] = {
                   NULL,
                   OR_ALL,
                   "ResponseFieldSize - Adjust the size of the proxy response field buffer."),
-    {NULL}
+    {NULL},
 };
 
 /* hooks declaration */
@@ -3923,5 +3927,5 @@ module AP_MODULE_DECLARE_DATA manager_module = {
     merge_manager_server_config,
     manager_cmds,               /* command table */
     manager_hooks,              /* register hooks */
-    AP_MODULE_FLAG_NONE         /* flags */
+    AP_MODULE_FLAG_NONE,       /* flags */
 };

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -55,7 +55,7 @@
 #define DEFMAXCONTEXT   100
 #define DEFMAXNODE      20
 #define DEFMAXHOST      20
-#define DEFMAXSESSIONID 0 /* it has performance/security impact */
+#define DEFMAXSESSIONID 0       /* it has performance/security impact */
 #define MAXMESSSIZE     1024
 
 /* Warning messages */
@@ -116,7 +116,8 @@
 #define TEXT_XML 2
 
 /* Data structure for shared memory block */
-typedef struct version_data {
+typedef struct version_data
+{
     apr_uint64_t counter;
 } version_data;
 
@@ -177,7 +178,7 @@ typedef struct mod_manager_config
     /* allow command logic */
     int allow_cmd;
     /* don't context in first status page */
-    int reduce_display;  
+    int reduce_display;
     /* maximum message size */
     int maxmesssize;
     /* Enable MCPM receiver */
@@ -193,31 +194,30 @@ typedef struct mod_manager_config
 
 } mod_manager_config;
 
-/*
- * routines for the node_storage_method
- */
+/* routines for the node_storage_method */
 static apr_status_t loc_read_node(int ids, nodeinfo_t **node)
 {
-    return (get_node(nodestatsmem, node, ids));
+    return get_node(nodestatsmem, node, ids);
 }
+
 static int loc_get_ids_used_node(int *ids)
 {
-    return(get_ids_used_node(nodestatsmem, ids)); 
+    return get_ids_used_node(nodestatsmem, ids);
 }
+
 static int loc_get_max_size_node(void)
 {
-    if (nodestatsmem)
-        return(get_max_size_node(nodestatsmem));
-    else
-        return 0;
+    return nodestatsmem ? get_max_size_node(nodestatsmem) : 0;
 }
+
 static apr_status_t loc_remove_node(int id)
 {
-    return (remove_node(nodestatsmem, id));
+    return remove_node(nodestatsmem, id);
 }
+
 static apr_status_t loc_find_node(nodeinfo_t **node, const char *route)
 {
-    return (find_node(nodestatsmem, node, route));
+    return find_node(nodestatsmem, node, route);
 }
 
 /*
@@ -226,7 +226,7 @@ static apr_status_t loc_find_node(nodeinfo_t **node, const char *route)
 static void inc_version_node(void)
 {
     version_data *base;
-    base = (version_data *)apr_shm_baseaddr_get(versionipc_shm);
+    base = (version_data *) apr_shm_baseaddr_get(versionipc_shm);
     base->counter++;
 }
 
@@ -243,49 +243,49 @@ static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
     unsigned int last = 0;
     version_data *base;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
-    (void) pool;
+    (void)pool;
 
     size = loc_get_max_size_node();
     if (size == 0)
-        return 0; /* broken */
+        return 0;               /* broken */
 
-    base = (version_data *)apr_shm_baseaddr_get(versionipc_shm);
+    base = (version_data *) apr_shm_baseaddr_get(versionipc_shm);
     last = base->counter;
 
     if (last != mconf->tableversion)
         return last;
-    return (0);
+    return 0;
 }
+
 /* Store the last version update in the proccess config */
 static int loc_worker_nodes_are_updated(void *data, unsigned int last)
 {
     server_rec *s = (server_rec *) data;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
     mconf->tableversion = last;
-    return (0);
+    return 0;
 }
+
 static apr_status_t loc_lock_nodes(void)
 {
-    return(apr_global_mutex_lock(node_mutex));
+    return apr_global_mutex_lock(node_mutex);
 }
+
 static apr_status_t loc_unlock_nodes(void)
 {
-    return(apr_global_mutex_unlock(node_mutex));
+    return apr_global_mutex_unlock(node_mutex);
 }
+
 static int loc_get_max_size_context(void)
 {
-    if (contextstatsmem)
-        return(get_max_size_context(contextstatsmem));
-    else
-        return 0;
+    return contextstatsmem ? get_max_size_context(contextstatsmem) : 0;
 }
+
 static int loc_get_max_size_host(void)
 {
-    if (hoststatsmem)
-        return(get_max_size_host(hoststatsmem));
-    else
-        return 0;
+    return hoststatsmem ? get_max_size_host(hoststatsmem) : 0;
 }
+
 /* Remove the virtual hosts and contexts corresponding the node */
 static void loc_remove_host_context(int node, apr_pool_t *pool)
 {
@@ -319,8 +319,8 @@ static void loc_remove_host_context(int node, apr_pool_t *pool)
             remove_context(contextstatsmem, context);
     }
 }
-static const struct node_storage_method node_storage =
-{
+
+static const struct node_storage_method node_storage = {
     loc_read_node,
     loc_get_ids_used_node,
     loc_get_max_size_node,
@@ -338,24 +338,25 @@ static const struct node_storage_method node_storage =
  */
 static apr_status_t loc_read_context(int ids, contextinfo_t **context)
 {
-    return (get_context(contextstatsmem, context, ids));
+    return get_context(contextstatsmem, context, ids);
 }
+
 static int loc_get_ids_used_context(int *ids)
 {
-    return(get_ids_used_context(contextstatsmem, ids)); 
+    return get_ids_used_context(contextstatsmem, ids);
 }
 
 static apr_status_t loc_lock_contexts(void)
 {
-    return(apr_global_mutex_lock(context_mutex));
-}
-static apr_status_t loc_unlock_contexts(void)
-{
-    return(apr_global_mutex_unlock(context_mutex));
+    return apr_global_mutex_lock(context_mutex);
 }
 
-static const struct context_storage_method context_storage =
+static apr_status_t loc_unlock_contexts(void)
 {
+    return apr_global_mutex_unlock(context_mutex);
+}
+
+static const struct context_storage_method context_storage = {
     loc_read_context,
     loc_get_ids_used_context,
     loc_get_max_size_context,
@@ -368,14 +369,15 @@ static const struct context_storage_method context_storage =
  */
 static apr_status_t loc_read_host(int ids, hostinfo_t **host)
 {
-    return (get_host(hoststatsmem, host, ids));
+    return get_host(hoststatsmem, host, ids);
 }
+
 static int loc_get_ids_used_host(int *ids)
 {
-    return(get_ids_used_host(hoststatsmem, ids)); 
+    return get_ids_used_host(hoststatsmem, ids);
 }
-static const struct host_storage_method host_storage =
-{
+
+static const struct host_storage_method host_storage = {
     loc_read_host,
     loc_get_ids_used_host,
     loc_get_max_size_host
@@ -386,53 +388,54 @@ static const struct host_storage_method host_storage =
  */
 static apr_status_t loc_read_balancer(int ids, balancerinfo_t **balancer)
 {
-    return (get_balancer(balancerstatsmem, balancer, ids));
+    return get_balancer(balancerstatsmem, balancer, ids);
 }
+
 static int loc_get_ids_used_balancer(int *ids)
 {
-    return(get_ids_used_balancer(balancerstatsmem, ids)); 
+    return get_ids_used_balancer(balancerstatsmem, ids);
 }
+
 static int loc_get_max_size_balancer(void)
 {
-    if (balancerstatsmem)
-        return(get_max_size_balancer(balancerstatsmem));
-    else
-        return 0;
+    return balancerstatsmem ? get_max_size_balancer(balancerstatsmem) : 0;
 }
-static const struct balancer_storage_method balancer_storage =
-{
+
+static const struct balancer_storage_method balancer_storage = {
     loc_read_balancer,
     loc_get_ids_used_balancer,
     loc_get_max_size_balancer
 };
+
 /*
  * routines for the sessionid_storage_method
  */
 static apr_status_t loc_read_sessionid(int ids, sessionidinfo_t **sessionid)
 {
-    return (get_sessionid(sessionidstatsmem, sessionid, ids));
+    return get_sessionid(sessionidstatsmem, sessionid, ids);
 }
+
 static int loc_get_ids_used_sessionid(int *ids)
 {
-    return(get_ids_used_sessionid(sessionidstatsmem, ids)); 
+    return get_ids_used_sessionid(sessionidstatsmem, ids);
 }
+
 static int loc_get_max_size_sessionid(void)
 {
-    if (sessionidstatsmem)
-        return(get_max_size_sessionid(sessionidstatsmem));
-    else
-        return 0;
+    return sessionidstatsmem ? get_max_size_sessionid(sessionidstatsmem) : 0;
 }
+
 static apr_status_t loc_remove_sessionid(sessionidinfo_t *sessionid)
 {
-    return (remove_sessionid(sessionidstatsmem, sessionid));
+    return remove_sessionid(sessionidstatsmem, sessionid);
 }
+
 static apr_status_t loc_insert_update_sessionid(sessionidinfo_t *sessionid)
 {
-    return (insert_update_sessionid(sessionidstatsmem, sessionid));
+    return insert_update_sessionid(sessionidstatsmem, sessionid);
 }
-static const struct  sessionid_storage_method sessionid_storage =
-{
+
+static const struct sessionid_storage_method sessionid_storage = {
     loc_read_sessionid,
     loc_get_ids_used_sessionid,
     loc_get_max_size_sessionid,
@@ -445,33 +448,35 @@ static const struct  sessionid_storage_method sessionid_storage =
  */
 static apr_status_t loc_read_domain(int ids, domaininfo_t **domain)
 {
-    return (get_domain(domainstatsmem, domain, ids));
+    return get_domain(domainstatsmem, domain, ids);
 }
+
 static int loc_get_ids_used_domain(int *ids)
 {
-    return(get_ids_used_domain(domainstatsmem, ids)); 
+    return get_ids_used_domain(domainstatsmem, ids);
 }
+
 static int loc_get_max_size_domain(void)
 {
-    if (domainstatsmem)
-        return(get_max_size_domain(domainstatsmem));
-    else
-        return 0;
+    return domainstatsmem ? get_max_size_domain(domainstatsmem) : 0;
 }
+
 static apr_status_t loc_remove_domain(domaininfo_t *domain)
 {
-    return (remove_domain(domainstatsmem, domain));
+    return remove_domain(domainstatsmem, domain);
 }
+
 static apr_status_t loc_insert_update_domain(domaininfo_t *domain)
 {
-    return (insert_update_domain(domainstatsmem, domain));
+    return insert_update_domain(domainstatsmem, domain);
 }
+
 static apr_status_t loc_find_domain(domaininfo_t **domain, const char *route, const char *balancer)
 {
-    return (find_domain(domainstatsmem, domain, route, balancer));
+    return find_domain(domainstatsmem, domain, route, balancer);
 }
-static const struct  domain_storage_method domain_storage =
-{
+
+static const struct domain_storage_method domain_storage = {
     loc_read_domain,
     loc_get_ids_used_domain,
     loc_get_max_size_domain,
@@ -481,7 +486,8 @@ static const struct  domain_storage_method domain_storage =
 };
 
 /* helper for the handling of the Alias: host1,... Context: context1,... */
-struct cluster_host {
+struct cluster_host
+{
     char *host;
     char *context;
     struct cluster_host *next;
@@ -499,7 +505,7 @@ static apr_status_t cleanup_manager(void *param)
     balancerstatsmem = NULL;
     sessionidstatsmem = NULL;
     domainstatsmem = NULL;
-    (void) param;
+    (void)param;
 
     if (versionipc_shm) {
         apr_shm_destroy(versionipc_shm);
@@ -507,15 +513,16 @@ static apr_status_t cleanup_manager(void *param)
     }
     return APR_SUCCESS;
 }
+
 static void mc_initialize_cleanup(apr_pool_t *p)
 {
     apr_pool_cleanup_register(p, NULL, cleanup_manager, apr_pool_cleanup_null);
 }
 
-static void normalize_balancer_name(char* balancer_name, server_rec *s)
+static void normalize_balancer_name(char *balancer_name, server_rec *s)
 {
     int upper_case_char_found = 0;
-    char* balancer_name_start = balancer_name;
+    char *balancer_name_start = balancer_name;
     for (; *balancer_name; ++balancer_name) {
         if (!upper_case_char_found) {
             upper_case_char_found = apr_isupper(*balancer_name);
@@ -524,7 +531,7 @@ static void normalize_balancer_name(char* balancer_name, server_rec *s)
     }
     balancer_name = balancer_name_start;
     if (upper_case_char_found) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_WARNING, 0, s, SBALBAD, balancer_name);
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_WARNING, 0, s, SBALBAD, balancer_name);
     }
 }
 
@@ -547,9 +554,8 @@ static APR_INLINE int is_child_process(void)
  * adjust the mutex settings using the Mutex directive.
  */
 
-static int manager_pre_config(apr_pool_t *pconf, apr_pool_t *plog,
-                            apr_pool_t *ptemp)
-{   
+static int manager_pre_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp)
+{
     ap_mutex_register(pconf, node_mutex_type, NULL, APR_LOCK_DEFAULT, 0);
     ap_mutex_register(pconf, context_mutex_type, NULL, APR_LOCK_DEFAULT, 0);
     return OK;
@@ -559,8 +565,7 @@ static int manager_pre_config(apr_pool_t *pconf, apr_pool_t *plog,
  * call after parser the configuration.
  * create the shared memory.
  */
-static int manager_init(apr_pool_t *p, apr_pool_t *plog,
-                          apr_pool_t *ptemp, server_rec *s)
+static int manager_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *s)
 {
     char *node;
     char *context;
@@ -573,7 +578,7 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
     apr_uuid_t uuid;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
     apr_status_t rv;
-    (void) plog; /* unused variable */
+    (void)plog;                 /* unused variable */
 
     if (ap_state_query(AP_SQ_MAIN_STATE) == AP_SQ_MS_CREATE_PRE_CONFIG)
         return OK;
@@ -586,7 +591,8 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
         sessionid = apr_pstrcat(ptemp, mconf->basefilename, "/manager.sessionid", NULL);
         domain = apr_pstrcat(ptemp, mconf->basefilename, "/manager.domain", NULL);
         version = apr_pstrcat(ptemp, mconf->basefilename, "/manager.version", NULL);
-    } else {
+    }
+    else {
         node = ap_server_root_relative(ptemp, "logs/manager.node");
         context = ap_server_root_relative(ptemp, "logs/manager.context");
         host = ap_server_root_relative(ptemp, "logs/manager.host");
@@ -605,80 +611,80 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
     /* Get a provider to handle the shared memory */
     storage = ap_lookup_provider(SLOTMEM_STORAGE, "shared", "0");
     if (storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "ap_lookup_provider %s failed", SLOTMEM_STORAGE);
-        return  !OK;
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "ap_lookup_provider %s failed", SLOTMEM_STORAGE);
+        return !OK;
     }
     nodestatsmem = create_mem_node(node, &mconf->maxnode, mconf->persistent, p, storage);
     if (nodestatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "create_mem_node %s failed", node);
-        return  !OK;
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_node %s failed", node);
+        return !OK;
     }
     if (get_last_mem_error(nodestatsmem) != APR_SUCCESS) {
         char buf[120];
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "create_mem_node %s failed: %s",
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_node %s failed: %s",
                      node, apr_strerror(get_last_mem_error(nodestatsmem), buf, sizeof(buf)));
-        return  !OK;
+        return !OK;
     }
 
     contextstatsmem = create_mem_context(context, &mconf->maxcontext, mconf->persistent, p, storage);
     if (contextstatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "create_mem_context failed");
-        return  !OK;
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_context failed");
+        return !OK;
     }
 
     hoststatsmem = create_mem_host(host, &mconf->maxhost, mconf->persistent, p, storage);
     if (hoststatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "create_mem_host failed");
-        return  !OK;
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_host failed");
+        return !OK;
     }
 
     balancerstatsmem = create_mem_balancer(balancer, &mconf->maxhost, mconf->persistent, p, storage);
     if (balancerstatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "create_mem_balancer failed");
-        return  !OK;
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_balancer failed");
+        return !OK;
     }
 
     if (mconf->maxsessionid) {
         /* Only create sessionid stuff if required */
         sessionidstatsmem = create_mem_sessionid(sessionid, &mconf->maxsessionid, mconf->persistent, p, storage);
         if (sessionidstatsmem == NULL) {
-            ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "create_mem_sessionid failed");
-            return  !OK;
+            ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_sessionid failed");
+            return !OK;
         }
     }
 
     domainstatsmem = create_mem_domain(domain, &mconf->maxnode, mconf->persistent, p, storage);
     if (domainstatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "create_mem_domain failed");
-        return  !OK;
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_domain failed");
+        return !OK;
     }
 
     if (is_child_process()) {
-        rv = apr_shm_attach(&versionipc_shm, (const char *) version, p);
-    } else {
+        rv = apr_shm_attach(&versionipc_shm, (const char *)version, p);
+    }
+    else {
         /* Use anonymous shm by default, fall back on name-based. */
         rv = apr_shm_create(&versionipc_shm, sizeof(version_data), NULL, p);
-        if (rv == APR_ENOTIMPL) 
-        {
+        if (rv == APR_ENOTIMPL) {
             /* For a name-based segment, remove it first in case of a
-            * previous unclean shutdown. */
-            apr_shm_remove((const char *) version, p);
+             * previous unclean shutdown. */
+            apr_shm_remove((const char *)version, p);
             /* Now create that segment */
-            rv = apr_shm_create(&versionipc_shm, sizeof(version_data), (const char *) version, p);
+            rv = apr_shm_create(&versionipc_shm, sizeof(version_data), (const char *)version, p);
         }
     }
     if (rv != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_EMERG, rv, s, "create_share_version failed");
-        return  !OK;
+        return !OK;
     }
-    base = (version_data *)apr_shm_baseaddr_get(versionipc_shm);
+    base = (version_data *) apr_shm_baseaddr_get(versionipc_shm);
     base->counter = 0;
 
     /* Get a provider to ping/pong logics */
 
     balancerhandler = ap_lookup_provider("proxy_cluster", "balancer", "0");
     if (balancerhandler == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_WARNING, 0, s, "can't find a ping/pong logic");
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_WARNING, 0, s, "can't find a ping/pong logic");
     }
 
     advertise_info = ap_lookup_provider("advertise", "info", "0");
@@ -697,16 +703,19 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog,
 
     /* Create global mutex */
     if (ap_global_mutex_create(&node_mutex, NULL, node_mutex_type, NULL, s, p, 0) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,"manager_init: ap_global_mutex_create %s failed", node_mutex_type);
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s, "manager_init: ap_global_mutex_create %s failed",
+                     node_mutex_type);
         return !OK;
     }
     if (ap_global_mutex_create(&context_mutex, NULL, context_mutex_type, NULL, s, p, 0) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,"manager_init: ap_global_mutex_create %s failed", node_mutex_type);
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s, "manager_init: ap_global_mutex_create %s failed",
+                     node_mutex_type);
         return !OK;
     }
 
     return OK;
 }
+
 static apr_status_t decodeenc(char **ptr);
 static char **process_buff(request_rec *r, char *buff)
 {
@@ -741,15 +750,16 @@ static char **process_buff(request_rec *r, char *buff)
 
     return ptr;
 }
+
 /*
  * Insert the hosts from Alias information
  */
-static apr_status_t  insert_update_hosts(mem_t *mem, char *str, int node, int vhost)
+static apr_status_t insert_update_hosts(mem_t *mem, char *str, int node, int vhost)
 {
     char *ptr = str;
     char *previous = str;
     hostinfo_t info;
-    char empty[1] = {'\0'};
+    char empty[1] = { '\0' };
     apr_status_t status;
 
     info.node = node;
@@ -762,7 +772,7 @@ static apr_status_t  insert_update_hosts(mem_t *mem, char *str, int node, int vh
         if (*ptr == ',') {
             *ptr = '\0';
             strncpy(info.host, previous, HOSTALIASZ);
-            status = insert_update_host(mem, &info); 
+            status = insert_update_host(mem, &info);
             if (status != APR_SUCCESS)
                 return status;
             previous = ptr + 1;
@@ -770,8 +780,9 @@ static apr_status_t  insert_update_hosts(mem_t *mem, char *str, int node, int vh
         ptr++;
     }
     strncpy(info.host, previous, sizeof(info.host));
-    return insert_update_host(mem, &info); 
+    return insert_update_host(mem, &info);
 }
+
 /*
  * Insert the context from Context information
  * Note:
@@ -779,13 +790,13 @@ static apr_status_t  insert_update_hosts(mem_t *mem, char *str, int node, int vh
  * 2 - return codes of REMOVE are ignored (always success).
  *
  */
-static apr_status_t  insert_update_contexts(mem_t *mem, char *str, int node, int vhost, int status)
+static apr_status_t insert_update_contexts(mem_t *mem, char *str, int node, int vhost, int status)
 {
     char *ptr = str;
     char *previous = str;
     apr_status_t ret = APR_SUCCESS;
     contextinfo_t info;
-    char empty[2] = {'/','\0'};
+    char empty[2] = { '/', '\0' };
 
     info.node = node;
     info.vhost = vhost;
@@ -803,7 +814,8 @@ static apr_status_t  insert_update_contexts(mem_t *mem, char *str, int node, int
                 ret = insert_update_context(mem, &info);
                 if (ret != APR_SUCCESS)
                     return ret;
-            } else
+            }
+            else
                 remove_context(mem, &info);
 
             previous = ptr + 1;
@@ -813,20 +825,22 @@ static apr_status_t  insert_update_contexts(mem_t *mem, char *str, int node, int
     info.id = 0;
     strncpy(info.context, previous, sizeof(info.context));
     if (status != REMOVE)
-        ret = insert_update_context(mem, &info); 
+        ret = insert_update_context(mem, &info);
     else
         remove_context(mem, &info);
     return ret;
 }
+
 /*
  * Check that the node could be handle as is there were the same.
  */
-static int  is_same_node(nodeinfo_t *nodeinfo, nodeinfo_t *node) {
-    if (strcmp(nodeinfo->mess.balancer,node->mess.balancer))
+static int is_same_node(nodeinfo_t *nodeinfo, nodeinfo_t *node)
+{
+    if (strcmp(nodeinfo->mess.balancer, node->mess.balancer))
         return 0;
     if (strcmp(nodeinfo->mess.Host, node->mess.Host))
         return 0;
-    if (strcmp(nodeinfo->mess.Port,node->mess.Port))
+    if (strcmp(nodeinfo->mess.Port, node->mess.Port))
         return 0;
     if (strcmp(nodeinfo->mess.Type, node->mess.Type))
         return 0;
@@ -834,7 +848,7 @@ static int  is_same_node(nodeinfo_t *nodeinfo, nodeinfo_t *node) {
         return 0;
 
     /* Those means the reslist has to be changed */
-    if (nodeinfo->mess.smax !=  node->mess.smax)
+    if (nodeinfo->mess.smax != node->mess.smax)
         return 0;
     if (nodeinfo->mess.ttl != node->mess.ttl)
         return 0;
@@ -842,10 +856,12 @@ static int  is_same_node(nodeinfo_t *nodeinfo, nodeinfo_t *node) {
     /* All other fields can be modified without causing problems */
     return -1;
 }
+
 /*
  * Check if another node has the same worker.
  */
-static int  is_same_worker_existing(request_rec *r, nodeinfo_t *node) {
+static int is_same_worker_existing(request_rec *r, nodeinfo_t *node)
+{
     int size, i;
     int *id;
     size = loc_get_max_size_node();
@@ -859,16 +875,17 @@ static int  is_same_worker_existing(request_rec *r, nodeinfo_t *node) {
             continue;
         if (is_same_node(ou, node)) {
             /* we have a node that corresponds to the same worker */
-            if (!strcmp(ou->mess.JVMRoute,node->mess.JVMRoute))
-                return 0; /* well it is the same */
+            if (!strcmp(ou->mess.JVMRoute, node->mess.JVMRoute))
+                return 0;       /* well it is the same */
             if (ou->mess.remove) {
                 if (strcmp(ou->mess.JVMRoute, "REMOVED") == 0) {
                     /* Look in remove_removed_node, only "REMOVED" have cleaned the contexts/hosts */
-                    return 0; /* well it marked removed */
+                    return 0;   /* well it marked removed */
                 }
             }
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "process_config: node %s and %s correspond to the same worker!", node->mess.JVMRoute, ou->mess.JVMRoute);
+                         "process_config: node %s and %s correspond to the same worker!", node->mess.JVMRoute,
+                         ou->mess.JVMRoute);
             return -1;
         }
     }
@@ -878,27 +895,30 @@ static int  is_same_worker_existing(request_rec *r, nodeinfo_t *node) {
 /*
  * Builds the parameter for mod_balancer
  */
-static apr_status_t mod_manager_manage_worker(request_rec *r, nodeinfo_t *node, balancerinfo_t *bal) {
+static apr_status_t mod_manager_manage_worker(request_rec *r, nodeinfo_t *node, balancerinfo_t *bal)
+{
     apr_table_t *params;
     params = apr_table_make(r->pool, 10);
     /* balancer */
-    apr_table_set(params, "b" , node->mess.balancer);
+    apr_table_set(params, "b", node->mess.balancer);
     apr_table_set(params, "b_lbm", "cluster");
     apr_table_set(params, "b_tmo", apr_psprintf(r->pool, "%d", bal->Timeout));
     apr_table_set(params, "b_max", apr_psprintf(r->pool, "%d", bal->Maxattempts));
     apr_table_set(params, "b_ss", apr_pstrcat(r->pool, bal->StickySessionCookie, "|", bal->StickySessionPath, NULL));
 
     /* and new worker */
-    apr_table_set(params, "b_wyes" , "1");
-    apr_table_set(params, "b_nwrkr" , apr_pstrcat(r->pool, node->mess.Type, "://", node->mess.Host, ":", node->mess.Port, NULL));
+    apr_table_set(params, "b_wyes", "1");
+    apr_table_set(params, "b_nwrkr",
+                  apr_pstrcat(r->pool, node->mess.Type, "://", node->mess.Host, ":", node->mess.Port, NULL));
     balancer_manage(r, params);
     apr_table_clear(params);
 
     /* now process the worker */
-    apr_table_set(params, "b" , node->mess.balancer);
-    apr_table_set(params, "w" , apr_pstrcat(r->pool, node->mess.Type, "://", node->mess.Host, ":", node->mess.Port, NULL));
+    apr_table_set(params, "b", node->mess.balancer);
+    apr_table_set(params, "w",
+                  apr_pstrcat(r->pool, node->mess.Type, "://", node->mess.Host, ":", node->mess.Port, NULL));
     apr_table_set(params, "w_wr", node->mess.JVMRoute);
-    apr_table_set(params, "w_status_D", "0"); /* Not Dissabled */
+    apr_table_set(params, "w_status_D", "0");   /* Not Dissabled */
 
     /* set the health check (requires mod_proxy_hcheck) */
     /* CPING for AJP and OPTIONS for HTTP/1.1 */
@@ -918,17 +938,21 @@ static apr_status_t mod_manager_manage_worker(request_rec *r, nodeinfo_t *node, 
 static proxy_worker *proxy_node_getid(request_rec *r, nodeinfo_t *nodeinfo, int *id, proxy_server_conf **the_conf)
 {
     if (balancerhandler != NULL) {
-        return (balancerhandler->proxy_node_getid(r, nodeinfo->mess.balancer, nodeinfo->mess.Type, nodeinfo->mess.Host, nodeinfo->mess.Port, id, the_conf));
+        return balancerhandler->
+               proxy_node_getid(r, nodeinfo->mess.balancer, nodeinfo->mess.Type, nodeinfo->mess.Host,
+                                nodeinfo->mess.Port, id, the_conf);
     }
     return NULL;
 }
 
-static void reenable_proxy_worker(request_rec *r, nodeinfo_t *node, proxy_worker *worker, nodeinfo_t *nodeinfo, proxy_server_conf *the_conf)
+static void reenable_proxy_worker(request_rec *r, nodeinfo_t *node, proxy_worker *worker, nodeinfo_t *nodeinfo,
+                                  proxy_server_conf *the_conf)
 {
     if (balancerhandler != NULL) {
         balancerhandler->reenable_proxy_worker(r->server, node, worker, nodeinfo, the_conf);
     }
 }
+
 static int proxy_node_get_free_id(request_rec *r, int node_table_size)
 {
     if (balancerhandler != NULL) {
@@ -956,19 +980,19 @@ static int proxy_node_get_free_id(request_rec *r, int node_table_size)
  * Context corresponding to the applications.
  * Context: <context list>
  */
-static char * process_config(request_rec *r, char **ptr, int *errtype)
+static char *process_config(request_rec *r, char **ptr, int *errtype)
 {
     /* Process the node/balancer description */
     nodeinfo_t nodeinfo;
     nodeinfo_t *node;
     balancerinfo_t balancerinfo;
-    
-    struct cluster_host *vhost; 
-    struct cluster_host *phost; 
+
+    struct cluster_host *vhost;
+    struct cluster_host *phost;
 
     int i = 0;
     int id;
-    int vid = 1; /* zero and "" is empty */
+    int vid = 1;                /* zero and "" is empty */
     int removed = 0;
     void *sconf = r->server->module_config;
     mod_manager_config *mconf = ap_get_module_config(sconf, &manager_module);
@@ -990,8 +1014,9 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
     if (mconf->balancername != NULL) {
         normalize_balancer_name(mconf->balancername, r->server);
         strncpy(nodeinfo.mess.balancer, mconf->balancername, sizeof(nodeinfo.mess.balancer));
-        nodeinfo.mess.balancer[sizeof(nodeinfo.mess.balancer) -1] = '\0';
-    } else {
+        nodeinfo.mess.balancer[sizeof(nodeinfo.mess.balancer) - 1] = '\0';
+    }
+    else {
         strcpy(nodeinfo.mess.balancer, "mycluster");
     }
     strcpy(nodeinfo.mess.Host, "localhost");
@@ -1000,11 +1025,11 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
     nodeinfo.mess.Upgrade[0] = '\0';
     nodeinfo.mess.AJPSecret[0] = '\0';
     nodeinfo.mess.reversed = 0;
-    nodeinfo.mess.remove = 0; /* not marked as removed */
-    nodeinfo.mess.flushpackets = flush_off; /* FLUSH_OFF; See enum flush_packets in proxy.h flush_off */
+    nodeinfo.mess.remove = 0;   /* not marked as removed */
+    nodeinfo.mess.flushpackets = flush_off;     /* FLUSH_OFF; See enum flush_packets in proxy.h flush_off */
     nodeinfo.mess.flushwait = PROXY_FLUSH_WAIT;
     nodeinfo.mess.ping = apr_time_from_sec(10);
-    nodeinfo.mess.smax = -1; /* let mod_proxy logic get the right one */
+    nodeinfo.mess.smax = -1;    /* let mod_proxy logic get the right one */
     nodeinfo.mess.ttl = apr_time_from_sec(60);
     nodeinfo.mess.timeout = 0;
     nodeinfo.mess.id = 0;
@@ -1016,7 +1041,8 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
         normalize_balancer_name(mconf->balancername, r->server);
         strncpy(balancerinfo.balancer, mconf->balancername, sizeof(balancerinfo.balancer));
         balancerinfo.balancer[sizeof(balancerinfo.balancer) - 1] = '\0';
-    } else {
+    }
+    else {
         strcpy(balancerinfo.balancer, "mycluster");
     }
     balancerinfo.StickySession = 1;
@@ -1066,7 +1092,7 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
             if (strcasecmp(ptr[i + 1], "no") == 0)
                 balancerinfo.StickySessionForce = 0;
         }
-        /* Note that it is workerTimeout (set/getWorkerTimeout in java code) */ 
+        /* Note that it is workerTimeout (set/getWorkerTimeout in java code) */
         if (strcasecmp(ptr[i], "WaitWorker") == 0) {
             balancerinfo.Timeout = apr_time_from_sec(atoi(ptr[i + 1]));
         }
@@ -1091,7 +1117,7 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
             strcpy(nodeinfo.mess.Domain, ptr[i + 1]);
         }
         if (strcasecmp(ptr[i], "Host") == 0) {
-            char *p_read = ptr[i+1], *p_write = ptr[i + 1];
+            char *p_read = ptr[i + 1], *p_write = ptr[i + 1];
             int flag = 0;
             if (strlen(ptr[i + 1]) >= sizeof(nodeinfo.mess.Host)) {
                 *errtype = TYPESYNTAX;
@@ -1104,7 +1130,8 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
                     *p_write = *p_read++;
                     if ((*p_write == '%' || flag) && *p_write != ']') {
                         flag = 1;
-                    } else {
+                    }
+                    else {
                         p_write++;
                     }
                 }
@@ -1125,11 +1152,11 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
                 *errtype = TYPESYNTAX;
                 return STYPBIG;
             }
-            strcpy(nodeinfo.mess.Type, ptr[i+1]);
+            strcpy(nodeinfo.mess.Type, ptr[i + 1]);
         }
         if (strcasecmp(ptr[i], "Reversed") == 0) {
             if (strcasecmp(ptr[i + 1], "yes") == 0) {
-            nodeinfo.mess.reversed = 1;
+                nodeinfo.mess.reversed = 1;
             }
         }
         if (strcasecmp(ptr[i], "flushpackets") == 0) {
@@ -1163,13 +1190,14 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
                 return SALIBAD;
             }
             if (phost->host) {
-               phost->next = apr_palloc(r->pool, sizeof(struct cluster_host));
-               phost = phost->next;
-               phost->next = NULL;
-               phost->host = ptr[i + 1];
-               phost->context = NULL;
-            } else {
-               phost->host = ptr[i + 1];
+                phost->next = apr_palloc(r->pool, sizeof(struct cluster_host));
+                phost = phost->next;
+                phost->next = NULL;
+                phost->host = ptr[i + 1];
+                phost->context = NULL;
+            }
+            else {
+                phost->host = ptr[i + 1];
             }
         }
         if (strcasecmp(ptr[i], "Context") == 0) {
@@ -1195,18 +1223,20 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
         if (!strcmp(nodeinfo.mess.Type, "https"))
             strcpy(nodeinfo.mess.Type, "wss");
         if (mconf->ws_upgrade_header) {
-            strncpy(nodeinfo.mess.Upgrade,mconf->ws_upgrade_header, sizeof(nodeinfo.mess.Upgrade));
+            strncpy(nodeinfo.mess.Upgrade, mconf->ws_upgrade_header, sizeof(nodeinfo.mess.Upgrade));
             nodeinfo.mess.Upgrade[sizeof(nodeinfo.mess.Upgrade) - 1] = '\0';
-        } else {
-            strcpy(nodeinfo.mess.Upgrade,"websocket");
         }
-    } else {
+        else {
+            strcpy(nodeinfo.mess.Upgrade, "websocket");
+        }
+    }
+    else {
         nodeinfo.mess.Upgrade[0] = '\0';
     }
 
     if (strcmp(nodeinfo.mess.Type, "ajp") == 0) {
         if (mconf->ajp_secret) {
-            strncpy(nodeinfo.mess.AJPSecret,mconf->ajp_secret, sizeof(nodeinfo.mess.AJPSecret));
+            strncpy(nodeinfo.mess.AJPSecret, mconf->ajp_secret, sizeof(nodeinfo.mess.AJPSecret));
             nodeinfo.mess.AJPSecret[sizeof(nodeinfo.mess.AJPSecret) - 1] = '\0';
         }
     }
@@ -1231,7 +1261,8 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
             /* Here we can't update it because the old one is still in */
             char *mess = apr_psprintf(r->pool, MNODERM, node->mess.JVMRoute);
             ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-                         "process_config: node %s %d %s : %s  %s already exist removing...", node->mess.JVMRoute, node->mess.id, node->mess.Port, nodeinfo.mess.JVMRoute,  nodeinfo.mess.Port);
+                         "process_config: node %s %d %s : %s  %s already exist removing...", node->mess.JVMRoute,
+                         node->mess.id, node->mess.Port, nodeinfo.mess.JVMRoute, nodeinfo.mess.Port);
             strcpy(node->mess.JVMRoute, "REMOVED");
             node->mess.remove = 1;
             node->updatetime = apr_time_now();
@@ -1253,83 +1284,93 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
     /* Check for corresponding proxy_worker */
     worker = proxy_node_getid(r, &nodeinfo, &id, &the_conf);
     if (id != 0) {
-       /* Same node should be OK, different nodes will bring problems */
-       if (node != NULL && node->mess.id==id) {
-          ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                       "process_config: proxy_node_getid() worker exist and should be OK");
-       } else {
-          /* Here that is the tricky part, we will insert_update the whole node including proxy_worker_shared */
-          char *pptr;
-          unsigned long offset;
-          
-          ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                       "process_config: proxy_node_getid() worker %d (%s) exists and IS NOT OK!!!", id, nodeinfo.mess.JVMRoute);
-          if (node == NULL) {
-              /* try to read the node */
-              nodeinfo_t workernodeinfo;
-              nodeinfo_t *workernode;
-              workernodeinfo.mess.id = id;
-              workernode = read_node(nodestatsmem, &workernodeinfo);
-              if (workernode != NULL) {
-                  if (strcmp(workernode->mess.JVMRoute, "REMOVED")==0) {
-                      /* We are in the remove process */
-                      /* Something to clean ? */
-                      removed = -1;
-                      strcpy(workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
-                  } else {
-                      /* if the workernode->mess is zeroed we are going to reinsert it */
-                      if (workernode->mess.JVMRoute[0] == '\0') {
-                          removed = -1;
-                      } else {
-                          ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-                                       "process_config: proxy_node_getid() worker %d (%s) exists and IS NOT %s!!!", id, workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
-                          ap_assert(0); /* we are in trouble */
-                      }
-                  }
-              }
-              ap_assert(the_conf);
-          }
-          clean = 0;
-          ap_assert(worker->s->port != 0);
-          pptr = (char *) &nodeinfo;
-          offset = sizeof(nodemess_t) + sizeof(apr_time_t) + sizeof(int); /* nodeinfo.offset doesn't contain the information */
-          offset = APR_ALIGN_DEFAULT(offset);
-          pptr = pptr + offset;
-          memcpy(pptr, worker->s, sizeof(proxy_worker_shared)); /* restore the information we are going to reuse */
-          ap_assert(the_conf);
-       }
-    } else {
-          nodeinfo_t *workernode;
-          rv = find_node_byhostport(nodestatsmem, &workernode, nodeinfo.mess.Host, nodeinfo.mess.Port);
-          if (rv == APR_SUCCESS) {
-              /* Normally the node is just being removed, so no host/context but some other child might have a worker */
-              ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                           "process_config: NOT NEW (%d %s) %s %s (%s)", workernode->mess.id, workernode->mess.JVMRoute, workernode->mess.Host, workernode->mess.Port, nodeinfo.mess.JVMRoute);
-              if (strcmp(workernode->mess.JVMRoute, "REMOVED") == 0) {
-                  id = workernode->mess.id; /* we are reusing it */
-                  strcpy(workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
-                  workernode->mess.remove = 0;
-                  workernode->mess.num_remove_check = 0;
-              } else {
-                  ap_assert(0); /* we need to figure out what to do... */
-              }
-          } else {
-                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                              "process_config: NEW (%s) %s", nodeinfo.mess.JVMRoute, nodeinfo.mess.Port);
-          }
+        /* Same node should be OK, different nodes will bring problems */
+        if (node != NULL && node->mess.id == id) {
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                         "process_config: proxy_node_getid() worker exist and should be OK");
+        }
+        else {
+            /* Here that is the tricky part, we will insert_update the whole node including proxy_worker_shared */
+            char *pptr;
+            unsigned long offset;
+
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                         "process_config: proxy_node_getid() worker %d (%s) exists and IS NOT OK!!!", id,
+                         nodeinfo.mess.JVMRoute);
+            if (node == NULL) {
+                /* try to read the node */
+                nodeinfo_t workernodeinfo;
+                nodeinfo_t *workernode;
+                workernodeinfo.mess.id = id;
+                workernode = read_node(nodestatsmem, &workernodeinfo);
+                if (workernode != NULL) {
+                    if (strcmp(workernode->mess.JVMRoute, "REMOVED") == 0) {
+                        /* We are in the remove process */
+                        /* Something to clean ? */
+                        removed = -1;
+                        strcpy(workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
+                    }
+                    else {
+                        /* if the workernode->mess is zeroed we are going to reinsert it */
+                        if (workernode->mess.JVMRoute[0] == '\0') {
+                            removed = -1;
+                        }
+                        else {
+                            ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
+                                         "process_config: proxy_node_getid() worker %d (%s) exists and IS NOT %s!!!",
+                                         id, workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
+                            ap_assert(0);       /* we are in trouble */
+                        }
+                    }
+                }
+                ap_assert(the_conf);
+            }
+            clean = 0;
+            ap_assert(worker->s->port != 0);
+            pptr = (char *)&nodeinfo;
+            offset = sizeof(nodemess_t) + sizeof(apr_time_t) + sizeof(int);     /* nodeinfo.offset doesn't contain the information */
+            offset = APR_ALIGN_DEFAULT(offset);
+            pptr = pptr + offset;
+            memcpy(pptr, worker->s, sizeof(proxy_worker_shared));       /* restore the information we are going to reuse */
+            ap_assert(the_conf);
+        }
+    }
+    else {
+        nodeinfo_t *workernode;
+        rv = find_node_byhostport(nodestatsmem, &workernode, nodeinfo.mess.Host, nodeinfo.mess.Port);
+        if (rv == APR_SUCCESS) {
+            /* Normally the node is just being removed, so no host/context but some other child might have a worker */
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                         "process_config: NOT NEW (%d %s) %s %s (%s)", workernode->mess.id, workernode->mess.JVMRoute,
+                         workernode->mess.Host, workernode->mess.Port, nodeinfo.mess.JVMRoute);
+            if (strcmp(workernode->mess.JVMRoute, "REMOVED") == 0) {
+                id = workernode->mess.id;       /* we are reusing it */
+                strcpy(workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
+                workernode->mess.remove = 0;
+                workernode->mess.num_remove_check = 0;
+            }
+            else {
+                ap_assert(0);   /* we need to figure out what to do... */
+            }
+        }
+        else {
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                         "process_config: NEW (%s) %s", nodeinfo.mess.JVMRoute, nodeinfo.mess.Port);
+        }
     }
     if (id == 0) {
         /* make sure we insert in a "free" node according to the worker logic */
         id = proxy_node_get_free_id(r, node_storage.get_max_size_node());
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "process_config: NEW (%s) %s %s in %d", nodeinfo.mess.JVMRoute, nodeinfo.mess.Host, nodeinfo.mess.Port, id);
+                     "process_config: NEW (%s) %s %s in %d", nodeinfo.mess.JVMRoute, nodeinfo.mess.Host,
+                     nodeinfo.mess.Port, id);
     }
 
     /* Insert or update node description */
     if (insert_update_node(nodestatsmem, &nodeinfo, &id, clean) != APR_SUCCESS) {
         loc_unlock_nodes();
         if (removed)
-            ap_assert(0); /* troubles */
+            ap_assert(0);       /* troubles */
         *errtype = TYPEMEM;
         return apr_psprintf(r->pool, MNODEUI, nodeinfo.mess.JVMRoute);
     }
@@ -1353,13 +1394,17 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
                      "process_config: reenable_proxy_worker... scheme %s hostname %s port %d route %s name %s id: %d",
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                     worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route, worker->s->name_ex, worker->s->index);
+                     worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route, worker->s->name_ex,
+                     worker->s->index);
 #else
-                     worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route, worker->s->name, worker->s->index);
+                     worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route, worker->s->name,
+                     worker->s->index);
 #endif
-    } else {
-          ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                       "process_config: NEW (%s) %s inserted in worker %d", nodeinfo.mess.JVMRoute, nodeinfo.mess.Port, id);
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                     "process_config: NEW (%s) %s inserted in worker %d", nodeinfo.mess.JVMRoute, nodeinfo.mess.Port,
+                     id);
     }
     inc_version_node();
 
@@ -1370,13 +1415,12 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
         /* if using mod_balancer create or update the worker */
         if (balancer_manage) {
             apr_status_t rv = mod_manager_manage_worker(r, &nodeinfo, &balancerinfo);
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "process_config: balancer-manager returned %d", rv);
-        } else {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "process_config: NO balancer-manager");
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: balancer-manager returned %d", rv);
         }
-        return NULL; /* Alias and Context missing */
+        else {
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NO balancer-manager");
+        }
+        return NULL;            /* Alias and Context missing */
     }
     while (phost) {
         if (insert_update_hosts(hoststatsmem, phost->host, id, vid) != APR_SUCCESS) {
@@ -1390,49 +1434,49 @@ static char * process_config(request_rec *r, char **ptr, int *errtype)
         phost = phost->next;
         vid++;
     }
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "process_config: DONE!!!");
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: DONE!!!");
     loc_unlock_nodes();
 
     /* if using mod_balancer create or update the worker */
     if (balancer_manage) {
         apr_status_t rv = mod_manager_manage_worker(r, &nodeinfo, &balancerinfo);
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "process_config: balancer-manager returned %d", rv);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: balancer-manager returned %d", rv);
 
-    } else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "process_config: NO balancer-manager");
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NO balancer-manager");
     }
 
     return NULL;
 }
+
 /*
  * Process a DUMP command.
  */
-static char * process_dump(request_rec *r, int *errtype)
+static char *process_dump(request_rec *r, int *errtype)
 {
     int size, i;
     int *id;
     unsigned char type;
     const char *accept_header = apr_table_get(r->headers_in, "Accept");
-    (void) errtype;
+    (void)errtype;
 
-    if (accept_header && strstr((char *)accept_header, "text/xml") != NULL )  {
+    if (accept_header && strstr((char *)accept_header, "text/xml") != NULL) {
         ap_set_content_type(r, "text/xml");
         type = TEXT_XML;
         ap_rprintf(r, "<?xml version=\"1.0\" standalone=\"yes\" ?>\n");
-    } else {
+    }
+    else {
         ap_set_content_type(r, "text/plain");
         type = TEXT_PLAIN;
     }
 
     size = loc_get_max_size_balancer();
     if (size == 0)
-       return NULL;
+        return NULL;
 
     if (type == TEXT_XML) {
-       ap_rprintf(r, "<Dump><Balancers>");
+        ap_rprintf(r, "<Dump><Balancers>");
     }
 
     id = apr_palloc(r->pool, sizeof(int) * size);
@@ -1443,42 +1487,36 @@ static char * process_dump(request_rec *r, int *errtype)
             continue;
 
         switch (type) {
-            case TEXT_XML:
-            {
-                ap_rprintf(r, "<Balancer id=\"%d\" name=\"%.*s\">\
-                                <StickySession>\
-                                    <Enabled>%d</Enabled>\
-                                    <Cookie>%.*s</Cookie>\
-                                    <Path>%.*s</Path>\
-                                    <Remove>%d</Remove>\
-                                    <Force>%d</Force>\
-                                </StickySession>\
-                                <Timeout>%d</Timeout>\
-                                <MaxAttempts>%d</MaxAttempts>\
-                                </Balancer>",
-                           id[i], (int) sizeof(ou->balancer), ou->balancer, ou->StickySession,
-                           (int) sizeof(ou->StickySessionCookie), ou->StickySessionCookie, (int) sizeof(ou->StickySessionPath), ou->StickySessionPath,
-                           ou->StickySessionRemove, ou->StickySessionForce,
-                           (int) apr_time_sec(ou->Timeout),
-                           ou->Maxattempts);
-                           break;
-            }
-            case TEXT_PLAIN:
-            default: {
-
-                ap_rprintf(r, "balancer: [%d] Name: %.*s Sticky: %d [%.*s]/[%.*s] remove: %d force: %d Timeout: %d maxAttempts: %d\n",
-                           id[i], (int) sizeof(ou->balancer), ou->balancer, ou->StickySession,
-                           (int) sizeof(ou->StickySessionCookie), ou->StickySessionCookie, (int) sizeof(ou->StickySessionPath), ou->StickySessionPath,
-                           ou->StickySessionRemove, ou->StickySessionForce,
-                           (int) apr_time_sec(ou->Timeout),
-                           ou->Maxattempts);
-                break;
-            }
-
+        case TEXT_XML:
+            ap_rprintf(r, "<Balancer id=\"%d\" name=\"%.*s\">\
+                           <StickySession>\
+                               <Enabled>%d</Enabled>\
+                               <Cookie>%.*s</Cookie>\
+                               <Path>%.*s</Path>\
+                               <Remove>%d</Remove>\
+                               <Force>%d</Force>\
+                           </StickySession>\
+                           <Timeout>%d</Timeout>\
+                           <MaxAttempts>%d</MaxAttempts>\
+                           </Balancer>",
+                       id[i], (int)sizeof(ou->balancer), ou->balancer, ou->StickySession,
+                       (int)sizeof(ou->StickySessionCookie), ou->StickySessionCookie,
+                       (int)sizeof(ou->StickySessionPath), ou->StickySessionPath, ou->StickySessionRemove,
+                       ou->StickySessionForce, (int)apr_time_sec(ou->Timeout), ou->Maxattempts);
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r,
+                       "balancer: [%d] Name: %.*s Sticky: %d [%.*s]/[%.*s] remove: %d force: %d Timeout: %d maxAttempts: %d\n",
+                       id[i], (int)sizeof(ou->balancer), ou->balancer, ou->StickySession,
+                       (int)sizeof(ou->StickySessionCookie), ou->StickySessionCookie,
+                       (int)sizeof(ou->StickySessionPath), ou->StickySessionPath, ou->StickySessionRemove,
+                       ou->StickySessionForce, (int)apr_time_sec(ou->Timeout), ou->Maxattempts);
+            break;
         }
     }
     if (type == TEXT_XML) {
-       ap_rprintf(r, "</Balancers>");
+        ap_rprintf(r, "</Balancers>");
     }
 
     size = loc_get_max_size_node();
@@ -1486,62 +1524,51 @@ static char * process_dump(request_rec *r, int *errtype)
     size = get_ids_used_node(nodestatsmem, id);
 
     if (type == TEXT_XML) {
-       ap_rprintf(r, "<Nodes>");
+        ap_rprintf(r, "<Nodes>");
     }
     for (i = 0; i < size; i++) {
         nodeinfo_t *ou;
         if (get_node(nodestatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
 
-        switch(type) {
-            case TEXT_XML:
-            {
-                ap_rprintf(r, "<Node id=\"%d\">\
-                                    <Balancer>%.*s</Balancer>\
-                                    <JVMRoute>%.*s</JVMRoute>\
-                                    <LBGroup>%.*s</LBGroup>\
-                                    <Host>%.*s</Host>\
-                                    <Port>%.*s</Port>\
-                                    <Type>%.*s</Type>\
-                                    <FlushPackets>%d</FlushPackets>\
-                                    <FlushWait>%d</FlushWait>\
-                                    <Ping>%d</Ping>\
-                                    <Smax>%d</Smax>\
-                                    <Ttl>%d</Ttl>\
-                                    <Timeout>%d</Timeout>\
-                                </Node>",
-                            ou->mess.id,
-                           (int) sizeof(ou->mess.balancer), ou->mess.balancer,
-                           (int) sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
-                           (int) sizeof(ou->mess.Domain), ou->mess.Domain,
-                           (int) sizeof(ou->mess.Host), ou->mess.Host,
-                           (int) sizeof(ou->mess.Port), ou->mess.Port,
-                           (int) sizeof(ou->mess.Type), ou->mess.Type,
-                           ou->mess.flushpackets, ou->mess.flushwait/1000, (int) apr_time_sec(ou->mess.ping), ou->mess.smax,
-                           (int) apr_time_sec(ou->mess.ttl), (int) apr_time_sec(ou->mess.timeout));
+        switch (type) {
+        case TEXT_XML:
+            ap_rprintf(r, "<Node id=\"%d\">\
+                               <Balancer>%.*s</Balancer>\
+                               <JVMRoute>%.*s</JVMRoute>\
+                               <LBGroup>%.*s</LBGroup>\
+                               <Host>%.*s</Host>\
+                               <Port>%.*s</Port>\
+                               <Type>%.*s</Type>\
+                               <FlushPackets>%d</FlushPackets>\
+                               <FlushWait>%d</FlushWait>\
+                               <Ping>%d</Ping>\
+                               <Smax>%d</Smax>\
+                               <Ttl>%d</Ttl>\
+                               <Timeout>%d</Timeout>\
+                           </Node>",
+                       ou->mess.id, (int)sizeof(ou->mess.balancer), ou->mess.balancer, (int)sizeof(ou->mess.JVMRoute),
+                       ou->mess.JVMRoute, (int)sizeof(ou->mess.Domain), ou->mess.Domain, (int)sizeof(ou->mess.Host),
+                       ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port, (int)sizeof(ou->mess.Type),
+                       ou->mess.Type, ou->mess.flushpackets, ou->mess.flushwait / 1000, (int)apr_time_sec(ou->mess.ping),
+                       ou->mess.smax, (int)apr_time_sec(ou->mess.ttl), (int)apr_time_sec(ou->mess.timeout));
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, "node: [%d:%d],Balancer: %.*s,JVMRoute: %.*s,LBGroup: [%.*s],Host: %.*s,Port: %.*s,\
+                           Type: %.*s,flushpackets: %d,flushwait: %d,ping: %d,smax: %d,ttl: %d,timeout: %d\n",
+                       id[i], ou->mess.id, (int)sizeof(ou->mess.balancer), ou->mess.balancer,
+                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute, (int)sizeof(ou->mess.Domain),
+                       ou->mess.Domain, (int)sizeof(ou->mess.Host), ou->mess.Host, (int)sizeof(ou->mess.Port),
+                       ou->mess.Port, (int)sizeof(ou->mess.Type), ou->mess.Type, ou->mess.flushpackets,
+                       ou->mess.flushwait / 1000, (int)apr_time_sec(ou->mess.ping), ou->mess.smax,
+                       (int)apr_time_sec(ou->mess.ttl), (int)apr_time_sec(ou->mess.timeout));
                 break;
-            }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, "node: [%d:%d],Balancer: %.*s,JVMRoute: %.*s,LBGroup: [%.*s],Host: %.*s,Port: %.*s,Type: %.*s,flushpackets: %d,flushwait: %d,ping: %d,smax: %d,ttl: %d,timeout: %d\n",
-                           id[i], ou->mess.id,
-                           (int) sizeof(ou->mess.balancer), ou->mess.balancer,
-                           (int) sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
-                           (int) sizeof(ou->mess.Domain), ou->mess.Domain,
-                           (int) sizeof(ou->mess.Host), ou->mess.Host,
-                           (int) sizeof(ou->mess.Port), ou->mess.Port,
-                           (int) sizeof(ou->mess.Type), ou->mess.Type,
-                           ou->mess.flushpackets, ou->mess.flushwait/1000, (int) apr_time_sec(ou->mess.ping), ou->mess.smax,
-                           (int) apr_time_sec(ou->mess.ttl), (int) apr_time_sec(ou->mess.timeout));
-
-                break;
-            }
         }
     }
 
     if (type == TEXT_XML) {
-       ap_rprintf(r, "</Nodes><Hosts>");
+        ap_rprintf(r, "</Nodes><Hosts>");
     }
 
     size = loc_get_max_size_host();
@@ -1553,27 +1580,21 @@ static char * process_dump(request_rec *r, int *errtype)
             continue;
 
         switch (type) {
-            case TEXT_XML:
-            {
-                ap_rprintf(r, "<Host id=\"%d\" alias=\"%.*s\">\
-                                    <Vhost>%d</Vhost>\
-                                    <Node>%d</Node>\
-                                </Host>",
-                 id[i], (int) sizeof(ou->host), ou->host, ou->vhost,ou->node);
-                 break;
-            }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, "host: %d [%.*s] vhost: %d node: %d\n", id[i], (int) sizeof(ou->host), ou->host, ou->vhost,
-                          ou->node);
-                break;
-
-            }
+        case TEXT_XML:
+            ap_rprintf(r, "<Host id=\"%d\" alias=\"%.*s\">\
+                               <Vhost>%d</Vhost>\
+                               <Node>%d</Node>\
+                           </Host>", id[i], (int)sizeof(ou->host), ou->host, ou->vhost, ou->node);
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, "host: %d [%.*s] vhost: %d node: %d\n", id[i], (int)sizeof(ou->host), ou->host, ou->vhost,
+                       ou->node);
+            break;
         }
     }
     if (type == TEXT_XML) {
-       ap_rprintf(r, "</Hosts><Contexts>");
+        ap_rprintf(r, "</Hosts><Contexts>");
     }
 
     size = loc_get_max_size_context();
@@ -1584,64 +1605,60 @@ static char * process_dump(request_rec *r, int *errtype)
         if (get_context(contextstatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
 
-        switch ( type ) {
-            case TEXT_XML:
-            {
-                char *status;
-                status = "REMOVED";
-                switch (ou->status) {
-                    case ENABLED:
-                        status = "ENABLED";
-                        break;
-                    case DISABLED:
-                        status = "DISABLED";
-                        break;
-                    case STOPPED:
-                        status = "STOPPED";
-                        break;
-                }
-                ap_rprintf(r, "<Context id=\"%d\" path=\"%.*s\">\
-                                <Vhost>%d</Vhost>\
-                                <Node>%d</Node>\
-                                <Status id=\"%d\">%s</Status>\
-                               </Context>",
-                    id[i], (int) sizeof(ou->context), ou->context, ou->vhost, ou->node,ou->status, status);        
-                    break;
-                }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, "context: %d [%.*s] vhost: %d node: %d status: %d\n", id[i],
-                           (int) sizeof(ou->context), ou->context,
-                           ou->vhost, ou->node,
-                           ou->status);
+        switch (type) {
+        case TEXT_XML:
+            char *status;
+            status = "REMOVED";
+            switch (ou->status) {
+            case ENABLED:
+                status = "ENABLED";
+                break;
+            case DISABLED:
+                status = "DISABLED";
+                break;
+            case STOPPED:
+                status = "STOPPED";
                 break;
             }
+            ap_rprintf(r, "<Context id=\"%d\" path=\"%.*s\">\
+                            <Vhost>%d</Vhost>\
+                            <Node>%d</Node>\
+                            <Status id=\"%d\">%s</Status>\
+                           </Context>", id[i], (int)sizeof(ou->context), ou->context, ou->vhost, ou->node, ou->status,
+                       status);
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, "context: %d [%.*s] vhost: %d node: %d status: %d\n", id[i], (int)sizeof(ou->context),
+                       ou->context, ou->vhost, ou->node, ou->status);
+            break;
         }
     }
 
     if (type == TEXT_XML) {
-       ap_rprintf(r, "</Contexts></Dump>");
+        ap_rprintf(r, "</Contexts></Dump>");
     }
     return NULL;
 }
+
 /*
  * Process a INFO command.
  * Statics informations ;-)
  */
-static char * process_info(request_rec *r, int *errtype)
+static char *process_info(request_rec *r, int *errtype)
 {
     int size, i;
     int *id;
     unsigned char type;
     const char *accept_header = apr_table_get(r->headers_in, "Accept");
-    (void) errtype;
+    (void)errtype;
 
-    if (accept_header && strstr((char *)accept_header, "text/xml") != NULL )  {
+    if (accept_header && strstr((char *)accept_header, "text/xml") != NULL) {
         ap_set_content_type(r, "text/xml");
         type = TEXT_XML;
         ap_rprintf(r, "<?xml version=\"1.0\" standalone=\"yes\" ?>\n");
-    } else {
+    }
+    else {
         ap_set_content_type(r, "text/plain");
         type = TEXT_PLAIN;
     }
@@ -1653,7 +1670,7 @@ static char * process_info(request_rec *r, int *errtype)
     size = get_ids_used_node(nodestatsmem, id);
 
     if (type == TEXT_XML) {
-       ap_rprintf(r, "<Info><Nodes>");
+        ap_rprintf(r, "<Info><Nodes>");
     }
 
     for (i = 0; i < size; i++) {
@@ -1664,101 +1681,81 @@ static char * process_info(request_rec *r, int *errtype)
         if (get_node(nodestatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
 
-        switch ( type ) {
-            case TEXT_XML:
-            {
-                ap_rprintf(r, "<Node id=\"%d\" name=\"%.*s\">\
-                    <Balancer>%.*s</Balancer>\
-                    <LBGroup>%.*s</LBGroup>\
-                    <Host>%.*s</Host>\
-                    <Port>%.*s</Port>\
-                    <Type>%.*s</Type>", 
+        switch (type) {
+        case TEXT_XML:
+            ap_rprintf(r, "<Node id=\"%d\" name=\"%.*s\">\
+                           <Balancer>%.*s</Balancer>\
+                           <LBGroup>%.*s</LBGroup>\
+                           <Host>%.*s</Host>\
+                           <Port>%.*s</Port>\
+                           <Type>%.*s</Type>",
+                       id[i], (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute, (int)sizeof(ou->mess.balancer),
+                       ou->mess.balancer, (int)sizeof(ou->mess.Domain), ou->mess.Domain, (int)sizeof(ou->mess.Host),
+                       ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port, (int)sizeof(ou->mess.Type),
+                       ou->mess.Type);
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, "Node: [%d],Name: %.*s,Balancer: %.*s,LBGroup: %.*s,Host: %.*s,Port: %.*s,Type: %.*s",
                        id[i],
-                       (int) sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
-                       (int) sizeof(ou->mess.balancer), ou->mess.balancer,
-                       (int) sizeof(ou->mess.Domain), ou->mess.Domain,
-                       (int) sizeof(ou->mess.Host), ou->mess.Host,
-                       (int) sizeof(ou->mess.Port), ou->mess.Port,
-                       (int) sizeof(ou->mess.Type), ou->mess.Type);
-                break;
-            }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, "Node: [%d],Name: %.*s,Balancer: %.*s,LBGroup: %.*s,Host: %.*s,Port: %.*s,Type: %.*s",
-                           id[i],
-                           (int) sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
-                           (int) sizeof(ou->mess.balancer), ou->mess.balancer,
-                           (int) sizeof(ou->mess.Domain), ou->mess.Domain,
-                           (int) sizeof(ou->mess.Host), ou->mess.Host,
-                           (int) sizeof(ou->mess.Port), ou->mess.Port,
-                           (int) sizeof(ou->mess.Type), ou->mess.Type);
-                break;
-            }
+                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
+                       (int)sizeof(ou->mess.balancer), ou->mess.balancer,
+                       (int)sizeof(ou->mess.Domain), ou->mess.Domain,
+                       (int)sizeof(ou->mess.Host), ou->mess.Host,
+                       (int)sizeof(ou->mess.Port), ou->mess.Port, (int)sizeof(ou->mess.Type), ou->mess.Type);
+            break;
         }
 
         flushpackets = "Off";
         switch (ou->mess.flushpackets) {
-            case flush_on:
-                flushpackets = "On";
-                break;
-            case flush_auto:
-                flushpackets = "Auto";
+        case flush_on:
+            flushpackets = "On";
+            break;
+        case flush_auto:
+            flushpackets = "Auto";
         }
 
-        switch ( type ) {
-            case TEXT_XML:
-            {
-                ap_rprintf(r, "<Flushpackets>%s</Flushpackets>\
-                              <Flushwait>%d</Flushwait>\
-                              <Ping>%d</Ping>\
-                              <Smax>%d</Smax>\
-                              <Ttl>%d</Ttl>",
-                           flushpackets, ou->mess.flushwait/1000,
-                           (int) apr_time_sec(ou->mess.ping),
-                           ou->mess.smax,
-                           (int) apr_time_sec(ou->mess.ttl));
-                break;
-            }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, ",Flushpackets: %s,Flushwait: %d,Ping: %d,Smax: %d,Ttl: %d",
-                           flushpackets, ou->mess.flushwait/1000,
-                           (int) apr_time_sec(ou->mess.ping),
-                           ou->mess.smax,
-                           (int) apr_time_sec(ou->mess.ttl));
-                break;
-            }
+        switch (type) {
+        case TEXT_XML:
+            ap_rprintf(r, "<Flushpackets>%s</Flushpackets>\
+                           <Flushwait>%d</Flushwait>\
+                           <Ping>%d</Ping>\
+                           <Smax>%d</Smax>\
+                           <Ttl>%d</Ttl>",
+                       flushpackets, ou->mess.flushwait / 1000, (int)apr_time_sec(ou->mess.ping), ou->mess.smax,
+                       (int)apr_time_sec(ou->mess.ttl));
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, ",Flushpackets: %s,Flushwait: %d,Ping: %d,Smax: %d,Ttl: %d",
+                       flushpackets, ou->mess.flushwait / 1000,
+                       (int)apr_time_sec(ou->mess.ping), ou->mess.smax, (int)apr_time_sec(ou->mess.ttl));
+            break;
         }
 
-        pptr = (char *) ou;
+        pptr = (char *)ou;
         pptr = pptr + ou->offset;
-        proxystat  = (proxy_worker_shared *) pptr;
+        proxystat = (proxy_worker_shared *) pptr;
 
-        switch ( type ) {
-            case TEXT_XML:  
-            {
-                ap_rprintf(r, "<Elected>%d</Elected>\
-                                <Read>%d</Read>\
-                                <Transfered>%d</Transfered>\
-                                <Connected>%d</Connected>\
-                                <Load>%d</Load>\
-                                </Node>",
-                           (int) proxystat->elected, (int) proxystat->read, (int) proxystat->transferred,
-                           (int) proxystat->busy, proxystat->lbfactor);
-                break;
-            }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, ",Elected: %d,Read: %d,Transfered: %d,Connected: %d,Load: %d\n",
-                           (int) proxystat->elected, (int) proxystat->read, (int) proxystat->transferred,
-                           (int) proxystat->busy, proxystat->lbfactor);
-                break;
-            }
+        switch (type) {
+        case TEXT_XML:
+            ap_rprintf(r, "<Elected>%d</Elected>\
+                           <Read>%d</Read>\
+                           <Transfered>%d</Transfered>\
+                           <Connected>%d</Connected>\
+                           <Load>%d</Load>\
+                           </Node>",
+                       (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred,
+                       (int)proxystat->busy, proxystat->lbfactor);
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, ",Elected: %d,Read: %d,Transfered: %d,Connected: %d,Load: %d\n",
+                       (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred,
+                       (int)proxystat->busy, proxystat->lbfactor);
+            break;
         }
-        
+
     }
 
     if (type == TEXT_XML) {
@@ -1777,23 +1774,18 @@ static char * process_info(request_rec *r, int *errtype)
         if (get_host(hoststatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
 
-        switch ( type ) {
-            case TEXT_XML:
-            {
-                ap_rprintf(r, "<Vhost id=\"%d\" alias=\"%.*s\">\
-                                <Node id=\"%d\"/>\
-                                </Vhost>\
-                ",
-                    ou->vhost, (int ) sizeof(ou->host), ou->host, ou->node);
-                break;
-            }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, "Vhost: [%d:%d:%d], Alias: %.*s\n",
-                           ou->node, ou->vhost, id[i], (int ) sizeof(ou->host), ou->host);
-                break;
-            }
+        switch (type) {
+        case TEXT_XML:
+            ap_rprintf(r, "<Vhost id=\"%d\" alias=\"%.*s\">\
+                           <Node id=\"%d\"/>\
+                           </Vhost>",
+                       ou->vhost, (int)sizeof(ou->host), ou->host, ou->node);
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, "Vhost: [%d:%d:%d], Alias: %.*s\n",
+                       ou->node, ou->vhost, id[i], (int)sizeof(ou->host), ou->host);
+            break;
         }
     }
 
@@ -1817,38 +1809,32 @@ static char * process_info(request_rec *r, int *errtype)
             continue;
         status = "REMOVED";
         switch (ou->status) {
-            case ENABLED:
-                status = "ENABLED";
-                break;
-            case DISABLED:
-                status = "DISABLED";
-                break;
-            case STOPPED:
-                status = "STOPPED";
-                break;
+        case ENABLED:
+            status = "ENABLED";
+            break;
+        case DISABLED:
+            status = "DISABLED";
+            break;
+        case STOPPED:
+            status = "STOPPED";
+            break;
         }
 
-        switch ( type ) {
-            case TEXT_XML:
-            {
-                ap_rprintf(r, "<Context id=\"%d\">\
-                                 <Status id=\"%d\">%s</Status>\
-                                 <Context>%.*s</Context>\
-                                 <Node id=\"%d\"/>\
-                                 <Vhost id=\"%d\"/>\
-                                </Context>",
-                                id[i], ou->status, status, (int) sizeof(ou->context), ou->context, ou->node, ou->vhost);
-                break;
-            }
-            case TEXT_PLAIN:
-            default:
-            {
-                ap_rprintf(r, "Context: [%d:%d:%d], Context: %.*s, Status: %s\n",
-                           ou->node, ou->vhost, id[i],
-                           (int) sizeof(ou->context), ou->context,
-                           status);
-                break;
-            }
+        switch (type) {
+        case TEXT_XML:
+            ap_rprintf(r, "<Context id=\"%d\">\
+                           <Status id=\"%d\">%s</Status>\
+                           <Context>%.*s</Context>\
+                           <Node id=\"%d\"/>\
+                           <Vhost id=\"%d\"/>\
+                           </Context>",
+                       id[i], ou->status, status, (int)sizeof(ou->context), ou->context, ou->node, ou->vhost);
+            break;
+        case TEXT_PLAIN:
+        default:
+            ap_rprintf(r, "Context: [%d:%d:%d], Context: %.*s, Status: %s\n",
+                       ou->node, ou->vhost, id[i], (int)sizeof(ou->context), ou->context, status);
+            break;
         }
     }
 
@@ -1859,16 +1845,16 @@ static char * process_info(request_rec *r, int *errtype)
 }
 
 /* Process a *-APP command that applies to the node NOTE: the node is locked */
-static char * process_node_cmd(request_rec *r, int status, int *errtype, nodeinfo_t *node)
+static char *process_node_cmd(request_rec *r, int status, int *errtype, nodeinfo_t *node)
 {
     /* for read the hosts */
-    int i,j;
+    int i, j;
     int size = loc_get_max_size_host();
     int *id;
-    (void) errtype;
+    (void)errtype;
 
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                "process_node_cmd %d processing node: %d", status, node->mess.id);
+                 "process_node_cmd %d processing node: %d", status, node->mess.id);
     if (size == 0)
         return NULL;
     id = apr_palloc(r->pool, sizeof(int) * size);
@@ -1890,14 +1876,15 @@ static char * process_node_cmd(request_rec *r, int status, int *errtype, nodeinf
             contextinfo_t *context;
             if (get_context(contextstatsmem, &context, idcontext[j]) != APR_SUCCESS)
                 continue;
-            if (context->vhost == ou->vhost &&
-                context->node == ou->node) {
+            if (context->vhost == ou->vhost && context->node == ou->node) {
                 /* Process the context */
                 if (status != REMOVE) {
                     context->status = status;
                     insert_update_context(contextstatsmem, context);
-                } else
+                }
+                else {
                     remove_context(contextstatsmem, context);
+                }
 
             }
         }
@@ -1917,7 +1904,7 @@ static char * process_node_cmd(request_rec *r, int status, int *errtype, nodeinf
 }
 
 /* Process an enable/disable/stop/remove application message */
-static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errtype, int global, int fromnode)
+static char *process_appl_cmd(request_rec *r, char **ptr, int status, int *errtype, int global, int fromnode)
 {
     nodeinfo_t nodeinfo;
     nodeinfo_t *node;
@@ -1988,7 +1975,7 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
     if (node == NULL) {
         loc_unlock_nodes();
         if (status == REMOVE)
-            return NULL; /* Already done */
+            return NULL;        /* Already done */
         *errtype = TYPEMEM;
         return apr_psprintf(r->pool, MNODERD, nodeinfo.mess.JVMRoute);
     }
@@ -1997,7 +1984,7 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
     if (node->mess.remove) {
         loc_unlock_nodes();
         if (status == REMOVE)
-            return NULL; /* Already done */
+            return NULL;        /* Already done */
         else {
             /* Act has if the node wasn't found */
             *errtype = TYPEMEM;
@@ -2021,13 +2008,14 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
         unsigned j = 1;
         strncpy(hostinfo.host, vhost->host, HOSTALIASZ);
         while (*s != ',' && j < sizeof(hostinfo.host)) {
-           j++;
-           s++;
+            j++;
+            s++;
         }
         *s = '\0';
-    } else
+    }
+    else {
         hostinfo.host[0] = '\0';
-
+    }
     hostinfo.id = 0;
     host = read_host(hoststatsmem, &hostinfo);
     if (host == NULL) {
@@ -2035,7 +2023,8 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
         if (status == REMOVE) {
             loc_unlock_nodes();
             return NULL;
-        } else {
+        }
+        else {
             int vid, size, *id;
             /* Find the first available vhost id */
             vid = 0;
@@ -2047,10 +2036,10 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
                 if (get_host(hoststatsmem, &ou, id[i]) != APR_SUCCESS)
                     continue;
 
-            if (ou->node == node->mess.id && ou->vhost > vid)
-                vid = ou->vhost;
+                if (ou->node == node->mess.id && ou->vhost > vid)
+                    vid = ou->vhost;
             }
-            vid++; /* Use next one. */
+            vid++;              /* Use next one. */
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_appl_cmd: adding vhost: %d node: %d",
                          vid, node->mess.id);
 
@@ -2065,7 +2054,8 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
             if (vhost->host != NULL) {
                 strncpy(hostinfo.host, vhost->host, sizeof(hostinfo.host));
                 hostinfo.host[sizeof(hostinfo.host) - 1] = '\0';
-            } else {
+            }
+            else {
                 hostinfo.host[0] = '\0';
             }
             host = read_host(hoststatsmem, &hostinfo);
@@ -2093,9 +2083,9 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
                     continue;
                 if (strcmp(hisnode->mess.balancer, node->mess.balancer)) {
                     /* the same context would be on 2 different balancer */
-                    ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_WARNING, 0, r->server,
+                    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_WARNING, 0, r->server,
                                  "ENABLE: context %s is in balancer %s and %s", vhost->context,
-                                  node->mess.balancer, hisnode->mess.balancer);
+                                 node->mess.balancer, hisnode->mess.balancer);
                 }
             }
         }
@@ -2117,8 +2107,7 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
             contextinfo_t *ou;
             if (get_context(contextstatsmem, &ou, id[i]) != APR_SUCCESS)
                 continue;
-            if (ou->vhost == host->vhost &&
-                ou->node == node->mess.id)
+            if (ou->vhost == host->vhost && ou->node == node->mess.id)
                 break;
         }
         if (i == size) {
@@ -2126,15 +2115,16 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
             int *id = apr_palloc(r->pool, sizeof(int) * size);
             size = get_ids_used_host(hoststatsmem, id);
             for (i = 0; i < size; i++) {
-                 hostinfo_t *ou;
+                hostinfo_t *ou;
 
-                 if (get_host(hoststatsmem, &ou, id[i]) != APR_SUCCESS)
-                     continue;
-                 if (ou->vhost == host->vhost && ou->node == node->mess.id)
-                     remove_host(hoststatsmem, ou);
+                if (get_host(hoststatsmem, &ou, id[i]) != APR_SUCCESS)
+                    continue;
+                if (ou->vhost == host->vhost && ou->node == node->mess.id)
+                    remove_host(hoststatsmem, ou);
             }
         }
-    } else if (status == STOPPED) {
+    }
+    else if (status == STOPPED) {
         /* insert_update_contexts in fact makes that vhost->context corresponds only to the first context... */
         contextinfo_t in;
         contextinfo_t *ou;
@@ -2144,36 +2134,41 @@ static char * process_appl_cmd(request_rec *r, char **ptr, int status, int *errt
         in.node = node->mess.id;
         ou = read_context(contextstatsmem, &in);
         if (ou != NULL) {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_appl_cmd: STOP-APP nbrequests %d", ou->nbrequests);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_appl_cmd: STOP-APP nbrequests %d",
+                         ou->nbrequests);
             if (fromnode) {
                 ap_set_content_type(r, "text/plain");
                 ap_rprintf(r, "Type=STOP-APP-RSP&JvmRoute=%.*s&Alias=%.*s&Context=%.*s&Requests=%d",
-                           (int) sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute,
-                           (int) sizeof(vhost->host), vhost->host,
-                           (int) sizeof(vhost->context), vhost->context,
-                           ou->nbrequests);
+                           (int)sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute,
+                           (int)sizeof(vhost->host), vhost->host,
+                           (int)sizeof(vhost->context), vhost->context, ou->nbrequests);
                 ap_rprintf(r, "\n");
             }
-        } else {
+        }
+        else {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_appl_cmd: STOP-APP can't read_context");
         }
-    } 
+    }
     loc_unlock_nodes();
     return NULL;
 }
-static char * process_enable(request_rec *r, char **ptr, int *errtype, int global)
+
+static char *process_enable(request_rec *r, char **ptr, int *errtype, int global)
 {
     return process_appl_cmd(r, ptr, ENABLED, errtype, global, 0);
 }
-static char * process_disable(request_rec *r, char **ptr, int *errtype, int global)
+
+static char *process_disable(request_rec *r, char **ptr, int *errtype, int global)
 {
     return process_appl_cmd(r, ptr, DISABLED, errtype, global, 0);
 }
-static char * process_stop(request_rec *r, char **ptr, int *errtype, int global, int fromnode)
+
+static char *process_stop(request_rec *r, char **ptr, int *errtype, int global, int fromnode)
 {
     return process_appl_cmd(r, ptr, STOPPED, errtype, global, fromnode);
 }
-static char * process_remove(request_rec *r, char **ptr, int *errtype, int global)
+
+static char *process_remove(request_rec *r, char **ptr, int *errtype, int global)
 {
     return process_appl_cmd(r, ptr, REMOVE, errtype, global, 0);
 }
@@ -2184,29 +2179,25 @@ static char * process_remove(request_rec *r, char **ptr, int *errtype, int globa
  */
 static int isnode_up(request_rec *r, int id, int Load)
 {
-    if (balancerhandler != NULL) {
-        return (balancerhandler->proxy_node_isup(r, id, Load));
-    }
-    return OK;
+    return balancerhandler != NULL ? balancerhandler->proxy_node_isup(r, id, Load) : OK;
 }
+
 /*
  * Call the ping/pong logic using scheme://host:port
  * Do a ping/png request to the node and set the load factor.
  */
 static int ishost_up(request_rec *r, char *scheme, char *host, char *port)
 {
-    if (balancerhandler != NULL) {
-        return (balancerhandler->proxy_host_isup(r, scheme, host, port));
-    }
-    return OK;
+    return balancerhandler != NULL ? balancerhandler->proxy_host_isup(r, scheme, host, port) : OK;
 }
+
 /*
  * Process the STATUS command
  * Load -1 : Broken
  * Load 0  : Standby.
  * Load 1-100 : Load factor.
  */
-static char * process_status(request_rec *r, char **ptr, int *errtype)
+static char *process_status(request_rec *r, char **ptr, int *errtype)
 {
     int Load = -1;
     nodeinfo_t nodeinfo;
@@ -2221,7 +2212,7 @@ static char * process_status(request_rec *r, char **ptr, int *errtype)
                 *errtype = TYPESYNTAX;
                 return SROUBIG;
             }
-            strcpy(nodeinfo.mess.JVMRoute, ptr[i+1]);
+            strcpy(nodeinfo.mess.JVMRoute, ptr[i + 1]);
             nodeinfo.mess.id = 0;
         }
         else if (strcasecmp(ptr[i], "Load") == 0) {
@@ -2249,13 +2240,13 @@ static char * process_status(request_rec *r, char **ptr, int *errtype)
      * and update the worker status and load factor acccording to the test result.
      */
     ap_set_content_type(r, "text/plain");
-    ap_rprintf(r, "Type=STATUS-RSP&JVMRoute=%.*s", (int) sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute);
+    ap_rprintf(r, "Type=STATUS-RSP&JVMRoute=%.*s", (int)sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute);
 
     if (isnode_up(r, node->mess.id, Load) != OK)
         ap_rprintf(r, "&State=NOTOK");
     else
         ap_rprintf(r, "&State=OK");
-    ap_rprintf(r, "&id=%d", (int) ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%d", (int)ap_scoreboard_image->global->restart_time);
 
     ap_rprintf(r, "\n");
     return NULL;
@@ -2264,22 +2255,26 @@ static char * process_status(request_rec *r, char **ptr, int *errtype)
 /*
  * Process the VERSION command
  */
-static char * process_version(request_rec *r, char **ptr, int *errtype)
+static char *process_version(request_rec *r, char **ptr, int *errtype)
 {
     const char *accept_header = apr_table_get(r->headers_in, "Accept");
-    (void) ptr; (void) errtype;
+    (void)ptr;
+    (void)errtype;
 
-    if (accept_header && strstr((char *)accept_header, "text/xml") != NULL )  {
+    if (accept_header && strstr((char *)accept_header, "text/xml") != NULL) {
         ap_set_content_type(r, "text/xml");
         ap_rprintf(r, "<?xml version=\"1.0\" standalone=\"yes\" ?>\n");
-        ap_rprintf(r, "<version><release>%s</release><protocol>%s</protocol></version>", MOD_CLUSTER_EXPOSED_VERSION, VERSION_PROTOCOL);
-    } else {
+        ap_rprintf(r, "<version><release>%s</release><protocol>%s</protocol></version>", MOD_CLUSTER_EXPOSED_VERSION,
+                   VERSION_PROTOCOL);
+    }
+    else {
         ap_set_content_type(r, "text/plain");
         ap_rprintf(r, "release: %s, protocol: %s", MOD_CLUSTER_EXPOSED_VERSION, VERSION_PROTOCOL);
     }
     ap_rprintf(r, "\n");
     return NULL;
 }
+
 /*
  * Process the PING command
  * With a JVMRoute does a cping/cpong in the node.
@@ -2287,7 +2282,7 @@ static char * process_version(request_rec *r, char **ptr, int *errtype)
  * NOTE: It is hard to cping/cpong a host + port but CONFIG + PING + REMOVE_APP *
  *       would do the same.
  */
-static char * process_ping(request_rec *r, char **ptr, int *errtype)
+static char *process_ping(request_rec *r, char **ptr, int *errtype)
 {
     nodeinfo_t nodeinfo;
     nodeinfo_t *node;
@@ -2309,7 +2304,7 @@ static char * process_ping(request_rec *r, char **ptr, int *errtype)
             nodeinfo.mess.id = 0;
         }
         else if (strcasecmp(ptr[i], "Scheme") == 0)
-            scheme = apr_pstrdup(r->pool, ptr[i+1]);
+            scheme = apr_pstrdup(r->pool, ptr[i + 1]);
         else if (strcasecmp(ptr[i], "Host") == 0)
             host = apr_pstrdup(r->pool, ptr[i + 1]);
         else if (strcasecmp(ptr[i], "Port") == 0)
@@ -2326,7 +2321,8 @@ static char * process_ping(request_rec *r, char **ptr, int *errtype)
         if (scheme == NULL && host == NULL && port == NULL) {
             ap_set_content_type(r, "text/plain");
             ap_rprintf(r, "Type=PING-RSP&State=OK");
-        }  else {
+        }
+        else {
             if (scheme == NULL || host == NULL || port == NULL) {
                 *errtype = TYPESYNTAX;
                 return apr_psprintf(r->pool, SMISFLD);
@@ -2339,7 +2335,8 @@ static char * process_ping(request_rec *r, char **ptr, int *errtype)
             else
                 ap_rprintf(r, "&State=OK");
         }
-    } else {
+    }
+    else {
 
         /* Read the node */
         loc_lock_nodes();
@@ -2355,14 +2352,14 @@ static char * process_ping(request_rec *r, char **ptr, int *errtype)
          * and update the worker status and load factor acccording to the test result.
          */
         ap_set_content_type(r, "text/plain");
-        ap_rprintf(r, "Type=PING-RSP&JVMRoute=%.*s", (int) sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute);
+        ap_rprintf(r, "Type=PING-RSP&JVMRoute=%.*s", (int)sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute);
 
         if (isnode_up(r, node->mess.id, -2) != OK)
             ap_rprintf(r, "&State=NOTOK");
         else
             ap_rprintf(r, "&State=OK");
     }
-    ap_rprintf(r, "&id=%d", (int) ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%d", (int)ap_scoreboard_image->global->restart_time);
 
     ap_rprintf(r, "\n");
     return NULL;
@@ -2403,7 +2400,7 @@ static int mod_manager_hex2c(const char *x)
         i += ch - ('a' - 10);
     }
     return i;
-#else /*APR_CHARSET_EBCDIC*/
+#else /*APR_CHARSET_EBCDIC */
     /*
      * we assume that the hex value refers to an ASCII character
      * so convert to EBCDIC so that it makes sense locally;
@@ -2426,7 +2423,7 @@ static int mod_manager_hex2c(const char *x)
     else {
         return 0;
     }
-#endif /*APR_CHARSET_EBCDIC*/
+#endif /*APR_CHARSET_EBCDIC */
 }
 
 /* Processing of decoded characters */
@@ -2437,13 +2434,13 @@ static apr_status_t decodeenc(char **ptr)
     val = 0;
     while (NULL != ptr[val]) {
         if (ptr[val][0] == '\0') {
-            return APR_SUCCESS;   /* special case for no characters */
+            return APR_SUCCESS; /* special case for no characters */
         }
         for (i = 0, j = 0; ptr[val][i] != '\0'; i++, j++) {
             /* decode it if not already done */
             ch = ptr[val][i];
             if (ch == '%' && apr_isxdigit(ptr[val][i + 1]) && apr_isxdigit(ptr[val][i + 2])) {
-                ch = (char) mod_manager_hex2c(&(ptr[val][i + 1]));
+                ch = (char)mod_manager_hex2c(&(ptr[val][i + 1]));
                 i += 2;
             }
 
@@ -2499,6 +2496,7 @@ static int check_method(request_rec *r)
         ours = 1;
     return ours;
 }
+
 /*
  * This routine is called before mod_proxy translate name.
  * This allows us to make decisions before mod_proxy
@@ -2507,14 +2505,12 @@ static int check_method(request_rec *r)
 static int manager_trans(request_rec *r)
 {
     int ours = 0;
-    core_dir_config *conf =
-        (core_dir_config *)ap_get_module_config(r->per_dir_config,
-                                                &core_module);
+    core_dir_config *conf = (core_dir_config *) ap_get_module_config(r->per_dir_config,
+                                                                     &core_module);
     mod_manager_config *mconf = ap_get_module_config(r->server->module_config,
                                                      &manager_module);
- 
-    if (conf && conf->handler && r->method_number == M_GET &&
-        strcmp(conf->handler, "mod_cluster-manager") == 0) {
+
+    if (conf && conf->handler && r->method_number == M_GET && strcmp(conf->handler, "mod_cluster-manager") == 0) {
         r->handler = "mod_cluster-manager";
         r->filename = apr_pstrdup(r->pool, r->uri);
         return OK;
@@ -2522,24 +2518,24 @@ static int manager_trans(request_rec *r)
     if (r->method_number != M_INVALID)
         return DECLINED;
     if (!mconf->enable_mcpm_receive)
-        return DECLINED; /* Not allowed to receive MCMP */
+        return DECLINED;        /* Not allowed to receive MCMP */
 
-    ours = check_method(r); 
+    ours = check_method(r);
     if (ours) {
         int i;
         /* The method one of ours */
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                    "manager_trans %s (%s)", r->method, r->uri);
-        r->handler = "mod-cluster"; /* that hack doesn't work on httpd-2.4.x */
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "manager_trans %s (%s)", r->method, r->uri);
+        r->handler = "mod-cluster";     /* that hack doesn't work on httpd-2.4.x */
         i = strlen(r->uri);
         if (strcmp(r->uri, "*") == 0 || (i >= 2 && r->uri[i - 1] == '*' && r->uri[i - 2] == '/')) {
             r->filename = apr_pstrdup(r->pool, NODE_COMMAND);
-        } else {
+        }
+        else {
             r->filename = apr_pstrdup(r->pool, r->uri);
         }
         return OK;
     }
-    
+
     return DECLINED;
 }
 
@@ -2552,21 +2548,20 @@ static int manager_map_to_storage(request_rec *r)
     if (r->method_number != M_INVALID)
         return DECLINED;
     if (!mconf->enable_mcpm_receive)
-        return DECLINED; /* Not allowed to receive MCMP */
+        return DECLINED;        /* Not allowed to receive MCMP */
 
-    ours = check_method(r); 
+    ours = check_method(r);
     if (ours) {
         /* The method one of ours */
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                    "manager_map_to_storage %s (%s)", r->method, r->uri);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "manager_map_to_storage %s (%s)", r->method, r->uri);
         return OK;
     }
-    
+
     return DECLINED;
 }
 
 /* Create the commands that are possible on the context */
-static char*context_string(request_rec *r, contextinfo_t *ou, char *Alias, char *JVMRoute)
+static char *context_string(request_rec *r, contextinfo_t *ou, char *Alias, char *JVMRoute)
 {
     char context[CONTEXTSZ + 1];
     char *raw;
@@ -2574,6 +2569,7 @@ static char*context_string(request_rec *r, contextinfo_t *ou, char *Alias, char 
     raw = apr_pstrcat(r->pool, "JVMRoute=", JVMRoute, "&Alias=", Alias, "&Context=", context, NULL);
     return raw;
 }
+
 static char *balancer_nonce_string(request_rec *r)
 {
     char *ret = "";
@@ -2583,6 +2579,7 @@ static char *balancer_nonce_string(request_rec *r)
         ret = apr_psprintf(r->pool, "nonce=%s&", balancer_nonce);
     return ret;
 }
+
 static void context_command_string(request_rec *r, contextinfo_t *ou, char *Alias, char *JVMRoute)
 {
     if (ou->status == DISABLED) {
@@ -2604,12 +2601,14 @@ static void context_command_string(request_rec *r, contextinfo_t *ou, char *Alia
                    r->uri, balancer_nonce_string(r), context_string(r, ou, Alias, JVMRoute));
     }
 }
+
 /* Create the commands that are possible on the node */
-static char*node_string(request_rec *r, char *JVMRoute)
+static char *node_string(request_rec *r, char *JVMRoute)
 {
     char *raw = apr_pstrcat(r->pool, "JVMRoute=", JVMRoute, NULL);
     return raw;
 }
+
 static void node_command_string(request_rec *r, char *JVMRoute)
 {
     ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=NODE&%s\">Enable Contexts</a> ",
@@ -2619,6 +2618,7 @@ static void node_command_string(request_rec *r, char *JVMRoute)
     ap_rprintf(r, "<a href=\"%s?%sCmd=STOP-APP&Range=NODE&%s\">Stop Contexts</a>",
                r->uri, balancer_nonce_string(r), node_string(r, JVMRoute));
 }
+
 static void domain_command_string(request_rec *r, char *Domain)
 {
     ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=DOMAIN&Domain=%s\">Enable Nodes</a> ",
@@ -2632,7 +2632,8 @@ static void domain_command_string(request_rec *r, char *Domain)
 /*
  * Process the parameters and display corresponding informations.
  */
-static void manager_info_contexts(request_rec *r, int reduce_display, int allow_cmd, int node, int host, char *Alias, char *JVMRoute)
+static void manager_info_contexts(request_rec *r, int reduce_display, int allow_cmd, int node, int host, char *Alias,
+                                  char *JVMRoute)
 {
     int size, i;
     int *id;
@@ -2654,23 +2655,24 @@ static void manager_info_contexts(request_rec *r, int reduce_display, int allow_
             continue;
         status = "REMOVED";
         switch (ou->status) {
-            case ENABLED:
-                status = "ENABLED";
-                break;
-            case DISABLED:
-                status = "DISABLED";
-                break;
-            case STOPPED:
-                status = "STOPPED";
-                break;
+        case ENABLED:
+            status = "ENABLED";
+            break;
+        case DISABLED:
+            status = "DISABLED";
+            break;
+        case STOPPED:
+            status = "STOPPED";
+            break;
         }
-        ap_rprintf(r, "%.*s, Status: %s Request: %d ", (int) sizeof(ou->context), ou->context, status, ou->nbrequests);
+        ap_rprintf(r, "%.*s, Status: %s Request: %d ", (int)sizeof(ou->context), ou->context, status, ou->nbrequests);
         if (allow_cmd)
             context_command_string(r, ou, Alias, JVMRoute);
         ap_rprintf(r, "\n");
     }
     ap_rprintf(r, "</pre>");
 }
+
 static void manager_info_hosts(request_rec *r, int reduce_display, int allow_cmd, int node, char *JVMRoute)
 {
     int size, i, j;
@@ -2706,14 +2708,14 @@ static void manager_info_hosts(request_rec *r, int reduce_display, int allow_cmd
                 ap_rprintf(r, "<pre>");
             }
             vhost = ou->vhost;
-        
+
             if (reduce_display)
-                ap_rprintf(r, "%.*s ", (int) sizeof(ou->host), ou->host);
+                ap_rprintf(r, "%.*s ", (int)sizeof(ou->host), ou->host);
             else
-                ap_rprintf(r, "%.*s\n", (int) sizeof(ou->host), ou->host);
-            
+                ap_rprintf(r, "%.*s\n", (int)sizeof(ou->host), ou->host);
+
             /* Go ahead and check for any other later alias entries for this vhost and print them now */
-            for (j = i+1; j < size; j++) {
+            for (j = i + 1; j < size; j++) {
                 hostinfo_t *pv;
                 if (get_host(hoststatsmem, &pv, id[j]) != APR_SUCCESS)
                     continue;
@@ -2728,9 +2730,9 @@ static void manager_info_hosts(request_rec *r, int reduce_display, int allow_cmd
                 if (i == j - 1)
                     i++;
                 if (reduce_display)
-                    ap_rprintf(r, "%.*s ", (int) sizeof(pv->host), pv->host);
+                    ap_rprintf(r, "%.*s ", (int)sizeof(pv->host), pv->host);
                 else
-                    ap_rprintf(r, "%.*s\n", (int) sizeof(pv->host), pv->host);
+                    ap_rprintf(r, "%.*s\n", (int)sizeof(pv->host), pv->host);
             }
         }
     }
@@ -2738,6 +2740,7 @@ static void manager_info_hosts(request_rec *r, int reduce_display, int allow_cmd
         ap_rprintf(r, "</pre>");
 
 }
+
 static void manager_sessionid(request_rec *r)
 {
     int size, i;
@@ -2757,7 +2760,8 @@ static void manager_sessionid(request_rec *r)
         sessionidinfo_t *ou;
         if (get_sessionid(sessionidstatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
-        ap_rprintf(r, "id: %.*s route: %.*s\n", (int) sizeof(ou->sessionid), ou->sessionid, (int) sizeof(ou->JVMRoute), ou->JVMRoute);
+        ap_rprintf(r, "id: %.*s route: %.*s\n", (int)sizeof(ou->sessionid), ou->sessionid, (int)sizeof(ou->JVMRoute),
+                   ou->JVMRoute);
     }
     ap_rprintf(r, "</pre>");
 
@@ -2786,8 +2790,7 @@ static void manager_domain(request_rec *r, int reduce_display)
             continue;
         ap_rprintf(r, "dom: %.*s route: %.*s balancer: %.*s\n",
                    sizeof(ou->domain), ou->domain,
-                   sizeof(ou->JVMRoute), ou->JVMRoute,
-                   sizeof(ou->balancer), ou->balancer);
+                   sizeof(ou->JVMRoute), ou->JVMRoute, sizeof(ou->balancer), ou->balancer);
     }
     ap_rprintf(r, "</pre>");
 
@@ -2811,29 +2814,31 @@ static int count_sessionid(request_rec *r, char *route)
         if (get_sessionid(sessionidstatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
         if (strcmp(route, ou->JVMRoute) == 0)
-            count++; 
+            count++;
     }
     return count;
 }
+
 static void process_error(request_rec *r, char *errstring, int errtype)
 {
     r->status_line = apr_psprintf(r->pool, "ERROR");
     apr_table_setn(r->err_headers_out, "Version", VERSION_PROTOCOL);
     switch (errtype) {
-      case TYPESYNTAX:
-         apr_table_setn(r->err_headers_out, "Type", "SYNTAX");
-         break;
-      case TYPEMEM:
-         apr_table_setn(r->err_headers_out, "Type", "MEM");
-         break;
-      default:
-         apr_table_setn(r->err_headers_out, "Type", "GENERAL");
-         break;
+    case TYPESYNTAX:
+        apr_table_setn(r->err_headers_out, "Type", "SYNTAX");
+        break;
+    case TYPEMEM:
+        apr_table_setn(r->err_headers_out, "Type", "MEM");
+        break;
+    default:
+        apr_table_setn(r->err_headers_out, "Type", "GENERAL");
+        break;
     }
     apr_table_setn(r->err_headers_out, "Mess", errstring);
-    ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_WARNING, 0, r->server,
-            "manager_handler %s error: %s", r->method, errstring);
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_WARNING, 0, r->server,
+                 "manager_handler %s error: %s", r->method, errstring);
 }
+
 static void sort_nodes(nodeinfo_t *nodes, int nbnodes)
 {
     int i;
@@ -2843,7 +2848,7 @@ static void sort_nodes(nodeinfo_t *nodes, int nbnodes)
     while (changed) {
         changed = 0;
         for (i = 0; i < nbnodes - 1; i++) {
-            if (strcmp(nodes[i].mess.Domain, nodes[i + 1].mess.Domain)> 0) {
+            if (strcmp(nodes[i].mess.Domain, nodes[i + 1].mess.Domain) > 0) {
                 nodeinfo_t node;
                 node = nodes[i + 1];
                 nodes[i + 1] = nodes[i];
@@ -2853,6 +2858,7 @@ static void sort_nodes(nodeinfo_t *nodes, int nbnodes)
         }
     }
 }
+
 static char *process_domain(request_rec *r, char **ptr, int *errtype, const char *cmd, const char *domain)
 {
     int size, i;
@@ -2865,12 +2871,12 @@ static char *process_domain(request_rec *r, char **ptr, int *errtype, const char
     id = apr_palloc(r->pool, sizeof(int) * size);
     size = get_ids_used_node(nodestatsmem, id);
 
-    for (pos = 0; ptr[pos] != NULL && ptr[pos + 1] != NULL; pos = pos + 2) ;
+    for (pos = 0; ptr[pos] != NULL && ptr[pos + 1] != NULL; pos = pos + 2);
 
     ptr[pos] = apr_pstrdup(r->pool, "JVMRoute");
     ptr[pos + 2] = NULL;
     ptr[pos + 3] = NULL;
-    ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, r->server, "process_domain");
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, r->server, "process_domain");
     for (i = 0; i < size; i++) {
         nodeinfo_t *ou;
         if (get_node(nodestatsmem, &ou, id[i]) != APR_SUCCESS)
@@ -2890,6 +2896,7 @@ static char *process_domain(request_rec *r, char **ptr, int *errtype, const char
     }
     return errstring;
 }
+
 /* XXX: move to mod_proxy_cluster as a provider ? */
 static void printproxy_stat(request_rec *r, int reduce_display, proxy_worker_shared *proxystat)
 {
@@ -2902,10 +2909,11 @@ static void printproxy_stat(request_rec *r, int reduce_display, proxy_worker_sha
         ap_rprintf(r, " %s ", status);
     else
         ap_rprintf(r, ",Status: %s,Elected: %d,Read: %d,Transferred: %d,Connected: %d,Load: %d",
-               status,
-               (int) proxystat->elected, (int) proxystat->read, (int) proxystat->transferred,
-               (int) proxystat->busy, proxystat->lbfactor);
+                   status,
+                   (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred,
+                   (int)proxystat->busy, proxystat->lbfactor);
 }
+
 /* Display module information */
 static void modules_info(request_rec *r)
 {
@@ -2922,9 +2930,9 @@ static void modules_info(request_rec *r)
     ap_rputs("Protocol supported: ", r);
     if (ap_find_linked_module("mod_proxy_http.c") != NULL)
         ap_rputs("http ", r);
-    if (ap_find_linked_module("mod_proxy_ajp.c") != NULL) 
+    if (ap_find_linked_module("mod_proxy_ajp.c") != NULL)
         ap_rputs("AJP ", r);
-    if (ap_find_linked_module("mod_ssl.c") != NULL) 
+    if (ap_find_linked_module("mod_ssl.c") != NULL)
         ap_rputs("https", r);
     ap_rputs("<br/>", r);
 
@@ -2934,6 +2942,7 @@ static void modules_info(request_rec *r)
         ap_rputs("mod_advertise.c: not loaded<br/>", r);
 
 }
+
 /* Process INFO message and mod_cluster_manager pages generation */
 static int manager_info(request_rec *r)
 {
@@ -2961,7 +2970,7 @@ static int manager_info(request_rec *r)
                  * Special case: contexts contain path information
                  */
                 if ((access_status = ap_unescape_url(val)) != OK)
-                    if (strcmp(args, "Context") || (access_status !=  HTTP_NOT_FOUND))
+                    if (strcmp(args, "Context") || (access_status != HTTP_NOT_FOUND))
                         return access_status;
                 apr_table_setn(params, args, val);
                 args = tok;
@@ -2969,16 +2978,14 @@ static int manager_info(request_rec *r)
             else
                 return HTTP_BAD_REQUEST;
         }
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                "manager_info request:%s", r->args);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "manager_info request:%s", r->args);
     }
 
     /*
      * Check that the supplied nonce matches this server's nonce;
      * otherwise ignore all parameters, to prevent a CSRF attack.
      */
-    if (mconf->nonce && ((name = apr_table_get(params, "nonce")) == NULL
-        || strcmp(balancer_nonce, name) != 0)) {
+    if (mconf->nonce && ((name = apr_table_get(params, "nonce")) == NULL || strcmp(balancer_nonce, name) != 0)) {
         apr_table_clear(params);
     }
 
@@ -2991,7 +2998,7 @@ static int manager_info(request_rec *r)
         /* Process the Refresh parameter */
         if (val) {
             long t = atol(val);
-            apr_table_set(r->headers_out, "Refresh", apr_ltoa(r->pool,t < 1 ? 10 : t));
+            apr_table_set(r->headers_out, "Refresh", apr_ltoa(r->pool, t < 1 ? 10 : t));
         }
         /* Process INFO and DUMP */
         if (cmd != NULL) {
@@ -3000,7 +3007,8 @@ static int manager_info(request_rec *r)
                 errstring = process_dump(r, &errtype);
                 if (!errstring)
                     return OK;
-            } else if (strcasecmp(cmd, "INFO") == 0) {
+            }
+            else if (strcasecmp(cmd, "INFO") == 0) {
                 errstring = process_info(r, &errtype);
                 if (!errstring)
                     return OK;
@@ -3018,9 +3026,9 @@ static int manager_info(request_rec *r)
             const apr_array_header_t *arr = apr_table_elts(params);
             const apr_table_entry_t *elts = (const apr_table_entry_t *)arr->elts;
 
-            if (strcasecmp(typ,"NODE") == 0)
+            if (strcasecmp(typ, "NODE") == 0)
                 global = RANGENODE;
-            else if (strcasecmp(typ,"DOMAIN") == 0)
+            else if (strcasecmp(typ, "DOMAIN") == 0)
                 global = RANGEDOMAIN;
 
             if (global == RANGEDOMAIN)
@@ -3033,7 +3041,7 @@ static int manager_info(request_rec *r)
             }
             ptr[arr->nelts * 2] = NULL;
             ptr[arr->nelts * 2 + 1] = NULL;
-             
+
             if (global == RANGEDOMAIN)
                 errstring = process_domain(r, ptr, &errtype, cmd, domain);
             else if (strcasecmp(cmd, "ENABLE-APP") == 0)
@@ -3053,15 +3061,13 @@ static int manager_info(request_rec *r)
             }
         }
     }
-    
+
     ap_set_content_type(r, "text/html; charset=ISO-8859-1");
-    ap_rputs(DOCTYPE_HTML_3_2
-             "<html><head>\n<title>Mod_cluster Status</title>\n</head><body>\n",
-             r);
+    ap_rputs(DOCTYPE_HTML_3_2 "<html><head>\n<title>Mod_cluster Status</title>\n</head><body>\n", r);
     ap_rvputs(r, "<h1>", MOD_CLUSTER_EXPOSED_VERSION, "</h1>", NULL);
 
     if (errstring) {
-        ap_rvputs(r, "<h1> Command failed: ", errstring , "</h1>\n", NULL);
+        ap_rvputs(r, "<h1> Command failed: ", errstring, "</h1>\n", NULL);
         ap_rvputs(r, " <a href=\"", r->uri, "\">Continue</a>\n", NULL);
         ap_rputs("</body></html>\n", r);
         return OK;
@@ -3069,24 +3075,20 @@ static int manager_info(request_rec *r)
 
     /* Advertise information */
     if (mconf->allow_display) {
-        ap_rputs("start of \"httpd.conf\" configuration<br/>", r); 
+        ap_rputs("start of \"httpd.conf\" configuration<br/>", r);
         modules_info(r);
         if (advertise_info != NULL)
             advertise_info(r);
         ap_rputs("end of \"httpd.conf\" configuration<br/><br/>", r);
     }
 
-    ap_rvputs(r, "<a href=\"", r->uri, "?", balancer_nonce_string(r),
-                 "refresh=10",
-                 "\">Auto Refresh</a>", NULL);
+    ap_rvputs(r, "<a href=\"", r->uri, "?", balancer_nonce_string(r), "refresh=10", "\">Auto Refresh</a>", NULL);
 
     ap_rvputs(r, " <a href=\"", r->uri, "?", balancer_nonce_string(r),
-                 "Cmd=DUMP&Range=ALL",
-                 "\">show DUMP output</a>", NULL);
+              "Cmd=DUMP&Range=ALL", "\">show DUMP output</a>", NULL);
 
     ap_rvputs(r, " <a href=\"", r->uri, "?", balancer_nonce_string(r),
-                 "Cmd=INFO&Range=ALL",
-                 "\">show INFO output</a>", NULL);
+              "Cmd=INFO&Range=ALL", "\">show INFO output</a>", NULL);
 
     ap_rputs("\n", r);
 
@@ -3105,7 +3107,7 @@ static int manager_info(request_rec *r)
         nodeinfo_t *ou;
         if (get_node(nodestatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
-        memcpy(&nodes[nbnodes],ou, sizeof(nodeinfo_t));
+        memcpy(&nodes[nbnodes], ou, sizeof(nodeinfo_t));
         nbnodes++;
     }
     sort_nodes(nodes, nbnodes);
@@ -3114,13 +3116,13 @@ static int manager_info(request_rec *r)
     for (i = 0; i < size; i++) {
         char *flushpackets;
         nodeinfo_t *ou = &nodes[i];
-        char *pptr = (char *) ou;
+        char *pptr = (char *)ou;
 
         if (strcmp(domain, ou->mess.Domain) != 0) {
             if (mconf->reduce_display)
-                ap_rprintf(r, "<br/><br/>LBGroup %.*s: ", (int) sizeof(ou->mess.Domain), ou->mess.Domain);
+                ap_rprintf(r, "<br/><br/>LBGroup %.*s: ", (int)sizeof(ou->mess.Domain), ou->mess.Domain);
             else
-                ap_rprintf(r, "<h1> LBGroup %.*s: ", (int) sizeof(ou->mess.Domain), ou->mess.Domain);
+                ap_rprintf(r, "<h1> LBGroup %.*s: ", (int)sizeof(ou->mess.Domain), ou->mess.Domain);
             domain = ou->mess.Domain;
             if (mconf->allow_cmd)
                 domain_command_string(r, domain);
@@ -3128,14 +3130,12 @@ static int manager_info(request_rec *r)
                 ap_rprintf(r, "</h1>\n");
         }
         if (mconf->reduce_display)
-            ap_rprintf(r, "<br/><br/>Node %.*s ",
-                   (int) sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute);
-        else 
+            ap_rprintf(r, "<br/><br/>Node %.*s ", (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute);
+        else
             ap_rprintf(r, "<h1> Node %.*s (%.*s://%.*s:%.*s): </h1>\n",
-                   (int) sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
-                   (int) sizeof(ou->mess.Type), ou->mess.Type,
-                   (int) sizeof(ou->mess.Host), ou->mess.Host,
-                   (int) sizeof(ou->mess.Port), ou->mess.Port);
+                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
+                       (int)sizeof(ou->mess.Type), ou->mess.Type,
+                       (int)sizeof(ou->mess.Host), ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port);
         pptr = pptr + ou->offset;
         if (mconf->reduce_display) {
             /* XXX: The logic depend on the proxy and should use shared memory directly */
@@ -3147,35 +3147,33 @@ static int manager_info(request_rec *r)
 
         if (!mconf->reduce_display) {
             ap_rprintf(r, "<br/>\n");
-            ap_rprintf(r, "Balancer: %.*s,LBGroup: %.*s", (int) sizeof(ou->mess.balancer), ou->mess.balancer,
-                   (int) sizeof(ou->mess.Domain), ou->mess.Domain);
+            ap_rprintf(r, "Balancer: %.*s,LBGroup: %.*s", (int)sizeof(ou->mess.balancer), ou->mess.balancer,
+                       (int)sizeof(ou->mess.Domain), ou->mess.Domain);
 
             flushpackets = "Off";
             switch (ou->mess.flushpackets) {
-                case flush_on:
-                    flushpackets = "On";
-                    break;
-                case flush_auto:
-                    flushpackets = "Auto";
+            case flush_on:
+                flushpackets = "On";
+                break;
+            case flush_auto:
+                flushpackets = "Auto";
             }
             ap_rprintf(r, ",Flushpackets: %s,Flushwait: %d,Ping: %d,Smax: %d,Ttl: %d",
-                   flushpackets, ou->mess.flushwait,
-                   (int) ou->mess.ping, ou->mess.smax, (int) ou->mess.ttl);
+                       flushpackets, ou->mess.flushwait, (int)ou->mess.ping, ou->mess.smax, (int)ou->mess.ttl);
         }
 
         if (mconf->reduce_display)
             ap_rprintf(r, "<br/>\n");
-        else {
+        else
             printproxy_stat(r, mconf->reduce_display, (proxy_worker_shared *) pptr);
-        }
 
         if (sizesessionid) {
-            ap_rprintf(r, ",Num sessions: %d",  count_sessionid(r, ou->mess.JVMRoute));
+            ap_rprintf(r, ",Num sessions: %d", count_sessionid(r, ou->mess.JVMRoute));
         }
         ap_rprintf(r, "\n");
 
         /* Process the Vhosts */
-        manager_info_hosts(r, mconf->reduce_display, mconf->allow_cmd, ou->mess.id, ou->mess.JVMRoute); 
+        manager_info_hosts(r, mconf->reduce_display, mconf->allow_cmd, ou->mess.id, ou->mess.JVMRoute);
     }
     /* Display the sessions */
     if (sizesessionid)
@@ -3183,7 +3181,6 @@ static int manager_info(request_rec *r)
 #if HAVE_CLUSTER_EX_DEBUG
     manager_domain(r, mconf->reduce_display);
 #endif
-
 
     ap_rputs("</body></html>\n", r);
     return OK;
@@ -3203,41 +3200,44 @@ static int manager_handler(request_rec *r)
     char **ptr;
     void *sconf = r->server->module_config;
     mod_manager_config *mconf;
-  
+
     if (strcmp(r->handler, "mod_cluster-manager") == 0) {
         /* Display the nodes information */
         if (r->method_number != M_GET)
             return DECLINED;
-        return(manager_info(r));
+        return manager_info(r);
     }
 
     mconf = ap_get_module_config(sconf, &manager_module);
     if (!mconf->enable_mcpm_receive)
-        return DECLINED; /* Not allowed to receive MCMP */
+        return DECLINED;        /* Not allowed to receive MCMP */
 
     ours = check_method(r);
     if (!ours)
         return DECLINED;
 
     /* Use a buffer to read the message */
-    if (mconf->maxmesssize)
-       maxbufsiz = mconf->maxmesssize;
-    else {
-       /* we calculate it */
-       maxbufsiz = 9 + JVMROUTESZ;
-       maxbufsiz = maxbufsiz + (mconf->maxhost * HOSTALIASZ) + 7;
-       maxbufsiz = maxbufsiz + (mconf->maxcontext * CONTEXTSZ) + 8;
+    if (mconf->maxmesssize) {
+        maxbufsiz = mconf->maxmesssize;
     }
-    if (maxbufsiz< MAXMESSSIZE)
-       maxbufsiz = MAXMESSSIZE;
+    else {
+        /* we calculate it */
+        maxbufsiz = 9 + JVMROUTESZ;
+        maxbufsiz = maxbufsiz + (mconf->maxhost * HOSTALIASZ) + 7;
+        maxbufsiz = maxbufsiz + (mconf->maxcontext * CONTEXTSZ) + 8;
+    }
+    if (maxbufsiz < MAXMESSSIZE)
+        maxbufsiz = MAXMESSSIZE;
     buff = apr_pcalloc(r->pool, maxbufsiz);
     input_brigade = apr_brigade_create(r->pool, r->connection->bucket_alloc);
     len = maxbufsiz;
-    while ((status = ap_get_brigade(r->input_filters, input_brigade, AP_MODE_READBYTES, APR_BLOCK_READ, len)) == APR_SUCCESS) {
+    while ((status =
+            ap_get_brigade(r->input_filters, input_brigade, AP_MODE_READBYTES, APR_BLOCK_READ, len)) == APR_SUCCESS) {
         apr_brigade_flatten(input_brigade, buff + bufsiz, &len);
         apr_brigade_cleanup(input_brigade);
         bufsiz += len;
-        if (bufsiz >= maxbufsiz || len == 0) break;
+        if (bufsiz >= maxbufsiz || len == 0)
+            break;
         len = maxbufsiz - bufsiz;
     }
 
@@ -3247,15 +3247,14 @@ static int manager_handler(request_rec *r)
         apr_table_setn(r->err_headers_out, "Version", VERSION_PROTOCOL);
         apr_table_setn(r->err_headers_out, "Type", "SYNTAX");
         apr_table_setn(r->err_headers_out, "Mess", errstring);
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                "manager_handler %s error: %s", r->method, errstring);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "manager_handler %s error: %s", r->method, errstring);
         return 500;
     }
     buff[bufsiz] = '\0';
 
     /* XXX: Size limit it? */
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                "manager_handler %s (%s) processing: \"%s\"", r->method, r->filename, buff);
+                 "manager_handler %s (%s) processing: \"%s\"", r->method, r->filename, buff);
 
     ptr = process_buff(r, buff);
     if (ptr == NULL) {
@@ -3298,17 +3297,16 @@ static int manager_handler(request_rec *r)
         return 500;
     }
 
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                "manager_handler %s  OK", r->method);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "manager_handler %s  OK", r->method);
 
     ap_rflush(r);
-    return (OK);
+    return OK;
 }
 
 /*
  *  Attach to the shared memory when the child is created.
  */
-static void  manager_child_init(apr_pool_t *p, server_rec *s)
+static void manager_child_init(apr_pool_t *p, server_rec *s)
 {
     char *node;
     char *context;
@@ -3319,20 +3317,18 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
 
     if (storage == NULL) {
         /* that happens when doing a gracefull restart for example after additing/changing the storage provider */
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "Fatal storage provider not initialized");
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "Fatal storage provider not initialized");
         return;
     }
 
     if (apr_global_mutex_child_init(&node_mutex, apr_global_mutex_lockfile(node_mutex), p) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(02994)
-                     "Failed to reopen mutex %s in child",
-                     node_mutex_type);
+                     "Failed to reopen mutex %s in child", node_mutex_type);
         exit(EXIT_FAILURE);
     }
     if (apr_global_mutex_child_init(&context_mutex, apr_global_mutex_lockfile(context_mutex), p) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(02994)
-                     "Failed to reopen mutex %s in child",
-                     context_mutex_type);
+                     "Failed to reopen mutex %s in child", context_mutex_type);
         exit(EXIT_FAILURE);
     }
 
@@ -3344,7 +3340,8 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
         host = apr_pstrcat(p, mconf->basefilename, "/manager.host", NULL);
         balancer = apr_pstrcat(p, mconf->basefilename, "/manager.balancer", NULL);
         sessionid = apr_pstrcat(p, mconf->basefilename, "/manager.sessionid", NULL);
-    } else {
+    }
+    else {
         node = ap_server_root_relative(p, "logs/manager.node");
         context = ap_server_root_relative(p, "logs/manager.context");
         host = ap_server_root_relative(p, "logs/manager.host");
@@ -3354,31 +3351,31 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
 
     nodestatsmem = get_mem_node(node, &mconf->maxnode, p, storage);
     if (nodestatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_node %s failed", node);
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_node %s failed", node);
         return;
     }
     if (get_last_mem_error(nodestatsmem) != APR_SUCCESS) {
         char buf[120];
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_node %s failed: %s",
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_node %s failed: %s",
                      node, apr_strerror(get_last_mem_error(nodestatsmem), buf, sizeof(buf)));
         return;
     }
 
     contextstatsmem = get_mem_context(context, &mconf->maxcontext, p, storage);
     if (contextstatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_context failed");
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_context failed");
         return;
     }
 
     hoststatsmem = get_mem_host(host, &mconf->maxhost, p, storage);
     if (hoststatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_host failed");
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_host failed");
         return;
     }
 
     balancerstatsmem = get_mem_balancer(balancer, &mconf->maxhost, p, storage);
     if (balancerstatsmem == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_balancer failed");
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_balancer failed");
         return;
     }
 
@@ -3386,7 +3383,7 @@ static void  manager_child_init(apr_pool_t *p, server_rec *s)
         /*  Try to get sessionid stuff only if required */
         sessionidstatsmem = get_mem_sessionid(sessionid, &mconf->maxsessionid, p, storage);
         if (sessionidstatsmem == NULL) {
-            ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_EMERG, 0, s, "get_mem_sessionid failed");
+            ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_sessionid failed");
             return;
         }
     }
@@ -3399,7 +3396,7 @@ static const char *cmd_manager_maxcontext(cmd_parms *cmd, void *mconfig, const c
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
@@ -3407,11 +3404,12 @@ static const char *cmd_manager_maxcontext(cmd_parms *cmd, void *mconfig, const c
     mconf->maxcontext = atoi(word);
     return NULL;
 }
+
 static const char *cmd_manager_maxnode(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
@@ -3419,11 +3417,12 @@ static const char *cmd_manager_maxnode(cmd_parms *cmd, void *mconfig, const char
     mconf->maxnode = atoi(word);
     return NULL;
 }
+
 static const char *cmd_manager_maxhost(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
@@ -3431,11 +3430,12 @@ static const char *cmd_manager_maxhost(cmd_parms *cmd, void *mconfig, const char
     mconf->maxhost = atoi(word);
     return NULL;
 }
+
 static const char *cmd_manager_maxsessionid(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
@@ -3443,137 +3443,141 @@ static const char *cmd_manager_maxsessionid(cmd_parms *cmd, void *mconfig, const
     mconf->maxsessionid = atoi(word);
     return NULL;
 }
+
 static const char *cmd_manager_memmanagerfile(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
     }
     mconf->basefilename = ap_server_root_relative(cmd->pool, word);
     if (apr_dir_make_recursive(mconf->basefilename, APR_UREAD | APR_UWRITE | APR_UEXECUTE, cmd->pool) != APR_SUCCESS)
-        return  "Can't create directory corresponding to MemManagerFile";
+        return "Can't create directory corresponding to MemManagerFile";
     return NULL;
 }
+
 static const char *cmd_manager_balancername(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     mconf->balancername = apr_pstrdup(cmd->pool, word);
     normalize_balancer_name(mconf->balancername, cmd->server);
-    (void) mconfig; /* unused variable */
+    (void)mconfig;              /* unused variable */
     return NULL;
 }
-static const char*cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg)
+
+static const char *cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) dummy;
+    (void)dummy;
 
     if (err != NULL) {
         return err;
     }
     if (strcasecmp(arg, "Off") == 0)
-       mconf->persistent = 0;
+        mconf->persistent = 0;
     else if (strcasecmp(arg, "On") == 0)
-       mconf->persistent = CREPER_SLOTMEM;
-    else {
-       return "PersistSlots must be one of: "
-              "off | on";
-    }
+        mconf->persistent = CREPER_SLOTMEM;
+    else
+        return "PersistSlots must be one of: " "off | on";
+
     return NULL;
 }
 
-static const char*cmd_manager_nonce(cmd_parms *cmd, void *dummy, const char *arg)
+static const char *cmd_manager_nonce(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
-    (void) dummy;
+    (void)dummy;
 
     if (strcasecmp(arg, "Off") == 0)
-       mconf->nonce = 0;
+        mconf->nonce = 0;
     else if (strcasecmp(arg, "On") == 0)
-       mconf->nonce = -1;
-    else {
-       return "CheckNonce must be one of: "
-              "off | on";
-    }
+        mconf->nonce = -1;
+    else
+        return "CheckNonce must be one of: " "off | on";
+
     return NULL;
 }
-static const char*cmd_manager_allow_display(cmd_parms *cmd, void *dummy, const char *arg)
+
+static const char *cmd_manager_allow_display(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
-    (void) dummy;
+    (void)dummy;
 
     if (strcasecmp(arg, "Off") == 0)
-       mconf->allow_display = 0;
+        mconf->allow_display = 0;
     else if (strcasecmp(arg, "On") == 0)
-       mconf->allow_display = -1;
-    else {
-       return "AllowDisplay must be one of: "
-              "off | on";
-    }
+        mconf->allow_display = -1;
+    else
+        return "AllowDisplay must be one of: " "off | on";
+
     return NULL;
 }
-static const char*cmd_manager_allow_cmd(cmd_parms *cmd, void *dummy, const char *arg)
+
+static const char *cmd_manager_allow_cmd(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
-    (void) dummy;
+    (void)dummy;
 
     if (strcasecmp(arg, "Off") == 0)
-       mconf->allow_cmd = 0;
+        mconf->allow_cmd = 0;
     else if (strcasecmp(arg, "On") == 0)
-       mconf->allow_cmd = -1;
-    else {
-       return "AllowCmd must be one of: "
-              "off | on";
-    }
+        mconf->allow_cmd = -1;
+    else
+        return "AllowCmd must be one of: " "off | on";
+
     return NULL;
 }
-static const char*cmd_manager_reduce_display(cmd_parms *cmd, void *dummy, const char *arg)
+
+static const char *cmd_manager_reduce_display(cmd_parms *cmd, void *dummy, const char *arg)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
-    (void) dummy;
+    (void)dummy;
 
     if (strcasecmp(arg, "Off") == 0)
-       mconf->reduce_display = 0;
+        mconf->reduce_display = 0;
     else if (strcasecmp(arg, "On") == 0)
-       mconf->reduce_display = -1;
-    else {
-       return "ReduceDisplay must be one of: "
-              "off | on";
-    }
+        mconf->reduce_display = -1;
+    else
+        return "ReduceDisplay must be one of: " "off | on";
+
     return NULL;
 }
-static const char*cmd_manager_maxmesssize(cmd_parms *cmd, void *mconfig, const char *word)
+
+static const char *cmd_manager_maxmesssize(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
     }
     mconf->maxmesssize = atoi(word);
     if (mconf->maxmesssize < MAXMESSSIZE)
-       return "MaxMCMPMessSize must bigger than 1024";
+        return "MaxMCMPMessSize must bigger than 1024";
     return NULL;
 }
-static const char*cmd_manager_enable_mcpm_receive(cmd_parms *cmd, void *dummy)
+
+static const char *cmd_manager_enable_mcpm_receive(cmd_parms *cmd, void *dummy)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
-    (void) dummy;
+    (void)dummy;
 
     if (!cmd->server->is_virtual)
         return "EnableMCPMReceive must be in a VirtualHost";
     mconf->enable_mcpm_receive = -1;
     return NULL;
 }
-static const char*cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void *dummy)
+
+static const char *cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void *dummy)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) dummy;
+    (void)dummy;
 
     if (err != NULL) {
         return err;
@@ -3581,16 +3585,17 @@ static const char*cmd_manager_enable_ws_tunnel(cmd_parms *cmd, void *dummy)
     if (ap_find_linked_module("mod_proxy_wstunnel.c") != NULL) {
         mconf->enable_ws_tunnel = -1;
         return NULL;
-    } else {
+    }
+    else {
         return "EnableWsTunnel requires mod_proxy_wstunnel.c";
     }
 }
 
-static const char*cmd_manager_ws_upgrade_header(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_ws_upgrade_header(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
@@ -3603,38 +3608,39 @@ static const char*cmd_manager_ws_upgrade_header(cmd_parms *cmd, void *mconfig, c
         mconf->enable_ws_tunnel = -1;
         mconf->ws_upgrade_header = apr_pstrdup(cmd->pool, word);
         return NULL;
-    } else {
+    }
+    else {
         return "WSUpgradeHeader requires mod_proxy_wstunnel.c";
     }
 }
 
-static const char*cmd_manager_ajp_secret(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_ajp_secret(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
     }
     if (strlen(word) >= PROXY_WORKER_MAX_SECRET_SIZE) {
-        return apr_psprintf(cmd->temp_pool, "AJP secret length must be < %d characters",
-                            PROXY_WORKER_MAX_SECRET_SIZE);
+        return apr_psprintf(cmd->temp_pool, "AJP secret length must be < %d characters", PROXY_WORKER_MAX_SECRET_SIZE);
     }
     if (ap_find_linked_module("mod_proxy_ajp.c") != NULL) {
         mconf->ajp_secret = apr_pstrdup(cmd->pool, word);
         return NULL;
-    } else {
+    }
+    else {
         return "AJPsecret requires mod_proxy_ajp.c";
     }
 }
 
-static const char*cmd_manager_responsefieldsize(cmd_parms *cmd, void *mconfig, const char *word)
+static const char *cmd_manager_responsefieldsize(cmd_parms *cmd, void *mconfig, const char *word)
 {
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     const char *err = ap_check_cmd_context(cmd, GLOBAL_ONLY);
     long s = atol(word);
-    (void) mconfig;
+    (void)mconfig;
 
     if (err != NULL) {
         return err;
@@ -3645,133 +3651,99 @@ static const char*cmd_manager_responsefieldsize(cmd_parms *cmd, void *mconfig, c
     if (ap_find_linked_module("mod_proxy_http.c") != NULL) {
         mconf->response_field_size = (s ? s : HUGE_STRING_LEN);
         return NULL;
-    } else {
+    }
+    else {
         return "ResponseFieldSize requires mod_proxy_http.c";
     }
 }
 
 
-static const command_rec  manager_cmds[] =
-{
-    AP_INIT_TAKE1(
-        "Maxcontext",
-        cmd_manager_maxcontext,
-        NULL,
-        OR_ALL,
-        "Maxcontext - number max context supported by mod_cluster"
-    ),
-    AP_INIT_TAKE1(
-        "Maxnode",
-        cmd_manager_maxnode,
-        NULL,
-        OR_ALL,
-        "Maxnode - number max node supported by mod_cluster"
-    ),
-    AP_INIT_TAKE1(
-        "Maxhost",
-        cmd_manager_maxhost,
-        NULL,
-        OR_ALL,
-        "Maxhost - number max host (Alias in virtual hosts) supported by mod_cluster"
-    ),
-    AP_INIT_TAKE1(
-        "Maxsessionid",
-        cmd_manager_maxsessionid,
-        NULL,
-        OR_ALL,
-        "Maxsessionid - number session (Used to track number of sessions per nodes) supported by mod_cluster"
-    ),
-    AP_INIT_TAKE1(
-        "MemManagerFile",
-        cmd_manager_memmanagerfile,
-        NULL,
-        OR_ALL,
-        "MemManagerFile - base name of the files used to create/attach to shared memory"
-    ),
-    AP_INIT_TAKE1(
-        "ManagerBalancerName",
-        cmd_manager_balancername,
-        NULL,
-        OR_ALL,
-        "ManagerBalancerName - name of a balancer corresponding to the manager"
-    ),
-    AP_INIT_TAKE1(
-        "PersistSlots",
-        cmd_manager_pers,
-        NULL,
-        OR_ALL,
-        "PersistSlots - Persist the slot mem elements on | off (Default: off No persistence)"
-    ),
-    AP_INIT_TAKE1(
-        "CheckNonce",
-        cmd_manager_nonce,
-        NULL,
-        OR_ALL,
-        "CheckNonce - Switch check of nonce when using mod_cluster-manager handler on | off (Default: on Nonce checked)"
-    ),
-    AP_INIT_TAKE1(
-        "AllowDisplay",
-        cmd_manager_allow_display,
-        NULL,
-        OR_ALL,
-        "AllowDisplay - Display additional information in the mod_cluster-manager page on | off (Default: off Only version displayed)"
-    ),
-    AP_INIT_TAKE1(
-        "AllowCmd",
-        cmd_manager_allow_cmd,
-        NULL,
-        OR_ALL,
-        "AllowCmd - Allow commands using mod_cluster-manager URL on | off (Default: on Commmands allowed)"
-    ),
-    AP_INIT_TAKE1(
-        "ReduceDisplay",
-        cmd_manager_reduce_display,
-        NULL,
-        OR_ALL,
-        "ReduceDisplay - Don't contexts in the main mod_cluster-manager page. on | off (Default: off Context displayed)"
-    ),
-    AP_INIT_TAKE1(
-        "MaxMCMPMessSize",
-        cmd_manager_maxmesssize,
-        NULL,
-        OR_ALL,
-        "MaxMCMPMaxMessSize - Maximum size of MCMP messages. (Default: calculated min value: 1024)"
-    ),
-    AP_INIT_NO_ARGS(
-        "EnableMCPMReceive",
-         cmd_manager_enable_mcpm_receive,
-         NULL,
-         OR_ALL,
-         "EnableMCPMReceive - Allow the VirtualHost to receive MCPM."
-    ),
-    AP_INIT_NO_ARGS(
-        "EnableWsTunnel",
-         cmd_manager_enable_ws_tunnel,
-         NULL,
-         OR_ALL,
-         "EnableWsTunnel - Use ws or wss instead http or https when creating nodes (Allow Websockets proxing)."
-    ),
-    AP_INIT_TAKE1(
-        "WSUpgradeHeader",
-         cmd_manager_ws_upgrade_header,
-         NULL,
-         OR_ALL,
-         "WSUpgradeHeader - Accepted upgrade headers, ONE bypass checks, ANY read it from request, other values: header value to check before using the WS tunnel."
-    ),
-    AP_INIT_TAKE1(
-        "AJPSecret",
-         cmd_manager_ajp_secret,
-         NULL,
-         OR_ALL,
-         "AJPSecret - secret for all mod_cluster node, not configued no secret."
-    ),
-    AP_INIT_TAKE1(
-        "ResponseFieldSize",
-        cmd_manager_responsefieldsize,
-        NULL,
-        OR_ALL,
-        "ResponseFieldSize - Adjust the size of the proxy response field buffer."
-    ),
+static const command_rec manager_cmds[] = {
+    AP_INIT_TAKE1("Maxcontext",
+                  cmd_manager_maxcontext,
+                  NULL,
+                  OR_ALL,
+                  "Maxcontext - number max context supported by mod_cluster"),
+    AP_INIT_TAKE1("Maxnode",
+                  cmd_manager_maxnode,
+                  NULL,
+                  OR_ALL,
+                  "Maxnode - number max node supported by mod_cluster"),
+    AP_INIT_TAKE1("Maxhost",
+                  cmd_manager_maxhost,
+                  NULL,
+                  OR_ALL,
+                  "Maxhost - number max host (Alias in virtual hosts) supported by mod_cluster"),
+    AP_INIT_TAKE1("Maxsessionid",
+                  cmd_manager_maxsessionid,
+                  NULL,
+                  OR_ALL,
+                  "Maxsessionid - number session (Used to track number of sessions per nodes) supported by mod_cluster"),
+    AP_INIT_TAKE1("MemManagerFile",
+                  cmd_manager_memmanagerfile,
+                  NULL,
+                  OR_ALL,
+                  "MemManagerFile - base name of the files used to create/attach to shared memory"),
+    AP_INIT_TAKE1("ManagerBalancerName",
+                  cmd_manager_balancername,
+                  NULL,
+                  OR_ALL,
+                  "ManagerBalancerName - name of a balancer corresponding to the manager"),
+    AP_INIT_TAKE1("PersistSlots",
+                  cmd_manager_pers,
+                  NULL,
+                  OR_ALL,
+                  "PersistSlots - Persist the slot mem elements on | off (Default: off No persistence)"),
+    AP_INIT_TAKE1("CheckNonce",
+                  cmd_manager_nonce,
+                  NULL,
+                  OR_ALL,
+                  "CheckNonce - Switch check of nonce when using mod_cluster-manager handler on | off (Default: on Nonce checked)"),
+    AP_INIT_TAKE1("AllowDisplay",
+                  cmd_manager_allow_display,
+                  NULL,
+                  OR_ALL,
+                  "AllowDisplay - Display additional information in the mod_cluster-manager page on | off (Default: off Only version displayed)"),
+    AP_INIT_TAKE1("AllowCmd",
+                  cmd_manager_allow_cmd,
+                  NULL,
+                  OR_ALL,
+                  "AllowCmd - Allow commands using mod_cluster-manager URL on | off (Default: on Commmands allowed)"),
+    AP_INIT_TAKE1("ReduceDisplay",
+                  cmd_manager_reduce_display,
+                  NULL,
+                  OR_ALL,
+                  "ReduceDisplay - Don't contexts in the main mod_cluster-manager page. on | off (Default: off Context displayed)"),
+    AP_INIT_TAKE1("MaxMCMPMessSize",
+                  cmd_manager_maxmesssize,
+                  NULL,
+                  OR_ALL,
+                  "MaxMCMPMaxMessSize - Maximum size of MCMP messages. (Default: calculated min value: 1024)"),
+    AP_INIT_NO_ARGS("EnableMCPMReceive",
+                    cmd_manager_enable_mcpm_receive,
+                    NULL,
+                    OR_ALL,
+                    "EnableMCPMReceive - Allow the VirtualHost to receive MCPM."),
+    AP_INIT_NO_ARGS("EnableWsTunnel",
+                    cmd_manager_enable_ws_tunnel,
+                    NULL,
+                    OR_ALL,
+                    "EnableWsTunnel - Use ws or wss instead http or https when creating nodes (Allow Websockets proxing)."),
+    AP_INIT_TAKE1("WSUpgradeHeader",
+                  cmd_manager_ws_upgrade_header,
+                  NULL,
+                  OR_ALL,
+                  "WSUpgradeHeader - Accepted upgrade headers, ONE bypass checks, ANY read it from request, other values: header value to check before using the WS tunnel."),
+    AP_INIT_TAKE1("AJPSecret",
+                  cmd_manager_ajp_secret,
+                  NULL,
+                  OR_ALL,
+                  "AJPSecret - secret for all mod_cluster node, not configued no secret."),
+    AP_INIT_TAKE1("ResponseFieldSize",
+                  cmd_manager_responsefieldsize,
+                  NULL,
+                  OR_ALL,
+                  "ResponseFieldSize - Adjust the size of the proxy response field buffer."),
     {NULL}
 };
 
@@ -3779,7 +3751,7 @@ static const command_rec  manager_cmds[] =
 
 static void manager_hooks(apr_pool_t *p)
 {
-    static const char * const aszSucc[] = { "mod_proxy.c", NULL };
+    static const char *const aszSucc[] = { "mod_proxy.c", NULL };
 
     /* For the lock */
     ap_hook_pre_config(manager_pre_config, NULL, NULL, APR_HOOK_MIDDLE);
@@ -3791,8 +3763,7 @@ static void manager_hooks(apr_pool_t *p)
     ap_hook_child_init(manager_child_init, NULL, NULL, APR_HOOK_FIRST);
 
     /* post read_request handling: to be handle to use ProxyPass / */
-    ap_hook_translate_name(manager_trans, NULL, aszSucc,
-                              APR_HOOK_FIRST);
+    ap_hook_translate_name(manager_trans, NULL, aszSucc, APR_HOOK_FIRST);
 
     /* Process the request from the ModClusterService */
     ap_hook_handler(manager_handler, NULL, NULL, APR_HOOK_REALLY_FIRST);
@@ -3801,12 +3772,12 @@ static void manager_hooks(apr_pool_t *p)
     ap_hook_map_to_storage(manager_map_to_storage, NULL, NULL, APR_HOOK_REALLY_FIRST);
 
     /* Register nodes/hosts/contexts table provider */
-    ap_register_provider(p, "manager" , "shared", "0", &node_storage);
-    ap_register_provider(p, "manager" , "shared", "1", &host_storage);
-    ap_register_provider(p, "manager" , "shared", "2", &context_storage);
-    ap_register_provider(p, "manager" , "shared", "3", &balancer_storage);
-    ap_register_provider(p, "manager" , "shared", "4", &sessionid_storage);
-    ap_register_provider(p, "manager" , "shared", "5", &domain_storage);
+    ap_register_provider(p, "manager", "shared", "0", &node_storage);
+    ap_register_provider(p, "manager", "shared", "1", &host_storage);
+    ap_register_provider(p, "manager", "shared", "2", &context_storage);
+    ap_register_provider(p, "manager", "shared", "3", &balancer_storage);
+    ap_register_provider(p, "manager", "shared", "4", &sessionid_storage);
+    ap_register_provider(p, "manager", "shared", "5", &domain_storage);
 }
 
 /*
@@ -3838,11 +3809,11 @@ static void *create_manager_config(apr_pool_t *p)
 
 static void *create_manager_server_config(apr_pool_t *p, server_rec *s)
 {
-    (void) s;
-    return(create_manager_config(p));
+    (void)s;
+    return create_manager_config(p);
 }
-static void *merge_manager_server_config(apr_pool_t *p, void *server1_conf,
-                                         void *server2_conf)
+
+static void *merge_manager_server_config(apr_pool_t *p, void *server1_conf, void *server2_conf)
 {
     mod_manager_config *mconf1 = (mod_manager_config *) server1_conf;
     mod_manager_config *mconf2 = (mod_manager_config *) server2_conf;
@@ -3950,7 +3921,7 @@ module AP_MODULE_DECLARE_DATA manager_module = {
     NULL,
     create_manager_server_config,
     merge_manager_server_config,
-    manager_cmds,       /* command table */
-    manager_hooks,      /* register hooks */
-    AP_MODULE_FLAG_NONE /* flags */
+    manager_cmds,               /* command table */
+    manager_hooks,              /* register hooks */
+    AP_MODULE_FLAG_NONE         /* flags */
 };

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -52,68 +52,68 @@
 
 #include "mod_proxy_cluster.h"
 
-#define DEFMAXCONTEXT   100
-#define DEFMAXNODE      20
-#define DEFMAXHOST      20
-#define DEFMAXSESSIONID 0       /* it has performance/security impact */
-#define MAXMESSSIZE     1024
+#define DEFMAXCONTEXT         100
+#define DEFMAXNODE            20
+#define DEFMAXHOST            20
+#define DEFMAXSESSIONID       0 /* it has performance/security impact */
+#define MAXMESSSIZE           1024
 
 /* Warning messages */
-#define SBALBAD "Balancer name contained an upper case character. We will use \"%s\" instead."
+#define SBALBAD               "Balancer name contained an upper case character. We will use \"%s\" instead."
 
 /* Error messages */
-#define TYPESYNTAX 1
-#define SMESPAR "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements."
-#define SBALBIG "SYNTAX: Balancer field too big"
-#define SBAFBIG "SYNTAX: A field is too big"
-#define SROUBIG "SYNTAX: JVMRoute field too big"
-#define SROUBAD "SYNTAX: JVMRoute can't be empty"
-#define SDOMBIG "SYNTAX: LBGroup field too big"
-#define SHOSBIG "SYNTAX: Host field too big"
-#define SPORBIG "SYNTAX: Port field too big"
-#define STYPBIG "SYNTAX: Type field too big"
-#define SALIBAD "SYNTAX: Alias without Context"
-#define SCONBAD "SYNTAX: Context without Alias"
-#define SBADFLD "SYNTAX: Invalid field \"%s\" in message"
-#define SMISFLD "SYNTAX: Mandatory field(s) missing in message"
-#define SCMDUNS "SYNTAX: Command is not supported"
-#define SMULALB "SYNTAX: Only one Alias in APP command"
-#define SMULCTB "SYNTAX: Only one Context in APP command"
-#define SREADER "SYNTAX: %s can't read POST data"
+#define TYPESYNTAX            1
+#define SMESPAR               "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements."
+#define SBALBIG               "SYNTAX: Balancer field too big"
+#define SBAFBIG               "SYNTAX: A field is too big"
+#define SROUBIG               "SYNTAX: JVMRoute field too big"
+#define SROUBAD               "SYNTAX: JVMRoute can't be empty"
+#define SDOMBIG               "SYNTAX: LBGroup field too big"
+#define SHOSBIG               "SYNTAX: Host field too big"
+#define SPORBIG               "SYNTAX: Port field too big"
+#define STYPBIG               "SYNTAX: Type field too big"
+#define SALIBAD               "SYNTAX: Alias without Context"
+#define SCONBAD               "SYNTAX: Context without Alias"
+#define SBADFLD               "SYNTAX: Invalid field \"%s\" in message"
+#define SMISFLD               "SYNTAX: Mandatory field(s) missing in message"
+#define SCMDUNS               "SYNTAX: Command is not supported"
+#define SMULALB               "SYNTAX: Only one Alias in APP command"
+#define SMULCTB               "SYNTAX: Only one Context in APP command"
+#define SREADER               "SYNTAX: %s can't read POST data"
 
-#define SJIDBIG "SYNTAX: JGroupUuid field too big"
-#define SJDDBIG "SYNTAX: JGroupData field too big"
-#define SJIDBAD "SYNTAX: JGroupUuid can't be empty"
+#define SJIDBIG               "SYNTAX: JGroupUuid field too big"
+#define SJDDBIG               "SYNTAX: JGroupData field too big"
+#define SJIDBAD               "SYNTAX: JGroupUuid can't be empty"
 
-#define TYPEMEM 2
-#define MNODEUI "MEM: Can't update or insert node with \"%s\" JVMRoute"
-#define MNODERM "MEM: Old node with \"%s\" JVMRoute still exists"
-#define MBALAUI "MEM: Can't update or insert balancer for node with \"%s\" JVMRoute"
-#define MNODERD "MEM: Can't read node with \"%s\" JVMRoute"
-#define MHOSTRD "MEM: Can't read host alias for node with \"%s\" JVMRoute"
-#define MHOSTUI "MEM: Can't update or insert host alias for node with \"%s\" JVMRoute"
-#define MCONTUI "MEM: Can't update or insert context for node with \"%s\" JVMRoute"
-#define MJBIDRD "MEM: Can't read JGroupId"
-#define MJBIDUI "MEM: Can't update or insert JGroupId"
-#define MNODEET "MEM: Another for the same worker already exist"
+#define TYPEMEM               2
+#define MNODEUI               "MEM: Can't update or insert node with \"%s\" JVMRoute"
+#define MNODERM               "MEM: Old node with \"%s\" JVMRoute still exists"
+#define MBALAUI               "MEM: Can't update or insert balancer for node with \"%s\" JVMRoute"
+#define MNODERD               "MEM: Can't read node with \"%s\" JVMRoute"
+#define MHOSTRD               "MEM: Can't read host alias for node with \"%s\" JVMRoute"
+#define MHOSTUI               "MEM: Can't update or insert host alias for node with \"%s\" JVMRoute"
+#define MCONTUI               "MEM: Can't update or insert context for node with \"%s\" JVMRoute"
+#define MJBIDRD               "MEM: Can't read JGroupId"
+#define MJBIDUI               "MEM: Can't update or insert JGroupId"
+#define MNODEET               "MEM: Another for the same worker already exist"
 
 /* Protocol version supported */
-#define VERSION_PROTOCOL "0.2.1"
+#define VERSION_PROTOCOL      "0.2.1"
 
 /* Internal substitution for node commands */
-#define NODE_COMMAND "/NODE_COMMAND"
+#define NODE_COMMAND          "/NODE_COMMAND"
 
 /* range of the commands */
-#define RANGECONTEXT 0
-#define RANGENODE    1
-#define RANGEDOMAIN  2
+#define RANGECONTEXT          0
+#define RANGENODE             1
+#define RANGEDOMAIN           2
 
 /* define HAVE_CLUSTER_EX_DEBUG to have extented debug in mod_cluster */
 #define HAVE_CLUSTER_EX_DEBUG 0
 
 /* define content-type */
-#define TEXT_PLAIN 1
-#define TEXT_XML 2
+#define TEXT_PLAIN            1
+#define TEXT_XML              2
 
 /* Data structure for shared memory block */
 typedef struct version_data
@@ -226,7 +226,7 @@ static apr_status_t loc_find_node(nodeinfo_t **node, const char *route)
 static void inc_version_node(void)
 {
     version_data *base;
-    base = (version_data *) apr_shm_baseaddr_get(versionipc_shm);
+    base = (version_data *)apr_shm_baseaddr_get(versionipc_shm);
     base->counter++;
 }
 
@@ -239,7 +239,7 @@ static void inc_version_node(void)
 static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
 {
     int size;
-    server_rec *s = (server_rec *) data;
+    server_rec *s = (server_rec *)data;
     unsigned int last = 0;
     version_data *base;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
@@ -247,9 +247,9 @@ static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
 
     size = loc_get_max_size_node();
     if (size == 0)
-        return 0;               /* broken */
+        return 0; /* broken */
 
-    base = (version_data *) apr_shm_baseaddr_get(versionipc_shm);
+    base = (version_data *)apr_shm_baseaddr_get(versionipc_shm);
     last = base->counter;
 
     if (last != mconf->tableversion)
@@ -260,7 +260,7 @@ static unsigned int loc_worker_nodes_need_update(void *data, apr_pool_t *pool)
 /* Store the last version update in the proccess config */
 static int loc_worker_nodes_are_updated(void *data, unsigned int last)
 {
-    server_rec *s = (server_rec *) data;
+    server_rec *s = (server_rec *)data;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
     mconf->tableversion = last;
     return 0;
@@ -438,11 +438,8 @@ static apr_status_t loc_insert_update_sessionid(sessionidinfo_t *sessionid)
 }
 
 static const struct sessionid_storage_method sessionid_storage = {
-    loc_read_sessionid,
-    loc_get_ids_used_sessionid,
-    loc_get_max_size_sessionid,
-    loc_remove_sessionid,
-    loc_insert_update_sessionid,
+    loc_read_sessionid,   loc_get_ids_used_sessionid,  loc_get_max_size_sessionid,
+    loc_remove_sessionid, loc_insert_update_sessionid,
 };
 
 /*
@@ -582,7 +579,7 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, serv
     apr_uuid_t uuid;
     mod_manager_config *mconf = ap_get_module_config(s->module_config, &manager_module);
     apr_status_t rv;
-    (void)plog;                 /* unused variable */
+    (void)plog; /* unused variable */
 
     if (ap_state_query(AP_SQ_MAIN_STATE) == AP_SQ_MS_CREATE_PRE_CONFIG)
         return OK;
@@ -625,8 +622,8 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, serv
     }
     if (get_last_mem_error(nodestatsmem) != APR_SUCCESS) {
         char buf[120];
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_node %s failed: %s",
-                     node, apr_strerror(get_last_mem_error(nodestatsmem), buf, sizeof(buf)));
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "create_mem_node %s failed: %s", node,
+                     apr_strerror(get_last_mem_error(nodestatsmem), buf, sizeof(buf)));
         return !OK;
     }
 
@@ -681,7 +678,7 @@ static int manager_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, serv
         ap_log_error(APLOG_MARK, APLOG_EMERG, rv, s, "create_share_version failed");
         return !OK;
     }
-    base = (version_data *) apr_shm_baseaddr_get(versionipc_shm);
+    base = (version_data *)apr_shm_baseaddr_get(versionipc_shm);
     base->counter = 0;
 
     /* Get a provider to ping/pong logics */
@@ -763,7 +760,7 @@ static apr_status_t insert_update_hosts(mem_t *mem, char *str, int node, int vho
     char *ptr = str;
     char *previous = str;
     hostinfo_t info;
-    char empty[1] = { '\0' };
+    char empty[1] = {'\0'};
     apr_status_t status;
 
     info.node = node;
@@ -800,7 +797,7 @@ static apr_status_t insert_update_contexts(mem_t *mem, char *str, int node, int 
     char *previous = str;
     apr_status_t ret = APR_SUCCESS;
     contextinfo_t info;
-    char empty[2] = { '/', '\0' };
+    char empty[2] = {'/', '\0'};
 
     info.node = node;
     info.vhost = vhost;
@@ -880,11 +877,11 @@ static int is_same_worker_existing(request_rec *r, nodeinfo_t *node)
         if (is_same_node(ou, node)) {
             /* we have a node that corresponds to the same worker */
             if (!strcmp(ou->mess.JVMRoute, node->mess.JVMRoute))
-                return 0;       /* well it is the same */
+                return 0; /* well it is the same */
             if (ou->mess.remove) {
                 if (strcmp(ou->mess.JVMRoute, "REMOVED") == 0) {
                     /* Look in remove_removed_node, only "REMOVED" have cleaned the contexts/hosts */
-                    return 0;   /* well it marked removed */
+                    return 0; /* well it marked removed */
                 }
             }
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
@@ -922,7 +919,7 @@ static apr_status_t mod_manager_manage_worker(request_rec *r, nodeinfo_t *node, 
     apr_table_set(params, "w",
                   apr_pstrcat(r->pool, node->mess.Type, "://", node->mess.Host, ":", node->mess.Port, NULL));
     apr_table_set(params, "w_wr", node->mess.JVMRoute);
-    apr_table_set(params, "w_status_D", "0");   /* Not Dissabled */
+    apr_table_set(params, "w_status_D", "0"); /* Not Dissabled */
 
     /* set the health check (requires mod_proxy_hcheck) */
     /* CPING for AJP and OPTIONS for HTTP/1.1 */
@@ -942,9 +939,8 @@ static apr_status_t mod_manager_manage_worker(request_rec *r, nodeinfo_t *node, 
 static proxy_worker *proxy_node_getid(request_rec *r, nodeinfo_t *nodeinfo, int *id, proxy_server_conf **the_conf)
 {
     if (balancerhandler != NULL) {
-        return balancerhandler->
-               proxy_node_getid(r, nodeinfo->mess.balancer, nodeinfo->mess.Type, nodeinfo->mess.Host,
-                                nodeinfo->mess.Port, id, the_conf);
+        return balancerhandler->proxy_node_getid(r, nodeinfo->mess.balancer, nodeinfo->mess.Type, nodeinfo->mess.Host,
+                                                 nodeinfo->mess.Port, id, the_conf);
     }
     return NULL;
 }
@@ -996,7 +992,7 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
 
     int i = 0;
     int id;
-    int vid = 1;                /* zero and "" is empty */
+    int vid = 1; /* zero and "" is empty */
     int removed = 0;
     void *sconf = r->server->module_config;
     mod_manager_config *mconf = ap_get_module_config(sconf, &manager_module);
@@ -1029,11 +1025,11 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
     nodeinfo.mess.Upgrade[0] = '\0';
     nodeinfo.mess.AJPSecret[0] = '\0';
     nodeinfo.mess.reversed = 0;
-    nodeinfo.mess.remove = 0;   /* not marked as removed */
-    nodeinfo.mess.flushpackets = flush_off;     /* FLUSH_OFF; See enum flush_packets in proxy.h flush_off */
+    nodeinfo.mess.remove = 0;               /* not marked as removed */
+    nodeinfo.mess.flushpackets = flush_off; /* FLUSH_OFF; See enum flush_packets in proxy.h flush_off */
     nodeinfo.mess.flushwait = PROXY_FLUSH_WAIT;
     nodeinfo.mess.ping = apr_time_from_sec(10);
-    nodeinfo.mess.smax = -1;    /* let mod_proxy logic get the right one */
+    nodeinfo.mess.smax = -1; /* let mod_proxy logic get the right one */
     nodeinfo.mess.ttl = apr_time_from_sec(60);
     nodeinfo.mess.timeout = 0;
     nodeinfo.mess.id = 0;
@@ -1323,7 +1319,7 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
                             ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
                                          "process_config: proxy_node_getid() worker %d (%s) exists and IS NOT %s!!!",
                                          id, workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
-                            ap_assert(0);       /* we are in trouble */
+                            ap_assert(0); /* we are in trouble */
                         }
                     }
                 }
@@ -1332,10 +1328,11 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
             clean = 0;
             ap_assert(worker->s->port != 0);
             pptr = (char *)&nodeinfo;
-            offset = sizeof(nodemess_t) + sizeof(apr_time_t) + sizeof(int); /* nodeinfo.offset doesn't contain the information */
+            offset = sizeof(nodemess_t) + sizeof(apr_time_t) +
+                     sizeof(int); /* nodeinfo.offset doesn't contain the information */
             offset = APR_ALIGN_DEFAULT(offset);
             pptr = pptr + offset;
-            memcpy(pptr, worker->s, sizeof(proxy_worker_shared));   /* restore the information we are going to reuse */
+            memcpy(pptr, worker->s, sizeof(proxy_worker_shared)); /* restore the information we are going to reuse */
             ap_assert(the_conf);
         }
     }
@@ -1344,37 +1341,36 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
         rv = find_node_byhostport(nodestatsmem, &workernode, nodeinfo.mess.Host, nodeinfo.mess.Port);
         if (rv == APR_SUCCESS) {
             /* Normally the node is just being removed, so no host/context but some other child might have a worker */
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "process_config: NOT NEW (%d %s) %s %s (%s)", workernode->mess.id, workernode->mess.JVMRoute,
-                         workernode->mess.Host, workernode->mess.Port, nodeinfo.mess.JVMRoute);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NOT NEW (%d %s) %s %s (%s)",
+                         workernode->mess.id, workernode->mess.JVMRoute, workernode->mess.Host, workernode->mess.Port,
+                         nodeinfo.mess.JVMRoute);
             if (strcmp(workernode->mess.JVMRoute, "REMOVED") == 0) {
-                id = workernode->mess.id;       /* we are reusing it */
+                id = workernode->mess.id; /* we are reusing it */
                 strcpy(workernode->mess.JVMRoute, nodeinfo.mess.JVMRoute);
                 workernode->mess.remove = 0;
                 workernode->mess.num_remove_check = 0;
             }
             else {
-                ap_assert(0);   /* we need to figure out what to do... */
+                ap_assert(0); /* we need to figure out what to do... */
             }
         }
         else {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "process_config: NEW (%s) %s", nodeinfo.mess.JVMRoute, nodeinfo.mess.Port);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NEW (%s) %s", nodeinfo.mess.JVMRoute,
+                         nodeinfo.mess.Port);
         }
     }
     if (id == 0) {
         /* make sure we insert in a "free" node according to the worker logic */
         id = proxy_node_get_free_id(r, node_storage.get_max_size_node());
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "process_config: NEW (%s) %s %s in %d", nodeinfo.mess.JVMRoute, nodeinfo.mess.Host,
-                     nodeinfo.mess.Port, id);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NEW (%s) %s %s in %d",
+                     nodeinfo.mess.JVMRoute, nodeinfo.mess.Host, nodeinfo.mess.Port, id);
     }
 
     /* Insert or update node description */
     if (insert_update_node(nodestatsmem, &nodeinfo, &id, clean) != APR_SUCCESS) {
         loc_unlock_nodes();
         if (removed)
-            ap_assert(0);       /* troubles */
+            ap_assert(0); /* troubles */
         *errtype = TYPEMEM;
         return apr_psprintf(r->pool, MNODEUI, nodeinfo.mess.JVMRoute);
     }
@@ -1406,9 +1402,8 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
 #endif
     }
     else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "process_config: NEW (%s) %s inserted in worker %d", nodeinfo.mess.JVMRoute, nodeinfo.mess.Port,
-                     id);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NEW (%s) %s inserted in worker %d",
+                     nodeinfo.mess.JVMRoute, nodeinfo.mess.Port, id);
     }
     inc_version_node();
 
@@ -1424,7 +1419,7 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
         else {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NO balancer-manager");
         }
-        return NULL;            /* Alias and Context missing */
+        return NULL; /* Alias and Context missing */
     }
     while (phost) {
         if (insert_update_hosts(hoststatsmem, phost->host, id, vid) != APR_SUCCESS) {
@@ -1445,7 +1440,6 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
     if (balancer_manage) {
         apr_status_t rv = mod_manager_manage_worker(r, &nodeinfo, &balancerinfo);
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: balancer-manager returned %d", rv);
-
     }
     else {
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_config: NO balancer-manager");
@@ -1510,12 +1504,12 @@ static char *process_dump(request_rec *r, int *errtype)
             break;
         case TEXT_PLAIN:
         default:
-            ap_rprintf(r,
-                       "balancer: [%d] Name: %.*s Sticky: %d [%.*s]/[%.*s] remove: %d force: %d Timeout: %d maxAttempts: %d\n",
-                       id[i], (int)sizeof(ou->balancer), ou->balancer, ou->StickySession,
-                       (int)sizeof(ou->StickySessionCookie), ou->StickySessionCookie,
-                       (int)sizeof(ou->StickySessionPath), ou->StickySessionPath, ou->StickySessionRemove,
-                       ou->StickySessionForce, (int)apr_time_sec(ou->Timeout), ou->Maxattempts);
+            ap_rprintf(
+                r,
+                "balancer: [%d] Name: %.*s Sticky: %d [%.*s]/[%.*s] remove: %d force: %d Timeout: %d maxAttempts: %d\n",
+                id[i], (int)sizeof(ou->balancer), ou->balancer, ou->StickySession, (int)sizeof(ou->StickySessionCookie),
+                ou->StickySessionCookie, (int)sizeof(ou->StickySessionPath), ou->StickySessionPath,
+                ou->StickySessionRemove, ou->StickySessionForce, (int)apr_time_sec(ou->Timeout), ou->Maxattempts);
             break;
         }
     }
@@ -1554,20 +1548,21 @@ static char *process_dump(request_rec *r, int *errtype)
                        ou->mess.id, (int)sizeof(ou->mess.balancer), ou->mess.balancer, (int)sizeof(ou->mess.JVMRoute),
                        ou->mess.JVMRoute, (int)sizeof(ou->mess.Domain), ou->mess.Domain, (int)sizeof(ou->mess.Host),
                        ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port, (int)sizeof(ou->mess.Type),
-                       ou->mess.Type, ou->mess.flushpackets, ou->mess.flushwait / 1000, (int)apr_time_sec(ou->mess.ping),
-                       ou->mess.smax, (int)apr_time_sec(ou->mess.ttl), (int)apr_time_sec(ou->mess.timeout));
+                       ou->mess.Type, ou->mess.flushpackets, ou->mess.flushwait / 1000,
+                       (int)apr_time_sec(ou->mess.ping), ou->mess.smax, (int)apr_time_sec(ou->mess.ttl),
+                       (int)apr_time_sec(ou->mess.timeout));
             break;
         case TEXT_PLAIN:
         default:
             ap_rprintf(r, "node: [%d:%d],Balancer: %.*s,JVMRoute: %.*s,LBGroup: [%.*s],Host: %.*s,Port: %.*s,\
                            Type: %.*s,flushpackets: %d,flushwait: %d,ping: %d,smax: %d,ttl: %d,timeout: %d\n",
                        id[i], ou->mess.id, (int)sizeof(ou->mess.balancer), ou->mess.balancer,
-                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute, (int)sizeof(ou->mess.Domain),
-                       ou->mess.Domain, (int)sizeof(ou->mess.Host), ou->mess.Host, (int)sizeof(ou->mess.Port),
-                       ou->mess.Port, (int)sizeof(ou->mess.Type), ou->mess.Type, ou->mess.flushpackets,
-                       ou->mess.flushwait / 1000, (int)apr_time_sec(ou->mess.ping), ou->mess.smax,
-                       (int)apr_time_sec(ou->mess.ttl), (int)apr_time_sec(ou->mess.timeout));
-                break;
+                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute, (int)sizeof(ou->mess.Domain), ou->mess.Domain,
+                       (int)sizeof(ou->mess.Host), ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port,
+                       (int)sizeof(ou->mess.Type), ou->mess.Type, ou->mess.flushpackets, ou->mess.flushwait / 1000,
+                       (int)apr_time_sec(ou->mess.ping), ou->mess.smax, (int)apr_time_sec(ou->mess.ttl),
+                       (int)apr_time_sec(ou->mess.timeout));
+            break;
         }
     }
 
@@ -1588,7 +1583,8 @@ static char *process_dump(request_rec *r, int *errtype)
             ap_rprintf(r, "<Host id=\"%d\" alias=\"%.*s\">\
                                <Vhost>%d</Vhost>\
                                <Node>%d</Node>\
-                           </Host>", id[i], (int)sizeof(ou->host), ou->host, ou->vhost, ou->node);
+                           </Host>",
+                       id[i], (int)sizeof(ou->host), ou->host, ou->vhost, ou->node);
             break;
         case TEXT_PLAIN:
         default:
@@ -1628,8 +1624,8 @@ static char *process_dump(request_rec *r, int *errtype)
                             <Vhost>%d</Vhost>\
                             <Node>%d</Node>\
                             <Status id=\"%d\">%s</Status>\
-                           </Context>", id[i], (int)sizeof(ou->context), ou->context, ou->vhost, ou->node, ou->status,
-                       status);
+                           </Context>",
+                       id[i], (int)sizeof(ou->context), ou->context, ou->vhost, ou->node, ou->status, status);
             break;
         case TEXT_PLAIN:
         default:
@@ -1700,13 +1696,11 @@ static char *process_info(request_rec *r, int *errtype)
             break;
         case TEXT_PLAIN:
         default:
-            ap_rprintf(r, "Node: [%d],Name: %.*s,Balancer: %.*s,LBGroup: %.*s,Host: %.*s,Port: %.*s,Type: %.*s",
-                       id[i],
-                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
-                       (int)sizeof(ou->mess.balancer), ou->mess.balancer,
-                       (int)sizeof(ou->mess.Domain), ou->mess.Domain,
-                       (int)sizeof(ou->mess.Host), ou->mess.Host,
-                       (int)sizeof(ou->mess.Port), ou->mess.Port, (int)sizeof(ou->mess.Type), ou->mess.Type);
+            ap_rprintf(r, "Node: [%d],Name: %.*s,Balancer: %.*s,LBGroup: %.*s,Host: %.*s,Port: %.*s,Type: %.*s", id[i],
+                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute, (int)sizeof(ou->mess.balancer),
+                       ou->mess.balancer, (int)sizeof(ou->mess.Domain), ou->mess.Domain, (int)sizeof(ou->mess.Host),
+                       ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port, (int)sizeof(ou->mess.Type),
+                       ou->mess.Type);
             break;
         }
 
@@ -1731,15 +1725,15 @@ static char *process_info(request_rec *r, int *errtype)
             break;
         case TEXT_PLAIN:
         default:
-            ap_rprintf(r, ",Flushpackets: %s,Flushwait: %d,Ping: %d,Smax: %d,Ttl: %d",
-                       flushpackets, ou->mess.flushwait / 1000,
-                       (int)apr_time_sec(ou->mess.ping), ou->mess.smax, (int)apr_time_sec(ou->mess.ttl));
+            ap_rprintf(r, ",Flushpackets: %s,Flushwait: %d,Ping: %d,Smax: %d,Ttl: %d", flushpackets,
+                       ou->mess.flushwait / 1000, (int)apr_time_sec(ou->mess.ping), ou->mess.smax,
+                       (int)apr_time_sec(ou->mess.ttl));
             break;
         }
 
         pptr = (char *)ou;
         pptr = pptr + ou->offset;
-        proxystat = (proxy_worker_shared *) pptr;
+        proxystat = (proxy_worker_shared *)pptr;
 
         switch (type) {
         case TEXT_XML:
@@ -1749,17 +1743,15 @@ static char *process_info(request_rec *r, int *errtype)
                            <Connected>%d</Connected>\
                            <Load>%d</Load>\
                            </Node>",
-                       (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred,
-                       (int)proxystat->busy, proxystat->lbfactor);
+                       (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred, (int)proxystat->busy,
+                       proxystat->lbfactor);
             break;
         case TEXT_PLAIN:
         default:
-            ap_rprintf(r, ",Elected: %d,Read: %d,Transfered: %d,Connected: %d,Load: %d\n",
-                       (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred,
-                       (int)proxystat->busy, proxystat->lbfactor);
+            ap_rprintf(r, ",Elected: %d,Read: %d,Transfered: %d,Connected: %d,Load: %d\n", (int)proxystat->elected,
+                       (int)proxystat->read, (int)proxystat->transferred, (int)proxystat->busy, proxystat->lbfactor);
             break;
         }
-
     }
 
     if (type == TEXT_XML) {
@@ -1787,8 +1779,8 @@ static char *process_info(request_rec *r, int *errtype)
             break;
         case TEXT_PLAIN:
         default:
-            ap_rprintf(r, "Vhost: [%d:%d:%d], Alias: %.*s\n",
-                       ou->node, ou->vhost, id[i], (int)sizeof(ou->host), ou->host);
+            ap_rprintf(r, "Vhost: [%d:%d:%d], Alias: %.*s\n", ou->node, ou->vhost, id[i], (int)sizeof(ou->host),
+                       ou->host);
             break;
         }
     }
@@ -1836,8 +1828,8 @@ static char *process_info(request_rec *r, int *errtype)
             break;
         case TEXT_PLAIN:
         default:
-            ap_rprintf(r, "Context: [%d:%d:%d], Context: %.*s, Status: %s\n",
-                       ou->node, ou->vhost, id[i], (int)sizeof(ou->context), ou->context, status);
+            ap_rprintf(r, "Context: [%d:%d:%d], Context: %.*s, Status: %s\n", ou->node, ou->vhost, id[i],
+                       (int)sizeof(ou->context), ou->context, status);
             break;
         }
     }
@@ -1857,8 +1849,8 @@ static char *process_node_cmd(request_rec *r, int status, int *errtype, nodeinfo
     int *id;
     (void)errtype;
 
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "process_node_cmd %d processing node: %d", status, node->mess.id);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_node_cmd %d processing node: %d", status,
+                 node->mess.id);
     if (size == 0)
         return NULL;
     id = apr_palloc(r->pool, sizeof(int) * size);
@@ -1889,7 +1881,6 @@ static char *process_node_cmd(request_rec *r, int status, int *errtype, nodeinfo
                 else {
                     remove_context(contextstatsmem, context);
                 }
-
             }
         }
         if (status == REMOVE) {
@@ -1904,7 +1895,6 @@ static char *process_node_cmd(request_rec *r, int status, int *errtype, nodeinfo
         insert_update_node(nodestatsmem, node, &id, 0);
     }
     return NULL;
-
 }
 
 /* Process an enable/disable/stop/remove application message */
@@ -1979,7 +1969,7 @@ static char *process_appl_cmd(request_rec *r, char **ptr, int status, int *errty
     if (node == NULL) {
         loc_unlock_nodes();
         if (status == REMOVE)
-            return NULL;        /* Already done */
+            return NULL; /* Already done */
         *errtype = TYPEMEM;
         return apr_psprintf(r->pool, MNODERD, nodeinfo.mess.JVMRoute);
     }
@@ -1988,7 +1978,7 @@ static char *process_appl_cmd(request_rec *r, char **ptr, int status, int *errty
     if (node->mess.remove) {
         loc_unlock_nodes();
         if (status == REMOVE)
-            return NULL;        /* Already done */
+            return NULL; /* Already done */
         else {
             /* Act has if the node wasn't found */
             *errtype = TYPEMEM;
@@ -2043,9 +2033,9 @@ static char *process_appl_cmd(request_rec *r, char **ptr, int status, int *errty
                 if (ou->node == node->mess.id && ou->vhost > vid)
                     vid = ou->vhost;
             }
-            vid++;              /* Use next one. */
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_appl_cmd: adding vhost: %d node: %d",
-                         vid, node->mess.id);
+            vid++; /* Use next one. */
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "process_appl_cmd: adding vhost: %d node: %d", vid,
+                         node->mess.id);
 
             /* If the Host doesn't exist yet create it */
             if (insert_update_hosts(hoststatsmem, vhost->host, node->mess.id, vid) != APR_SUCCESS) {
@@ -2088,8 +2078,8 @@ static char *process_appl_cmd(request_rec *r, char **ptr, int status, int *errty
                 if (strcmp(hisnode->mess.balancer, node->mess.balancer)) {
                     /* the same context would be on 2 different balancer */
                     ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_WARNING, 0, r->server,
-                                 "ENABLE: context %s is in balancer %s and %s", vhost->context,
-                                 node->mess.balancer, hisnode->mess.balancer);
+                                 "ENABLE: context %s is in balancer %s and %s", vhost->context, node->mess.balancer,
+                                 hisnode->mess.balancer);
                 }
             }
         }
@@ -2143,9 +2133,8 @@ static char *process_appl_cmd(request_rec *r, char **ptr, int status, int *errty
             if (fromnode) {
                 ap_set_content_type(r, "text/plain");
                 ap_rprintf(r, "Type=STOP-APP-RSP&JvmRoute=%.*s&Alias=%.*s&Context=%.*s&Requests=%d",
-                           (int)sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute,
-                           (int)sizeof(vhost->host), vhost->host,
-                           (int)sizeof(vhost->context), vhost->context, ou->nbrequests);
+                           (int)sizeof(nodeinfo.mess.JVMRoute), nodeinfo.mess.JVMRoute, (int)sizeof(vhost->host),
+                           vhost->host, (int)sizeof(vhost->context), vhost->context, ou->nbrequests);
                 ap_rprintf(r, "\n");
             }
         }
@@ -2404,7 +2393,7 @@ static int mod_manager_hex2c(const char *x)
         i += ch - ('a' - 10);
     }
     return i;
-#else /*APR_CHARSET_EBCDIC */
+#else  /*APR_CHARSET_EBCDIC */
     /*
      * we assume that the hex value refers to an ASCII character
      * so convert to EBCDIC so that it makes sense locally;
@@ -2509,10 +2498,8 @@ static int check_method(request_rec *r)
 static int manager_trans(request_rec *r)
 {
     int ours = 0;
-    core_dir_config *conf = (core_dir_config *) ap_get_module_config(r->per_dir_config,
-                                                                     &core_module);
-    mod_manager_config *mconf = ap_get_module_config(r->server->module_config,
-                                                     &manager_module);
+    core_dir_config *conf = (core_dir_config *)ap_get_module_config(r->per_dir_config, &core_module);
+    mod_manager_config *mconf = ap_get_module_config(r->server->module_config, &manager_module);
 
     if (conf && conf->handler && r->method_number == M_GET && strcmp(conf->handler, "mod_cluster-manager") == 0) {
         r->handler = "mod_cluster-manager";
@@ -2522,14 +2509,14 @@ static int manager_trans(request_rec *r)
     if (r->method_number != M_INVALID)
         return DECLINED;
     if (!mconf->enable_mcpm_receive)
-        return DECLINED;        /* Not allowed to receive MCMP */
+        return DECLINED; /* Not allowed to receive MCMP */
 
     ours = check_method(r);
     if (ours) {
         int i;
         /* The method one of ours */
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "manager_trans %s (%s)", r->method, r->uri);
-        r->handler = "mod-cluster";     /* that hack doesn't work on httpd-2.4.x */
+        r->handler = "mod-cluster"; /* that hack doesn't work on httpd-2.4.x */
         i = strlen(r->uri);
         if (strcmp(r->uri, "*") == 0 || (i >= 2 && r->uri[i - 1] == '*' && r->uri[i - 2] == '/')) {
             r->filename = apr_pstrdup(r->pool, NODE_COMMAND);
@@ -2547,12 +2534,11 @@ static int manager_trans(request_rec *r)
 static int manager_map_to_storage(request_rec *r)
 {
     int ours = 0;
-    mod_manager_config *mconf = ap_get_module_config(r->server->module_config,
-                                                     &manager_module);
+    mod_manager_config *mconf = ap_get_module_config(r->server->module_config, &manager_module);
     if (r->method_number != M_INVALID)
         return DECLINED;
     if (!mconf->enable_mcpm_receive)
-        return DECLINED;        /* Not allowed to receive MCMP */
+        return DECLINED; /* Not allowed to receive MCMP */
 
     ours = check_method(r);
     if (ours) {
@@ -2587,22 +2573,22 @@ static char *balancer_nonce_string(request_rec *r)
 static void context_command_string(request_rec *r, contextinfo_t *ou, char *Alias, char *JVMRoute)
 {
     if (ou->status == DISABLED) {
-        ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=CONTEXT&%s\">Enable</a> ",
-                   r->uri, balancer_nonce_string(r), context_string(r, ou, Alias, JVMRoute));
-        ap_rprintf(r, " <a href=\"%s?%sCmd=STOP-APP&Range=CONTEXT&%s\">Stop</a>",
-                   r->uri, balancer_nonce_string(r), context_string(r, ou, Alias, JVMRoute));
+        ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=CONTEXT&%s\">Enable</a> ", r->uri, balancer_nonce_string(r),
+                   context_string(r, ou, Alias, JVMRoute));
+        ap_rprintf(r, " <a href=\"%s?%sCmd=STOP-APP&Range=CONTEXT&%s\">Stop</a>", r->uri, balancer_nonce_string(r),
+                   context_string(r, ou, Alias, JVMRoute));
     }
     if (ou->status == ENABLED) {
-        ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=CONTEXT&%s\">Disable</a>",
-                   r->uri, balancer_nonce_string(r), context_string(r, ou, Alias, JVMRoute));
-        ap_rprintf(r, " <a href=\"%s?%sCmd=STOP-APP&Range=CONTEXT&%s\">Stop</a>",
-                   r->uri, balancer_nonce_string(r), context_string(r, ou, Alias, JVMRoute));
+        ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=CONTEXT&%s\">Disable</a>", r->uri, balancer_nonce_string(r),
+                   context_string(r, ou, Alias, JVMRoute));
+        ap_rprintf(r, " <a href=\"%s?%sCmd=STOP-APP&Range=CONTEXT&%s\">Stop</a>", r->uri, balancer_nonce_string(r),
+                   context_string(r, ou, Alias, JVMRoute));
     }
     if (ou->status == STOPPED) {
-        ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=CONTEXT&%s\">Enable</a> ",
-                   r->uri, balancer_nonce_string(r), context_string(r, ou, Alias, JVMRoute));
-        ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=CONTEXT&%s\">Disable</a>",
-                   r->uri, balancer_nonce_string(r), context_string(r, ou, Alias, JVMRoute));
+        ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=CONTEXT&%s\">Enable</a> ", r->uri, balancer_nonce_string(r),
+                   context_string(r, ou, Alias, JVMRoute));
+        ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=CONTEXT&%s\">Disable</a>", r->uri, balancer_nonce_string(r),
+                   context_string(r, ou, Alias, JVMRoute));
     }
 }
 
@@ -2615,22 +2601,22 @@ static char *node_string(request_rec *r, char *JVMRoute)
 
 static void node_command_string(request_rec *r, char *JVMRoute)
 {
-    ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=NODE&%s\">Enable Contexts</a> ",
-               r->uri, balancer_nonce_string(r), node_string(r, JVMRoute));
-    ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=NODE&%s\">Disable Contexts</a> ",
-               r->uri, balancer_nonce_string(r), node_string(r, JVMRoute));
-    ap_rprintf(r, "<a href=\"%s?%sCmd=STOP-APP&Range=NODE&%s\">Stop Contexts</a>",
-               r->uri, balancer_nonce_string(r), node_string(r, JVMRoute));
+    ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=NODE&%s\">Enable Contexts</a> ", r->uri,
+               balancer_nonce_string(r), node_string(r, JVMRoute));
+    ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=NODE&%s\">Disable Contexts</a> ", r->uri,
+               balancer_nonce_string(r), node_string(r, JVMRoute));
+    ap_rprintf(r, "<a href=\"%s?%sCmd=STOP-APP&Range=NODE&%s\">Stop Contexts</a>", r->uri, balancer_nonce_string(r),
+               node_string(r, JVMRoute));
 }
 
 static void domain_command_string(request_rec *r, char *Domain)
 {
-    ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=DOMAIN&Domain=%s\">Enable Nodes</a> ",
-               r->uri, balancer_nonce_string(r), Domain);
-    ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=DOMAIN&Domain=%s\">Disable Nodes</a> ",
-               r->uri, balancer_nonce_string(r), Domain);
-    ap_rprintf(r, "<a href=\"%s?%sCmd=STOP-APP&Range=DOMAIN&Domain=%s\">Stop Nodes</a>",
-               r->uri, balancer_nonce_string(r), Domain);
+    ap_rprintf(r, "<a href=\"%s?%sCmd=ENABLE-APP&Range=DOMAIN&Domain=%s\">Enable Nodes</a> ", r->uri,
+               balancer_nonce_string(r), Domain);
+    ap_rprintf(r, "<a href=\"%s?%sCmd=DISABLE-APP&Range=DOMAIN&Domain=%s\">Disable Nodes</a> ", r->uri,
+               balancer_nonce_string(r), Domain);
+    ap_rprintf(r, "<a href=\"%s?%sCmd=STOP-APP&Range=DOMAIN&Domain=%s\">Stop Nodes</a>", r->uri,
+               balancer_nonce_string(r), Domain);
 }
 
 /*
@@ -2742,7 +2728,6 @@ static void manager_info_hosts(request_rec *r, int reduce_display, int allow_cmd
     }
     if (size && !reduce_display)
         ap_rprintf(r, "</pre>");
-
 }
 
 static void manager_sessionid(request_rec *r)
@@ -2768,7 +2753,6 @@ static void manager_sessionid(request_rec *r)
                    ou->JVMRoute);
     }
     ap_rprintf(r, "</pre>");
-
 }
 
 #if HAVE_CLUSTER_EX_DEBUG
@@ -2792,12 +2776,10 @@ static void manager_domain(request_rec *r, int reduce_display)
         domaininfo_t *ou;
         if (get_domain(domainstatsmem, &ou, id[i]) != APR_SUCCESS)
             continue;
-        ap_rprintf(r, "dom: %.*s route: %.*s balancer: %.*s\n",
-                   sizeof(ou->domain), ou->domain,
-                   sizeof(ou->JVMRoute), ou->JVMRoute, sizeof(ou->balancer), ou->balancer);
+        ap_rprintf(r, "dom: %.*s route: %.*s balancer: %.*s\n", sizeof(ou->domain), ou->domain, sizeof(ou->JVMRoute),
+                   ou->JVMRoute, sizeof(ou->balancer), ou->balancer);
     }
     ap_rprintf(r, "</pre>");
-
 }
 #endif
 
@@ -2839,8 +2821,8 @@ static void process_error(request_rec *r, char *errstring, int errtype)
         break;
     }
     apr_table_setn(r->err_headers_out, "Mess", errstring);
-    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_WARNING, 0, r->server,
-                 "manager_handler %s error: %s", r->method, errstring);
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_WARNING, 0, r->server, "manager_handler %s error: %s", r->method,
+                 errstring);
 }
 
 static void sort_nodes(nodeinfo_t *nodes, int nbnodes)
@@ -2875,7 +2857,8 @@ static char *process_domain(request_rec *r, char **ptr, int *errtype, const char
     id = apr_palloc(r->pool, sizeof(int) * size);
     size = get_ids_used_node(nodestatsmem, id);
 
-    for (pos = 0; ptr[pos] != NULL && ptr[pos + 1] != NULL; pos = pos + 2) {}
+    for (pos = 0; ptr[pos] != NULL && ptr[pos + 1] != NULL; pos = pos + 2) {
+    }
 
     ptr[pos] = apr_pstrdup(r->pool, "JVMRoute");
     ptr[pos + 2] = NULL;
@@ -2912,10 +2895,9 @@ static void printproxy_stat(request_rec *r, int reduce_display, proxy_worker_sha
     if (reduce_display)
         ap_rprintf(r, " %s ", status);
     else
-        ap_rprintf(r, ",Status: %s,Elected: %d,Read: %d,Transferred: %d,Connected: %d,Load: %d",
-                   status,
-                   (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred,
-                   (int)proxystat->busy, proxystat->lbfactor);
+        ap_rprintf(r, ",Status: %s,Elected: %d,Read: %d,Transferred: %d,Connected: %d,Load: %d", status,
+                   (int)proxystat->elected, (int)proxystat->read, (int)proxystat->transferred, (int)proxystat->busy,
+                   proxystat->lbfactor);
 }
 
 /* Display module information */
@@ -2944,7 +2926,6 @@ static void modules_info(request_rec *r)
         ap_rputs("mod_advertise.c: OK<br/>", r);
     else
         ap_rputs("mod_advertise.c: not loaded<br/>", r);
-
 }
 
 /* Process INFO message and mod_cluster_manager pages generation */
@@ -3088,11 +3069,11 @@ static int manager_info(request_rec *r)
 
     ap_rvputs(r, "<a href=\"", r->uri, "?", balancer_nonce_string(r), "refresh=10", "\">Auto Refresh</a>", NULL);
 
-    ap_rvputs(r, " <a href=\"", r->uri, "?", balancer_nonce_string(r),
-              "Cmd=DUMP&Range=ALL", "\">show DUMP output</a>", NULL);
+    ap_rvputs(r, " <a href=\"", r->uri, "?", balancer_nonce_string(r), "Cmd=DUMP&Range=ALL", "\">show DUMP output</a>",
+              NULL);
 
-    ap_rvputs(r, " <a href=\"", r->uri, "?", balancer_nonce_string(r),
-              "Cmd=INFO&Range=ALL", "\">show INFO output</a>", NULL);
+    ap_rvputs(r, " <a href=\"", r->uri, "?", balancer_nonce_string(r), "Cmd=INFO&Range=ALL", "\">show INFO output</a>",
+              NULL);
 
     ap_rputs("\n", r);
 
@@ -3136,14 +3117,13 @@ static int manager_info(request_rec *r)
         if (mconf->reduce_display)
             ap_rprintf(r, "<br/><br/>Node %.*s ", (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute);
         else
-            ap_rprintf(r, "<h1> Node %.*s (%.*s://%.*s:%.*s): </h1>\n",
-                       (int)sizeof(ou->mess.JVMRoute), ou->mess.JVMRoute,
-                       (int)sizeof(ou->mess.Type), ou->mess.Type,
-                       (int)sizeof(ou->mess.Host), ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port);
+            ap_rprintf(r, "<h1> Node %.*s (%.*s://%.*s:%.*s): </h1>\n", (int)sizeof(ou->mess.JVMRoute),
+                       ou->mess.JVMRoute, (int)sizeof(ou->mess.Type), ou->mess.Type, (int)sizeof(ou->mess.Host),
+                       ou->mess.Host, (int)sizeof(ou->mess.Port), ou->mess.Port);
         pptr = pptr + ou->offset;
         if (mconf->reduce_display) {
             /* XXX: The logic depend on the proxy and should use shared memory directly */
-            printproxy_stat(r, mconf->reduce_display, (proxy_worker_shared *) pptr);
+            printproxy_stat(r, mconf->reduce_display, (proxy_worker_shared *)pptr);
         }
 
         if (mconf->allow_cmd)
@@ -3162,14 +3142,14 @@ static int manager_info(request_rec *r)
             case flush_auto:
                 flushpackets = "Auto";
             }
-            ap_rprintf(r, ",Flushpackets: %s,Flushwait: %d,Ping: %d,Smax: %d,Ttl: %d",
-                       flushpackets, ou->mess.flushwait, (int)ou->mess.ping, ou->mess.smax, (int)ou->mess.ttl);
+            ap_rprintf(r, ",Flushpackets: %s,Flushwait: %d,Ping: %d,Smax: %d,Ttl: %d", flushpackets, ou->mess.flushwait,
+                       (int)ou->mess.ping, ou->mess.smax, (int)ou->mess.ttl);
         }
 
         if (mconf->reduce_display)
             ap_rprintf(r, "<br/>\n");
         else
-            printproxy_stat(r, mconf->reduce_display, (proxy_worker_shared *) pptr);
+            printproxy_stat(r, mconf->reduce_display, (proxy_worker_shared *)pptr);
 
         if (sizesessionid) {
             ap_rprintf(r, ",Num sessions: %d", count_sessionid(r, ou->mess.JVMRoute));
@@ -3214,7 +3194,7 @@ static int manager_handler(request_rec *r)
 
     mconf = ap_get_module_config(sconf, &manager_module);
     if (!mconf->enable_mcpm_receive)
-        return DECLINED;        /* Not allowed to receive MCMP */
+        return DECLINED; /* Not allowed to receive MCMP */
 
     ours = check_method(r);
     if (!ours)
@@ -3235,8 +3215,8 @@ static int manager_handler(request_rec *r)
     buff = apr_pcalloc(r->pool, maxbufsiz);
     input_brigade = apr_brigade_create(r->pool, r->connection->bucket_alloc);
     len = maxbufsiz;
-    while ((status =
-            ap_get_brigade(r->input_filters, input_brigade, AP_MODE_READBYTES, APR_BLOCK_READ, len)) == APR_SUCCESS) {
+    while ((status = ap_get_brigade(r->input_filters, input_brigade, AP_MODE_READBYTES, APR_BLOCK_READ, len)) ==
+           APR_SUCCESS) {
         apr_brigade_flatten(input_brigade, buff + bufsiz, &len);
         apr_brigade_cleanup(input_brigade);
         bufsiz += len;
@@ -3257,8 +3237,8 @@ static int manager_handler(request_rec *r)
     buff[bufsiz] = '\0';
 
     /* XXX: Size limit it? */
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "manager_handler %s (%s) processing: \"%s\"", r->method, r->filename, buff);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "manager_handler %s (%s) processing: \"%s\"", r->method,
+                 r->filename, buff);
 
     ptr = process_buff(r, buff);
     if (ptr == NULL) {
@@ -3326,13 +3306,13 @@ static void manager_child_init(apr_pool_t *p, server_rec *s)
     }
 
     if (apr_global_mutex_child_init(&node_mutex, apr_global_mutex_lockfile(node_mutex), p) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(02994)
-                     "Failed to reopen mutex %s in child", node_mutex_type);
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(02994) "Failed to reopen mutex %s in child",
+                     node_mutex_type);
         exit(EXIT_FAILURE);
     }
     if (apr_global_mutex_child_init(&context_mutex, apr_global_mutex_lockfile(context_mutex), p) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(02994)
-                     "Failed to reopen mutex %s in child", context_mutex_type);
+        ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(02994) "Failed to reopen mutex %s in child",
+                     context_mutex_type);
         exit(EXIT_FAILURE);
     }
 
@@ -3360,8 +3340,8 @@ static void manager_child_init(apr_pool_t *p, server_rec *s)
     }
     if (get_last_mem_error(nodestatsmem) != APR_SUCCESS) {
         char buf[120];
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_node %s failed: %s",
-                     node, apr_strerror(get_last_mem_error(nodestatsmem), buf, sizeof(buf)));
+        ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_EMERG, 0, s, "get_mem_node %s failed: %s", node,
+                     apr_strerror(get_last_mem_error(nodestatsmem), buf, sizeof(buf)));
         return;
     }
 
@@ -3468,7 +3448,7 @@ static const char *cmd_manager_balancername(cmd_parms *cmd, void *mconfig, const
     mod_manager_config *mconf = ap_get_module_config(cmd->server->module_config, &manager_module);
     mconf->balancername = apr_pstrdup(cmd->pool, word);
     normalize_balancer_name(mconf->balancername, cmd->server);
-    (void)mconfig;              /* unused variable */
+    (void)mconfig; /* unused variable */
     return NULL;
 }
 
@@ -3486,7 +3466,8 @@ static const char *cmd_manager_pers(cmd_parms *cmd, void *dummy, const char *arg
     else if (strcasecmp(arg, "On") == 0)
         mconf->persistent = CREPER_SLOTMEM;
     else
-        return "PersistSlots must be one of: " "off | on";
+        return "PersistSlots must be one of: "
+               "off | on";
 
     return NULL;
 }
@@ -3501,7 +3482,8 @@ static const char *cmd_manager_nonce(cmd_parms *cmd, void *dummy, const char *ar
     else if (strcasecmp(arg, "On") == 0)
         mconf->nonce = -1;
     else
-        return "CheckNonce must be one of: " "off | on";
+        return "CheckNonce must be one of: "
+               "off | on";
 
     return NULL;
 }
@@ -3516,7 +3498,8 @@ static const char *cmd_manager_allow_display(cmd_parms *cmd, void *dummy, const 
     else if (strcasecmp(arg, "On") == 0)
         mconf->allow_display = -1;
     else
-        return "AllowDisplay must be one of: " "off | on";
+        return "AllowDisplay must be one of: "
+               "off | on";
 
     return NULL;
 }
@@ -3531,7 +3514,8 @@ static const char *cmd_manager_allow_cmd(cmd_parms *cmd, void *dummy, const char
     else if (strcasecmp(arg, "On") == 0)
         mconf->allow_cmd = -1;
     else
-        return "AllowCmd must be one of: " "off | on";
+        return "AllowCmd must be one of: "
+               "off | on";
 
     return NULL;
 }
@@ -3546,7 +3530,8 @@ static const char *cmd_manager_reduce_display(cmd_parms *cmd, void *dummy, const
     else if (strcasecmp(arg, "On") == 0)
         mconf->reduce_display = -1;
     else
-        return "ReduceDisplay must be one of: " "off | on";
+        return "ReduceDisplay must be one of: "
+               "off | on";
 
     return NULL;
 }
@@ -3663,90 +3648,44 @@ static const char *cmd_manager_responsefieldsize(cmd_parms *cmd, void *mconfig, 
 
 
 static const command_rec manager_cmds[] = {
-    AP_INIT_TAKE1("Maxcontext",
-                  cmd_manager_maxcontext,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1("Maxcontext", cmd_manager_maxcontext, NULL, OR_ALL,
                   "Maxcontext - number max context supported by mod_cluster"),
-    AP_INIT_TAKE1("Maxnode",
-                  cmd_manager_maxnode,
-                  NULL,
-                  OR_ALL,
-                  "Maxnode - number max node supported by mod_cluster"),
-    AP_INIT_TAKE1("Maxhost",
-                  cmd_manager_maxhost,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1("Maxnode", cmd_manager_maxnode, NULL, OR_ALL, "Maxnode - number max node supported by mod_cluster"),
+    AP_INIT_TAKE1("Maxhost", cmd_manager_maxhost, NULL, OR_ALL,
                   "Maxhost - number max host (Alias in virtual hosts) supported by mod_cluster"),
-    AP_INIT_TAKE1("Maxsessionid",
-                  cmd_manager_maxsessionid,
-                  NULL,
-                  OR_ALL,
-                  "Maxsessionid - number session (Used to track number of sessions per nodes) supported by mod_cluster"),
-    AP_INIT_TAKE1("MemManagerFile",
-                  cmd_manager_memmanagerfile,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1(
+        "Maxsessionid", cmd_manager_maxsessionid, NULL, OR_ALL,
+        "Maxsessionid - number session (Used to track number of sessions per nodes) supported by mod_cluster"),
+    AP_INIT_TAKE1("MemManagerFile", cmd_manager_memmanagerfile, NULL, OR_ALL,
                   "MemManagerFile - base name of the files used to create/attach to shared memory"),
-    AP_INIT_TAKE1("ManagerBalancerName",
-                  cmd_manager_balancername,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1("ManagerBalancerName", cmd_manager_balancername, NULL, OR_ALL,
                   "ManagerBalancerName - name of a balancer corresponding to the manager"),
-    AP_INIT_TAKE1("PersistSlots",
-                  cmd_manager_pers,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1("PersistSlots", cmd_manager_pers, NULL, OR_ALL,
                   "PersistSlots - Persist the slot mem elements on | off (Default: off No persistence)"),
-    AP_INIT_TAKE1("CheckNonce",
-                  cmd_manager_nonce,
-                  NULL,
-                  OR_ALL,
-                  "CheckNonce - Switch check of nonce when using mod_cluster-manager handler on | off (Default: on Nonce checked)"),
-    AP_INIT_TAKE1("AllowDisplay",
-                  cmd_manager_allow_display,
-                  NULL,
-                  OR_ALL,
-                  "AllowDisplay - Display additional information in the mod_cluster-manager page on | off (Default: off Only version displayed)"),
-    AP_INIT_TAKE1("AllowCmd",
-                  cmd_manager_allow_cmd,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1("CheckNonce", cmd_manager_nonce, NULL, OR_ALL,
+                  "CheckNonce - Switch check of nonce when using mod_cluster-manager handler on | off (Default: on "
+                  "Nonce checked)"),
+    AP_INIT_TAKE1("AllowDisplay", cmd_manager_allow_display, NULL, OR_ALL,
+                  "AllowDisplay - Display additional information in the mod_cluster-manager page on | off (Default: "
+                  "off Only version displayed)"),
+    AP_INIT_TAKE1("AllowCmd", cmd_manager_allow_cmd, NULL, OR_ALL,
                   "AllowCmd - Allow commands using mod_cluster-manager URL on | off (Default: on Commmands allowed)"),
-    AP_INIT_TAKE1("ReduceDisplay",
-                  cmd_manager_reduce_display,
-                  NULL,
-                  OR_ALL,
-                  "ReduceDisplay - Don't contexts in the main mod_cluster-manager page. on | off (Default: off Context displayed)"),
-    AP_INIT_TAKE1("MaxMCMPMessSize",
-                  cmd_manager_maxmesssize,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1("ReduceDisplay", cmd_manager_reduce_display, NULL, OR_ALL,
+                  "ReduceDisplay - Don't contexts in the main mod_cluster-manager page. on | off (Default: off Context "
+                  "displayed)"),
+    AP_INIT_TAKE1("MaxMCMPMessSize", cmd_manager_maxmesssize, NULL, OR_ALL,
                   "MaxMCMPMaxMessSize - Maximum size of MCMP messages. (Default: calculated min value: 1024)"),
-    AP_INIT_NO_ARGS("EnableMCPMReceive",
-                    cmd_manager_enable_mcpm_receive,
-                    NULL,
-                    OR_ALL,
+    AP_INIT_NO_ARGS("EnableMCPMReceive", cmd_manager_enable_mcpm_receive, NULL, OR_ALL,
                     "EnableMCPMReceive - Allow the VirtualHost to receive MCPM."),
-    AP_INIT_NO_ARGS("EnableWsTunnel",
-                    cmd_manager_enable_ws_tunnel,
-                    NULL,
-                    OR_ALL,
-                    "EnableWsTunnel - Use ws or wss instead http or https when creating nodes (Allow Websockets proxing)."),
-    AP_INIT_TAKE1("WSUpgradeHeader",
-                  cmd_manager_ws_upgrade_header,
-                  NULL,
-                  OR_ALL,
-                  "WSUpgradeHeader - Accepted upgrade headers, ONE bypass checks, ANY read it from request, other values: header value to check before using the WS tunnel."),
-    AP_INIT_TAKE1("AJPSecret",
-                  cmd_manager_ajp_secret,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_NO_ARGS(
+        "EnableWsTunnel", cmd_manager_enable_ws_tunnel, NULL, OR_ALL,
+        "EnableWsTunnel - Use ws or wss instead http or https when creating nodes (Allow Websockets proxing)."),
+    AP_INIT_TAKE1("WSUpgradeHeader", cmd_manager_ws_upgrade_header, NULL, OR_ALL,
+                  "WSUpgradeHeader - Accepted upgrade headers, ONE bypass checks, ANY read it from request, other "
+                  "values: header value to check before using the WS tunnel."),
+    AP_INIT_TAKE1("AJPSecret", cmd_manager_ajp_secret, NULL, OR_ALL,
                   "AJPSecret - secret for all mod_cluster node, not configued no secret."),
-    AP_INIT_TAKE1("ResponseFieldSize",
-                  cmd_manager_responsefieldsize,
-                  NULL,
-                  OR_ALL,
+    AP_INIT_TAKE1("ResponseFieldSize", cmd_manager_responsefieldsize, NULL, OR_ALL,
                   "ResponseFieldSize - Adjust the size of the proxy response field buffer."),
     {NULL},
 };
@@ -3755,7 +3694,7 @@ static const command_rec manager_cmds[] = {
 
 static void manager_hooks(apr_pool_t *p)
 {
-    static const char *const aszSucc[] = { "mod_proxy.c", NULL };
+    static const char *const aszSucc[] = {"mod_proxy.c", NULL};
 
     /* For the lock */
     ap_hook_pre_config(manager_pre_config, NULL, NULL, APR_HOOK_MIDDLE);
@@ -3819,8 +3758,8 @@ static void *create_manager_server_config(apr_pool_t *p, server_rec *s)
 
 static void *merge_manager_server_config(apr_pool_t *p, void *server1_conf, void *server2_conf)
 {
-    mod_manager_config *mconf1 = (mod_manager_config *) server1_conf;
-    mod_manager_config *mconf2 = (mod_manager_config *) server2_conf;
+    mod_manager_config *mconf1 = (mod_manager_config *)server1_conf;
+    mod_manager_config *mconf2 = (mod_manager_config *)server2_conf;
     mod_manager_config *mconf = apr_pcalloc(p, sizeof(*mconf));
 
     mconf->basefilename = NULL;
@@ -3925,7 +3864,7 @@ module AP_MODULE_DECLARE_DATA manager_module = {
     NULL,
     create_manager_server_config,
     merge_manager_server_config,
-    manager_cmds,               /* command table */
-    manager_hooks,              /* register hooks */
-    AP_MODULE_FLAG_NONE,       /* flags */
+    manager_cmds,        /* command table */
+    manager_hooks,       /* register hooks */
+    AP_MODULE_FLAG_NONE, /* flags */
 };

--- a/native/mod_manager/mod_manager.h
+++ b/native/mod_manager/mod_manager.h
@@ -25,7 +25,8 @@
  * @version $Revision$
  */
 
-struct mem {
+struct mem
+{
     ap_slotmem_t *slotmem;
     const slotmem_storage_method *storage;
     int num;

--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2008 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -94,8 +94,8 @@ apr_status_t get_last_mem_error(mem_t *mem)
  */
 static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    nodeinfo_t *in = (nodeinfo_t *) *data;
-    nodeinfo_t *ou = (nodeinfo_t *) mem;
+    nodeinfo_t *in = (nodeinfo_t *)*data;
+    nodeinfo_t *ou = (nodeinfo_t *)mem;
     (void)pool;
 
     if (strcmp(in->mess.JVMRoute, ou->mess.JVMRoute) == 0) {
@@ -128,7 +128,7 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id, int clean)
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &node, s->p);
     if (rv == APR_SUCCESS) {
         *id = node->mess.id;
-        return APR_SUCCESS;     /* updated */
+        return APR_SUCCESS; /* updated */
     }
 
     /* we have to insert it */
@@ -162,8 +162,8 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id, int clean)
  */
 static apr_status_t loc_read_node(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    nodeinfo_t *in = (nodeinfo_t *) *data;
-    nodeinfo_t *ou = (nodeinfo_t *) mem;
+    nodeinfo_t *in = (nodeinfo_t *)*data;
+    nodeinfo_t *ou = (nodeinfo_t *)mem;
     (void)id;
     (void)pool;
 
@@ -293,8 +293,8 @@ mem_t *create_mem_node(char *string, int *num, int persist, apr_pool_t *p, slotm
  */
 static apr_status_t loc_read_node_byhostport(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    nodeinfo_t *in = (nodeinfo_t *) *data;
-    nodeinfo_t *ou = (nodeinfo_t *) mem;
+    nodeinfo_t *in = (nodeinfo_t *)*data;
+    nodeinfo_t *ou = (nodeinfo_t *)mem;
     (void)id;
     (void)pool;
 

--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -44,7 +44,8 @@
 
 #include "mod_manager.h"
 
-static mem_t * create_attach_mem_node(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage) {
+static mem_t *create_attach_mem_node(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage)
+{
     mem_t *ptr;
     const char *storename;
     apr_status_t rv;
@@ -53,11 +54,12 @@ static mem_t * create_attach_mem_node(char *string, int *num, int type, apr_pool
     if (!ptr) {
         return NULL;
     }
-    ptr->storage =  storage;
-    storename = apr_pstrcat(p, string, NODEEXE, NULL); 
+    ptr->storage = storage;
+    storename = apr_pstrcat(p, string, NODEEXE, NULL);
     if (type) {
         rv = ptr->storage->ap_slotmem_create(&ptr->slotmem, storename, sizeof(nodeinfo_t), *num, type, p);
-    } else {
+    }
+    else {
         apr_size_t size = sizeof(nodeinfo_t);
         rv = ptr->storage->ap_slotmem_attach(&ptr->slotmem, storename, &size, num, p);
     }
@@ -77,7 +79,8 @@ static mem_t * create_attach_mem_node(char *string, int *num, int type, apr_pool
  * @return APR_SUCCESS if all went well
  *
  */
-apr_status_t get_last_mem_error(mem_t *mem) {
+apr_status_t get_last_mem_error(mem_t *mem)
+{
     return mem->laststatus;
 }
 
@@ -89,11 +92,11 @@ apr_status_t get_last_mem_error(mem_t *mem) {
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    nodeinfo_t *in = (nodeinfo_t *)*data;
-    nodeinfo_t *ou = (nodeinfo_t *)mem;
-    (void) pool;
+    nodeinfo_t *in = (nodeinfo_t *) *data;
+    nodeinfo_t *ou = (nodeinfo_t *) mem;
+    (void)pool;
 
     if (strcmp(in->mess.JVMRoute, ou->mess.JVMRoute) == 0) {
         /*
@@ -113,6 +116,7 @@ static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *po
     }
     return APR_NOTFOUND;
 }
+
 apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id, int clean)
 {
     apr_status_t rv;
@@ -124,12 +128,12 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id, int clean)
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &node, s->p);
     if (rv == APR_SUCCESS) {
         *id = node->mess.id;
-        return APR_SUCCESS; /* updated */
+        return APR_SUCCESS;     /* updated */
     }
 
     /* we have to insert it */
     ident = *id;
-    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **) &ou);
+    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **)&ou);
     if (rv != APR_SUCCESS) {
         return rv;
     }
@@ -156,10 +160,12 @@ apr_status_t insert_update_node(mem_t *s, nodeinfo_t *node, int *id, int clean)
  * @param node node to read from the shared table.
  * @return address of the read node or NULL if error.
  */
-static apr_status_t loc_read_node(void* mem, void **data, int id, apr_pool_t *pool) {
-    nodeinfo_t *in = (nodeinfo_t *)*data;
-    nodeinfo_t *ou = (nodeinfo_t *)mem;
-    (void) id; (void) pool;
+static apr_status_t loc_read_node(void *mem, void **data, int id, apr_pool_t *pool)
+{
+    nodeinfo_t *in = (nodeinfo_t *) *data;
+    nodeinfo_t *ou = (nodeinfo_t *) mem;
+    (void)id;
+    (void)pool;
 
     if (strcmp(in->mess.JVMRoute, ou->mess.JVMRoute) == 0) {
         *data = ou;
@@ -167,13 +173,14 @@ static apr_status_t loc_read_node(void* mem, void **data, int id, apr_pool_t *po
     }
     return APR_NOTFOUND;
 }
-nodeinfo_t * read_node(mem_t *s, nodeinfo_t *node)
+
+nodeinfo_t *read_node(mem_t *s, nodeinfo_t *node)
 {
     apr_status_t rv;
     nodeinfo_t *ou = node;
 
     if (node->mess.id)
-        rv = s->storage->ap_slotmem_mem(s->slotmem, node->mess.id, (void **) &ou);
+        rv = s->storage->ap_slotmem_mem(s->slotmem, node->mess.id, (void **)&ou);
     else {
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_node, &ou, s->p);
     }
@@ -181,6 +188,7 @@ nodeinfo_t * read_node(mem_t *s, nodeinfo_t *node)
         return ou;
     return NULL;
 }
+
 /**
  * get a node record from the shared table (using ids).
  * @param pointer to the shared table.
@@ -190,9 +198,9 @@ nodeinfo_t * read_node(mem_t *s, nodeinfo_t *node)
  */
 apr_status_t get_node(mem_t *s, nodeinfo_t **node, int ids)
 {
-  apr_status_t status;
-  status = s->storage->ap_slotmem_mem(s->slotmem, ids, (void **) node);
-  return(status);
+    apr_status_t status;
+    status = s->storage->ap_slotmem_mem(s->slotmem, ids, (void **)node);
+    return status;
 }
 
 /**
@@ -204,7 +212,7 @@ apr_status_t get_node(mem_t *s, nodeinfo_t **node, int ids)
 apr_status_t remove_node(mem_t *s, int ids)
 {
     nodeinfo_t *ou = NULL;
-    return(s->storage->ap_slotmem_free(s->slotmem, ids, ou));
+    return s->storage->ap_slotmem_free(s->slotmem, ids, ou);
 }
 
 /**
@@ -234,7 +242,7 @@ apr_status_t find_node(mem_t *s, nodeinfo_t **node, const char *route)
  */
 int get_ids_used_node(mem_t *s, int *ids)
 {
-    return (s->storage->ap_slotmem_get_used(s->slotmem, ids));
+    return s->storage->ap_slotmem_get_used(s->slotmem, ids);
 }
 
 /*
@@ -244,10 +252,7 @@ int get_ids_used_node(mem_t *s, int *ids)
  */
 int get_max_size_node(mem_t *s)
 {
-    if (s->storage == NULL)
-        return 0;
-    else
-        return (s->storage->ap_slotmem_get_max_size(s->slotmem));
+    return s->storage == NULL ? 0 : s->storage->ap_slotmem_get_max_size(s->slotmem);
 }
 
 /**
@@ -258,10 +263,11 @@ int get_max_size_node(mem_t *s)
  * @param storage slotmem logic provider.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_node(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *get_mem_node(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_node(string, num, 0, p, storage));
+    return create_attach_mem_node(string, num, 0, p, storage);
 }
+
 /**
  * create a shared node table
  * @param name to use to create the table.
@@ -271,9 +277,9 @@ mem_t * get_mem_node(char *string, int *num, apr_pool_t *p, slotmem_storage_meth
  * @param storage slotmem logic provider.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_node(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *create_mem_node(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_node(string, num, CREATE_SLOTMEM|persist, p, storage));
+    return create_attach_mem_node(string, num, CREATE_SLOTMEM | persist, p, storage);
 }
 
 
@@ -285,18 +291,20 @@ mem_t * create_mem_node(char *string, int *num, int persist, apr_pool_t *p, slot
  * @param port string containing the port .
  * @return APR_SUCCESS if all went well
  */
-static apr_status_t loc_read_node_byhostport(void* mem, void **data, int id, apr_pool_t *pool) {
-    nodeinfo_t *in = (nodeinfo_t *)*data;
-    nodeinfo_t *ou = (nodeinfo_t *)mem;
-    (void) id; (void) pool;
+static apr_status_t loc_read_node_byhostport(void *mem, void **data, int id, apr_pool_t *pool)
+{
+    nodeinfo_t *in = (nodeinfo_t *) *data;
+    nodeinfo_t *ou = (nodeinfo_t *) mem;
+    (void)id;
+    (void)pool;
 
-    if (strcmp(in->mess.Host, ou->mess.Host) == 0 &&
-        strcmp(in->mess.Port, ou->mess.Port) == 0) {
+    if (strcmp(in->mess.Host, ou->mess.Host) == 0 && strcmp(in->mess.Port, ou->mess.Port) == 0) {
         *data = ou;
         return APR_SUCCESS;
     }
     return APR_NOTFOUND;
 }
+
 apr_status_t find_node_byhostport(mem_t *s, nodeinfo_t **node, const char *host, const char *port)
 {
     nodeinfo_t ou;

--- a/native/mod_manager/sessionid.c
+++ b/native/mod_manager/sessionid.c
@@ -44,7 +44,9 @@
 
 #include "mod_manager.h"
 
-static mem_t * create_attach_mem_sessionid(char *string, int *num, int type, apr_pool_t *p, slotmem_storage_method *storage) {
+static mem_t *create_attach_mem_sessionid(char *string, int *num, int type, apr_pool_t *p,
+                                          slotmem_storage_method *storage)
+{
     mem_t *ptr;
     const char *storename;
     apr_status_t rv;
@@ -53,8 +55,8 @@ static mem_t * create_attach_mem_sessionid(char *string, int *num, int type, apr
     if (!ptr) {
         return NULL;
     }
-    ptr->storage =  storage;
-    storename = apr_pstrcat(p, string, SESSIONIDEXE, NULL); 
+    ptr->storage = storage;
+    storename = apr_pstrcat(p, string, SESSIONIDEXE, NULL);
     if (type)
         rv = ptr->storage->ap_slotmem_create(&ptr->slotmem, storename, sizeof(sessionidinfo_t), *num, type, p);
     else {
@@ -68,6 +70,7 @@ static mem_t * create_attach_mem_sessionid(char *string, int *num, int type, apr
     ptr->p = p;
     return ptr;
 }
+
 /**
  * Insert(alloc) and update a sessionid record in the shared table
  * @param pointer to the shared table.
@@ -75,11 +78,11 @@ static mem_t * create_attach_mem_sessionid(char *string, int *num, int type, apr
  * @return APR_SUCCESS if all went well
  *
  */
-static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *pool)
+static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    sessionidinfo_t *in = (sessionidinfo_t *)*data;
-    sessionidinfo_t *ou = (sessionidinfo_t *)mem;
-    (void) pool;
+    sessionidinfo_t *in = (sessionidinfo_t *) *data;
+    sessionidinfo_t *ou = (sessionidinfo_t *) mem;
+    (void)pool;
 
     if (strcmp(in->sessionid, ou->sessionid) == 0) {
         memcpy(ou, in, sizeof(sessionidinfo_t));
@@ -90,6 +93,7 @@ static apr_status_t insert_update(void* mem, void **data, int id, apr_pool_t *po
     }
     return APR_NOTFOUND;
 }
+
 apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
 {
     apr_status_t rv;
@@ -99,11 +103,11 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
     sessionid->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &sessionid, s->p);
     if (sessionid->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS; /* updated */
+        return APR_SUCCESS;     /* updated */
     }
 
     /* we have to insert it */
-    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **) &ou);
+    rv = s->storage->ap_slotmem_alloc(s->slotmem, &ident, (void **)&ou);
     if (rv != APR_SUCCESS) {
         return rv;
     }
@@ -120,10 +124,12 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
  * @param sessionid sessionid to read from the shared table.
  * @return address of the read sessionid or NULL if error.
  */
-static apr_status_t loc_read_sessionid(void* mem, void **data, int id, apr_pool_t *pool) {
-    sessionidinfo_t *in = (sessionidinfo_t *)*data;
-    sessionidinfo_t *ou = (sessionidinfo_t *)mem;
-    (void) id; (void) pool;
+static apr_status_t loc_read_sessionid(void *mem, void **data, int id, apr_pool_t *pool)
+{
+    sessionidinfo_t *in = (sessionidinfo_t *) *data;
+    sessionidinfo_t *ou = (sessionidinfo_t *) mem;
+    (void)id;
+    (void)pool;
 
     if (strcmp(in->sessionid, ou->sessionid) == 0) {
         *data = ou;
@@ -131,13 +137,14 @@ static apr_status_t loc_read_sessionid(void* mem, void **data, int id, apr_pool_
     }
     return APR_NOTFOUND;
 }
-sessionidinfo_t * read_sessionid(mem_t *s, sessionidinfo_t *sessionid)
+
+sessionidinfo_t *read_sessionid(mem_t *s, sessionidinfo_t *sessionid)
 {
     apr_status_t rv;
     sessionidinfo_t *ou = sessionid;
 
     if (sessionid->id)
-        rv = s->storage->ap_slotmem_mem(s->slotmem, sessionid->id, (void **) &ou);
+        rv = s->storage->ap_slotmem_mem(s->slotmem, sessionid->id, (void **)&ou);
     else {
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_sessionid, &ou, s->p);
     }
@@ -145,6 +152,7 @@ sessionidinfo_t * read_sessionid(mem_t *s, sessionidinfo_t *sessionid)
         return ou;
     return NULL;
 }
+
 /**
  * get a sessionid record from the shared table
  * @param pointer to the shared table.
@@ -154,7 +162,7 @@ sessionidinfo_t * read_sessionid(mem_t *s, sessionidinfo_t *sessionid)
  */
 apr_status_t get_sessionid(mem_t *s, sessionidinfo_t **sessionid, int ids)
 {
-  return(s->storage->ap_slotmem_mem(s->slotmem, ids, (void **) sessionid));
+    return s->storage->ap_slotmem_mem(s->slotmem, ids, (void **)sessionid);
 }
 
 /**
@@ -169,7 +177,8 @@ apr_status_t remove_sessionid(mem_t *s, sessionidinfo_t *sessionid)
     sessionidinfo_t *ou = sessionid;
     if (sessionid->id) {
         rv = s->storage->ap_slotmem_free(s->slotmem, sessionid->id, sessionid);
-    } else {
+    }
+    else {
         /* XXX: for the moment January 2007 ap_slotmem_free only uses ident to remove */
         rv = s->storage->ap_slotmem_do(s->slotmem, loc_read_sessionid, &ou, s->p);
         if (rv == APR_SUCCESS)
@@ -186,7 +195,7 @@ apr_status_t remove_sessionid(mem_t *s, sessionidinfo_t *sessionid)
  */
 int get_ids_used_sessionid(mem_t *s, int *ids)
 {
-    return (s->storage->ap_slotmem_get_used(s->slotmem, ids));
+    return s->storage->ap_slotmem_get_used(s->slotmem, ids);
 }
 
 /*
@@ -196,7 +205,7 @@ int get_ids_used_sessionid(mem_t *s, int *ids)
  */
 int get_max_size_sessionid(mem_t *s)
 {
-    return (s->storage->ap_slotmem_get_max_size(s->slotmem));
+    return s->storage->ap_slotmem_get_max_size(s->slotmem);
 }
 
 /**
@@ -206,10 +215,11 @@ int get_max_size_sessionid(mem_t *s)
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * get_mem_sessionid(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *get_mem_sessionid(char *string, int *num, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_sessionid(string, num, 0, p, storage));
+    return create_attach_mem_sessionid(string, num, 0, p, storage);
 }
+
 /**
  * create a shared sessionid table
  * @param name to use to create the table.
@@ -218,7 +228,7 @@ mem_t * get_mem_sessionid(char *string, int *num, apr_pool_t *p, slotmem_storage
  * @param p pool to use for allocations.
  * @return address of struct used to access the table.
  */
-mem_t * create_mem_sessionid(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
+mem_t *create_mem_sessionid(char *string, int *num, int persist, apr_pool_t *p, slotmem_storage_method *storage)
 {
-    return(create_attach_mem_sessionid(string, num, CREATE_SLOTMEM|persist, p, storage));
+    return create_attach_mem_sessionid(string, num, CREATE_SLOTMEM | persist, p, storage);
 }

--- a/native/mod_manager/sessionid.c
+++ b/native/mod_manager/sessionid.c
@@ -4,7 +4,7 @@
  *  Copyright(c) 2009 Red Hat Middleware, LLC,
  *  and individual contributors as indicated by the @authors tag.
  *  See the copyright.txt in the distribution for a
- *  full listing of individual contributors. 
+ *  full listing of individual contributors.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -80,8 +80,8 @@ static mem_t *create_attach_mem_sessionid(char *string, int *num, int type, apr_
  */
 static apr_status_t insert_update(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    sessionidinfo_t *in = (sessionidinfo_t *) *data;
-    sessionidinfo_t *ou = (sessionidinfo_t *) mem;
+    sessionidinfo_t *in = (sessionidinfo_t *)*data;
+    sessionidinfo_t *ou = (sessionidinfo_t *)mem;
     (void)pool;
 
     if (strcmp(in->sessionid, ou->sessionid) == 0) {
@@ -103,7 +103,7 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
     sessionid->id = 0;
     rv = s->storage->ap_slotmem_do(s->slotmem, insert_update, &sessionid, s->p);
     if (sessionid->id != 0 && rv == APR_SUCCESS) {
-        return APR_SUCCESS;     /* updated */
+        return APR_SUCCESS; /* updated */
     }
 
     /* we have to insert it */
@@ -126,8 +126,8 @@ apr_status_t insert_update_sessionid(mem_t *s, sessionidinfo_t *sessionid)
  */
 static apr_status_t loc_read_sessionid(void *mem, void **data, int id, apr_pool_t *pool)
 {
-    sessionidinfo_t *in = (sessionidinfo_t *) *data;
-    sessionidinfo_t *ou = (sessionidinfo_t *) mem;
+    sessionidinfo_t *in = (sessionidinfo_t *)*data;
+    sessionidinfo_t *ou = (sessionidinfo_t *)mem;
     (void)id;
     (void)pool;
 

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2115,6 +2115,7 @@ static void reenable_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_wo
 /*
  * For the provider
  */
+// clang-format off
 static const struct balancer_method balancerhandler = {
     proxy_node_isup,
     proxy_host_isup,
@@ -2122,6 +2123,7 @@ static const struct balancer_method balancerhandler = {
     reenable_proxy_worker,
     proxy_node_get_free_id
 };
+// clang-format on
 
 static int node_has_workers(server_rec *server, proxy_server_conf *conf, int id)
 {
@@ -3671,7 +3673,7 @@ static const char *cmd_proxy_cluster_proxyhctemplate(cmd_parms *cmd, void *dummy
         key = ap_getword_conf(cmd->pool, &arg);
         val = strchr(key, '=');
         if (!val) {
-            return "Invalid ProxyHCTemplate parameter. Parameter must be " "in the form 'key=value'";
+            return "Invalid ProxyHCTemplate parameter. Parameter must be in the form 'key=value'";
         }
         else
             *val++ = '\0';
@@ -3777,7 +3779,7 @@ static const command_rec proxy_cluster_cmds[] = {
                   OR_ALL,
                   "ModProxyClusterThreadCount - Set custom size for the watchdog thread pool (Default: 16)"),
 #endif
-    {NULL}
+    {NULL},
 };
 
 module AP_MODULE_DECLARE_DATA proxy_cluster_module = {

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -81,15 +81,17 @@
 
 #define MC_THREADPOOL_SIZE (16)
 
-struct proxy_cluster_helper {
-    int count_active; /* currently active request using the worker */
+struct proxy_cluster_helper
+{
+    int count_active;           /* currently active request using the worker */
     proxy_worker_shared *shared;
-    int index; /* like the worker->id */
-    int isinnodes; /* the proxy_worker_shared is in our shared memory */
+    int index;                  /* like the worker->id */
+    int isinnodes;              /* the proxy_worker_shared is in our shared memory */
 };
-typedef struct  proxy_cluster_helper proxy_cluster_helper;
+typedef struct proxy_cluster_helper proxy_cluster_helper;
 
-typedef struct watchdog_thread_args {
+typedef struct watchdog_thread_args
+{
     proxy_worker *worker;
     apr_pool_t *pool;
     proxy_server_conf *conf;
@@ -99,12 +101,12 @@ typedef struct watchdog_thread_args {
     int id;
 } watchdog_thread_args_t;
 
-static struct node_storage_method *node_storage = NULL; 
-static struct host_storage_method *host_storage = NULL; 
-static struct context_storage_method *context_storage = NULL; 
-static struct balancer_storage_method *balancer_storage = NULL; 
-static struct sessionid_storage_method *sessionid_storage = NULL; 
-static struct domain_storage_method *domain_storage = NULL; 
+static struct node_storage_method *node_storage = NULL;
+static struct host_storage_method *host_storage = NULL;
+static struct context_storage_method *context_storage = NULL;
+static struct balancer_storage_method *balancer_storage = NULL;
+static struct sessionid_storage_method *sessionid_storage = NULL;
+static struct domain_storage_method *domain_storage = NULL;
 
 #define LB_CLUSTER_WATHCHDOG_NAME ("_mod_cluster_")
 static APR_OPTIONAL_FN_TYPE(ap_watchdog_set_callback_interval) *mc_watchdog_set_interval;
@@ -116,27 +118,27 @@ static int mc_thread_pool_size;
 #endif
 
 static server_rec *main_server = NULL;
-#define CREAT_ALL  0 /* create balancers/workers in all VirtualHost */
-#define CREAT_NONE 1 /* don't create balancers (but add workers) */
-#define CREAT_ROOT 2 /* Only create balancers/workers in the main server */
+#define CREAT_ALL  0            /* create balancers/workers in all VirtualHost */
+#define CREAT_NONE 1            /* don't create balancers (but add workers) */
+#define CREAT_ROOT 2            /* Only create balancers/workers in the main server */
 static int creat_bal = CREAT_ROOT;
 
-static int use_alias = 0; /* 1 : Compare Alias with server_name */
+static int use_alias = 0;  /* 1 : Compare Alias with server_name */
 static int deterministic_failover = 0;
 static int use_nocanon = 0;
 
-static apr_time_t lbstatus_recalc_time = apr_time_from_sec(5); /* recalcul the lbstatus based on number of request in the time interval */
+static apr_time_t lbstatus_recalc_time = apr_time_from_sec(5);     /* recalcul the lbstatus based on number of request in the time interval */
 
-static apr_time_t wait_for_remove =  apr_time_from_sec(10); /* wait until that before removing a removed node */
+static apr_time_t wait_for_remove = apr_time_from_sec(10); /* wait until that before removing a removed node */
 
-static int enable_options = -1; /* Use OPTIONS * for CPING/CPONG */
+static int enable_options = -1;    /* Use OPTIONS * for CPING/CPONG */
 
-#define TIMESESSIONID 300                    /* after 5 minutes the sessionid have probably timeout */
-#define TIMEDOMAIN    300                    /* after 5 minutes the sessionid have probably timeout */
+#define TIMESESSIONID 300       /* after 5 minutes the sessionid have probably timeout */
+#define TIMEDOMAIN    300       /* after 5 minutes the sessionid have probably timeout */
 
 
 /* Create static table references we can look back to instead of fetching each request */
-static apr_time_t cache_share_for =  apr_time_from_sec(0); /* cache the shared memory in the process for n seconds */
+static apr_time_t cache_share_for = apr_time_from_sec(0);  /* cache the shared memory in the process for n seconds */
 static apr_time_t last_cached = 0;
 static apr_pool_t *cached_pool = NULL;
 static proxy_vhost_table *cached_vhost_table = NULL;
@@ -162,28 +164,31 @@ static int proxy_worker_cmp(const void *a, const void *b)
 static int compare_hostname(char *proxyhostname, char *nodehostname)
 {
     if (nodehostname[0] == '[') {
-       char *ptr = nodehostname;
-       ptr++;
-       return strncasecmp(ptr, proxyhostname, strlen(ptr)-1);
-    } else {
-       return strcasecmp(proxyhostname, nodehostname);
+        char *ptr = nodehostname;
+        ptr++;
+        return strncasecmp(ptr, proxyhostname, strlen(ptr) - 1);
+    }
+    else {
+        return strcasecmp(proxyhostname, nodehostname);
     }
 }
 
-static char * normalize_hostname(apr_pool_t *p, char *hostname)
+static char *normalize_hostname(apr_pool_t *p, char *hostname)
 {
     char *ret = apr_palloc(p, strlen(hostname) + 1);
     char *ptr = ret;
     strcpy(ptr, hostname);
     for (; *ptr; ++ptr) {
-       *ptr = apr_tolower(*ptr);
+        *ptr = apr_tolower(*ptr);
     }
     return ret;
 }
+
 /**
  * Normalize the worker name
  */
-static char* normalize_workername(apr_pool_t *pool, char *url) {
+static char *normalize_workername(apr_pool_t *pool, char *url)
+{
     apr_uri_t uri;
     if (apr_uri_parse(pool, url, &uri) != APR_SUCCESS) {
         return NULL;
@@ -209,59 +214,59 @@ static void add_hcheck(server_rec *s, proxy_server_conf *conf, proxy_worker *wor
             key = ap_getword_conf(conf->pool, &arg);
             val = strchr(key, '=');
             if (!val) {
-                ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                              "Invalid ProxyHCTemplate parameter. Parameter must be "
-                                      "in the form 'key=value'");
+                ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                             "Invalid ProxyHCTemplate parameter. Parameter must be " "in the form 'key=value'");
                 return;
-             }
-             else
-                 *val++ = '\0';
-             err =  set_worker_hc_param_f(conf->pool, s, worker, key, val, NULL);
-             if (err != NULL) {
-                ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                             "%s key: %s=%s", err, key, val);
-             }
-             ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_DEBUG, 0, s,
-                             "hcheck %s=%s add to worker %s", key, val,
+            }
+            else {
+                *val++ = '\0';
+            }
+            err = set_worker_hc_param_f(conf->pool, s, worker, key, val, NULL);
+            if (err != NULL) {
+                ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s, "%s key: %s=%s", err, key, val);
+            }
+            ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, s, "hcheck %s=%s add to worker %s", key, val,
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                               worker->s->name_ex
+                         worker->s->name_ex
 #else
-                               worker->s->name
+                         worker->s->name
 #endif
-                              );
+                );
         }
     }
 }
 
-static int (*ap_proxy_retry_worker_fn)(const char *proxy_function,
-        proxy_worker *worker, server_rec *s) = NULL;
+static int (*ap_proxy_retry_worker_fn)(const char *proxy_function, proxy_worker *worker, server_rec *s) = NULL;
 
 static void check_workers(proxy_server_conf *conf, server_rec *s)
 {
     int i;
     proxy_balancer *balancer;
-    balancer = (proxy_balancer *)conf->balancers->elts;
+    balancer = (proxy_balancer *) conf->balancers->elts;
     for (i = 0; i < conf->balancers->nelts; i++, balancer++) {
         int j;
         proxy_worker **workers;
-        workers = (proxy_worker **)balancer->workers->elts;
+        workers = (proxy_worker **) balancer->workers->elts;
         for (j = 0; j < balancer->workers->nelts; j++, workers++) {
             volatile proxy_worker *worker = *workers;
             proxy_cluster_helper *helper;
             int stop_worker = 0;
             helper = (proxy_cluster_helper *) worker->context;
-            ap_assert(helper); /* we are in trouble ... */
-            if (worker->s->port == 0 && worker->s->scheme[0] == '\0' && worker->s->hostname[0] == '\0' && worker->s->route[0] == '\0') {
+            ap_assert(helper);  /* we are in trouble ... */
+            if (worker->s->port == 0 && worker->s->scheme[0] == '\0' && worker->s->hostname[0] == '\0'
+                && worker->s->route[0] == '\0') {
                 /* this happens when a new child process is created and it "cleaned" some old slotmem */
                 /* it is like the remove_workers_node we try to restore the non shared memory allocated in create_worker() */
-                ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, "check_workers DOING (empty port : %d id : %d!!!!", helper->shared->port, helper->index);
+                ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, "check_workers DOING (empty port : %d id : %d!!!!",
+                             helper->shared->port, helper->index);
                 stop_worker = 1;
             }
             if (worker->s->port != helper->shared->port ||
                 strcmp(worker->s->scheme, helper->shared->scheme) ||
                 strcmp(worker->s->hostname, helper->shared->hostname)) {
                 /* here the shared memory has changed since we created the worker */
-                ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, "check_workers DOING (changed %d : %d)!!!!", helper->shared->port, worker->s->port);
+                ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, "check_workers DOING (changed %d : %d)!!!!",
+                             helper->shared->port, worker->s->port);
                 stop_worker = 1;
             }
             if (stop_worker) {
@@ -273,9 +278,9 @@ static void check_workers(proxy_server_conf *conf, server_rec *s)
                 helper->isinnodes = 0;
                 /* If we use hcheck, we need to stop it for the worker */
                 if (proxyhctemplate != NULL) {
-                   worker->s->method = NONE;
-                   worker->s->updated = 0;
-                   worker->s->status |= PROXY_WORKER_STOPPED;
+                    worker->s->method = NONE;
+                    worker->s->updated = 0;
+                    worker->s->status |= PROXY_WORKER_STOPPED;
                 }
                 continue;
             }
@@ -298,8 +303,7 @@ static void check_workers(proxy_server_conf *conf, server_rec *s)
  *
  */
 static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balancer,
-                          server_rec *server,
-                          nodeinfo_t *node, char *ptr_node, apr_pool_t *pool)
+                                  server_rec *server, nodeinfo_t *node, char *ptr_node, apr_pool_t *pool)
 {
     char *url;
     char *ptr;
@@ -310,36 +314,37 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
     apr_uri_t uri;
 
     /* build the name (scheme and port) when needed */
-    url = apr_pstrcat(pool, node->mess.Type, "://", normalize_hostname(pool,node->mess.Host), ":", node->mess.Port, NULL);
+    url = apr_pstrcat(pool, node->mess.Type, "://", normalize_hostname(pool, node->mess.Host), ":", node->mess.Port,
+                      NULL);
     if (apr_uri_parse(pool, url, &uri) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_NOTICE|APLOG_NOERRNO, 0, server,
+        ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, server,
                      "Created: worker for %s failed: Unable to parse URL", url);
         return APR_EGENERAL;
     }
     if (!uri.scheme) {
-        ap_log_error(APLOG_MARK, APLOG_NOTICE|APLOG_NOERRNO, 0, server,
+        ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, server,
                      "Created: worker for %s failed: URL must be absolute!", url);
         return APR_EGENERAL;
     }
     if (uri.port && uri.port == ap_proxy_port_of_scheme(uri.scheme)) {
-        url = apr_pstrcat(pool, node->mess.Type, "://", normalize_hostname(pool,node->mess.Host), NULL);
+        url = apr_pstrcat(pool, node->mess.Type, "://", normalize_hostname(pool, node->mess.Host), NULL);
     }
 
     worker = ap_proxy_get_worker(pool, balancer, conf, url);
     if (worker == NULL) {
 
-        /* creates it note the ap_proxy_get_worker and ap_proxy_define_worker aren't symetrical, and this leaks via the conf->pool */ 
+        /* creates it note the ap_proxy_get_worker and ap_proxy_define_worker aren't symetrical, and this leaks via the conf->pool */
         const char *err;
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                      "Created: worker for %s Will create %d!!!", url, node->mess.id);
         err = ap_proxy_define_worker(conf->pool, &worker, balancer, conf, url, 0);
         if (err) {
-            ap_log_error(APLOG_MARK, APLOG_NOTICE|APLOG_NOERRNO, 0, server,
+            ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, server,
                          "Created: worker for %s failed: %s", url, err);
             return APR_EGENERAL;
         }
 
-        worker->context = (proxy_cluster_helper *) apr_pcalloc(conf->pool,  sizeof(proxy_cluster_helper));
+        worker->context = (proxy_cluster_helper *) apr_pcalloc(conf->pool, sizeof(proxy_cluster_helper));
         if (!worker->context) {
             return APR_EGENERAL;
         }
@@ -347,49 +352,47 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
         helper->count_active = 0;
         helper->shared = worker->s;
         helper->isinnodes = 0;
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                     "Created: worker for %s", url);
-    } else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                     "Created: worker for %s Already exist!!!", url);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: worker for %s", url);
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: worker for %s Already exist!!!", url);
         if (!worker->context) {
             /* That is BalancerMember, we dropped support of it */
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                         "Created: reusing BalancerMember worker for %s", url);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: reusing BalancerMember worker for %s", url);
             return APR_EGENERAL;
         }
         helper = (proxy_cluster_helper *) worker->context;
         if (helper->index == 0) {
             /* We are going to reuse a removed one */
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                         "Created: reusing removed worker for %s", url);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: reusing removed worker for %s", url);
             ap_assert(0);
-        } else {
+        }
+        else {
             /* Check if the shared memory goes to the right place */
             char *pptr = ptr_node;
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                         "Created: reusing worker for %s", url);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: reusing worker for %s", url);
             pptr = pptr + node->offset;
             if (helper->index == node->mess.id && worker->s == (proxy_worker_shared *) pptr) {
                 /* the share memory may have been removed and recreated */
                 if (!worker->s->status) {
                     worker->s->status = PROXY_WORKER_INITIALIZED;
-                    strncpy(worker->s->route, node->mess.JVMRoute, sizeof( worker->s->route));
-                    worker->s->route[sizeof(worker->s->route)-1] = '\0';
+                    strncpy(worker->s->route, node->mess.JVMRoute, sizeof(worker->s->route));
+                    worker->s->route[sizeof(worker->s->route) - 1] = '\0';
                     strncpy(worker->s->upgrade, node->mess.Upgrade, sizeof(worker->s->upgrade));
-                    worker->s->upgrade[sizeof(worker->s->upgrade)-1] = '\0';
+                    worker->s->upgrade[sizeof(worker->s->upgrade) - 1] = '\0';
                     strncpy(worker->s->secret, node->mess.AJPSecret, sizeof(worker->s->secret));
-                    worker->s->secret[sizeof(worker->s->secret)-1] = '\0';
+                    worker->s->secret[sizeof(worker->s->secret) - 1] = '\0';
                     if (node->mess.ResponseFieldSize > 0) {
-                       worker->s->response_field_size = node->mess.ResponseFieldSize;
-                       worker->s->response_field_size_set = 1;
-                    } else {
-                       worker->s->response_field_size_set = 0;
+                        worker->s->response_field_size = node->mess.ResponseFieldSize;
+                        worker->s->response_field_size_set = 1;
+                    }
+                    else {
+                        worker->s->response_field_size_set = 0;
                     }
                     /* XXX: We need that information from TC */
                     worker->s->redirect[0] = '\0';
                     worker->s->lbstatus = 0;
-                    worker->s->lbfactor = -1; /* prevent using the node using status message */
+                    worker->s->lbfactor = -1;   /* prevent using the node using status message */
 
                     /* add health check */
                     worker->s->updated = apr_time_now();
@@ -399,25 +402,30 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                                  "Created: REUSING %s (scheme: %s hostname %s port %d route %s name %s) cleaning...",
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                                  url, worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route, worker->s->name_ex );
+                                 url, worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route,
+                                 worker->s->name_ex);
 #else
-                                  url, worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route, worker->s->name );
+                                 url, worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route,
+                                 worker->s->name);
 #endif
                 }
-                return APR_SUCCESS; /* Done Already existing */
-            } else {
+                return APR_SUCCESS;     /* Done Already existing */
+            }
+            else {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                              "Created: can't reuse worker as it is for %s (scheme: %s hostname %s port %d route %s name %s) cleaning...",
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                              url, worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route, worker->s->name_ex );
+                             url, worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route,
+                             worker->s->name_ex);
 #else
-                              url, worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route, worker->s->name );
+                             url, worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route,
+                             worker->s->name);
 #endif
                 ptr = ptr_node;
                 ptr = ptr + node->offset;
                 shared = worker->s;
                 worker->s = (proxy_worker_shared *) ptr;
-                worker->s->was_malloced = 0; /* Prevent mod_proxy to free it */
+                worker->s->was_malloced = 0;    /* Prevent mod_proxy to free it */
                 helper->index = node->mess.id;
                 helper->isinnodes = 1;
 
@@ -463,7 +471,7 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
 #else
                      "Created: worker for %s arranging shared memory %s:%s", url, worker->s->name, shared->name);
 #endif
-        worker->s->was_malloced = 0; /* Prevent mod_proxy to free it */
+        worker->s->was_malloced = 0;    /* Prevent mod_proxy to free it */
         worker->s->index = node->mess.id;
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
         strncpy(worker->s->name_ex, shared->name_ex, sizeof(worker->s->name_ex));
@@ -471,30 +479,34 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
         strncpy(worker->s->name, shared->name, sizeof(worker->s->name));
 #endif
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                     "Created: worker for %s arranging shared memory hostname %s:%s", url, worker->s->hostname, shared->hostname);
+                     "Created: worker for %s arranging shared memory hostname %s:%s", url, worker->s->hostname,
+                     shared->hostname);
         strncpy(worker->s->hostname, shared->hostname, sizeof(worker->s->hostname));
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                     "Created: worker for %s arranging shared memory hostname_ex %s:%s", url, worker->s->hostname_ex, shared->hostname_ex);
+                     "Created: worker for %s arranging shared memory hostname_ex %s:%s", url, worker->s->hostname_ex,
+                     shared->hostname_ex);
         strncpy(worker->s->hostname_ex, shared->hostname_ex, sizeof(worker->s->hostname_ex));
 #endif
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                     "Created: worker for %s arranging shared memory scheme %s:%s", url, worker->s->scheme, shared->scheme);
+                     "Created: worker for %s arranging shared memory scheme %s:%s", url, worker->s->scheme,
+                     shared->scheme);
         strncpy(worker->s->scheme, shared->scheme, sizeof(worker->s->scheme));
         worker->s->port = shared->port;
         worker->s->hmax = shared->hmax;
         strncpy(worker->s->route, node->mess.JVMRoute, sizeof(worker->s->route));
-        worker->s->route[sizeof(worker->s->route)-1] = '\0';
+        worker->s->route[sizeof(worker->s->route) - 1] = '\0';
         strncpy(worker->s->upgrade, node->mess.Upgrade, sizeof(worker->s->upgrade));
-        worker->s->upgrade[sizeof(worker->s->upgrade)-1] = '\0';
+        worker->s->upgrade[sizeof(worker->s->upgrade) - 1] = '\0';
         if (node->mess.ResponseFieldSize > 0) {
             worker->s->response_field_size = node->mess.ResponseFieldSize;
             worker->s->response_field_size_set = 1;
-        } else {
+        }
+        else {
             worker->s->response_field_size_set = 0;
         }
         strncpy(worker->s->secret, node->mess.AJPSecret, sizeof(worker->s->secret));
-        worker->s->secret[sizeof(worker->s->secret)-1] = '\0';
+        worker->s->secret[sizeof(worker->s->secret) - 1] = '\0';
         worker->s->redirect[0] = '\0';
         worker->s->smax = node->mess.smax;
         worker->s->ttl = node->mess.ttl;
@@ -512,7 +524,7 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
         worker->s->keepalive = 1;
         worker->s->keepalive_set = 1;
         worker->s->is_address_reusable = 1;
-        worker->s->acquire = apr_time_make(0, 2 * 1000); /* 2 ms */
+        worker->s->acquire = apr_time_make(0, 2 * 1000);        /* 2 ms */
         worker->s->retry = apr_time_from_sec(PROXY_WORKER_DEFAULT_RETRY);
 
         /* check add health check */
@@ -520,19 +532,19 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
         if (proxyhctemplate != NULL) {
             add_hcheck(server, conf, worker);
         }
-    } else {
+    }
+    else {
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                      "Created: worker for %s shared memory  OK %s:%s", url, worker->s->name_ex, shared->name_ex);
 #else
                      "Created: worker for %s shared memory  OK %s:%s", url, worker->s->name, shared->name);
 #endif
-        worker->s->was_malloced = 0; /* Prevent mod_proxy to free it */
+        worker->s->was_malloced = 0;    /* Prevent mod_proxy to free it */
     }
 
     if ((rv = ap_proxy_initialize_worker(worker, server, conf->pool)) != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, rv, server,
-                     "ap_proxy_initialize_worker failed %d for %s:%s", rv, url, ptr);
+        ap_log_error(APLOG_MARK, APLOG_ERR, rv, server, "ap_proxy_initialize_worker failed %d for %s:%s", rv, url, ptr);
         return rv;
     }
 
@@ -544,9 +556,9 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
         /* XXX: We need that information from TC */
         worker->s->redirect[0] = '\0';
         worker->s->lbstatus = 0;
-        worker->s->lbfactor = -1; /* prevent using the node using status message */
+        worker->s->lbfactor = -1;       /* prevent using the node using status message */
     }
- 
+
     return rv;
 }
 
@@ -554,9 +566,9 @@ static balancerinfo_t *read_balancer_name(const char *name, apr_pool_t *pool)
 {
     int sizebal, i;
     int *bal;
-    sizebal =  balancer_storage->get_max_size_balancer();
+    sizebal = balancer_storage->get_max_size_balancer();
     if (sizebal == 0)
-        return NULL; /* Done broken. */
+        return NULL;            /* Done broken. */
     bal = apr_pcalloc(pool, sizeof(int) * sizebal);
     sizebal = balancer_storage->get_ids_used_balancer(bal);
     for (i = 0; i < sizebal; i++) {
@@ -589,20 +601,19 @@ static proxy_balancer *add_balancer_node(nodeinfo_t *node, proxy_server_conf *co
 
     balancer = ap_proxy_get_balancer(pool, conf, name, 0);
     if (!balancer) {
-       int sizeb = conf->balancers->elt_size;
-       proxy_balancer_shared *bshared;
-       ap_log_error(APLOG_MARK, APLOG_DEBUG|APLOG_NOERRNO, 0, server,
-                    "add_balancer_node: Create balancer %s", name);
+        int sizeb = conf->balancers->elt_size;
+        proxy_balancer_shared *bshared;
+        ap_log_error(APLOG_MARK, APLOG_DEBUG | APLOG_NOERRNO, 0, server, "add_balancer_node: Create balancer %s", name);
 
-       balancer = apr_array_push(conf->balancers);
-       memset(balancer, 0, sizeb);
+        balancer = apr_array_push(conf->balancers);
+        memset(balancer, 0, sizeb);
 
         balancer->gmutex = NULL;
         bshared = apr_palloc(conf->pool, sizeof(proxy_balancer_shared));
         memset(bshared, 0, sizeof(proxy_balancer_shared));
         if (PROXY_STRNCPY(bshared->sname, name) != APR_SUCCESS) {
-            ap_log_error(APLOG_MARK, APLOG_NOTICE|APLOG_NOERRNO, 0, server,
-                          "add_balancer_node: balancer safe-name (%s) too long", name);
+            ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, server,
+                         "add_balancer_node: balancer safe-name (%s) too long", name);
             return NULL;
         }
         bshared->hash.def = ap_proxy_hashfunc(name, PROXY_HASHFUNC_DEFAULT);
@@ -610,33 +621,34 @@ static proxy_balancer *add_balancer_node(nodeinfo_t *node, proxy_server_conf *co
         balancer->s = bshared;
         balancer->hash = bshared->hash;
         balancer->sconf = conf;
-        if (apr_thread_mutex_create(&(balancer->tmutex),
-                    APR_THREAD_MUTEX_DEFAULT, conf->pool) != APR_SUCCESS) {
+        if (apr_thread_mutex_create(&(balancer->tmutex), APR_THREAD_MUTEX_DEFAULT, conf->pool) != APR_SUCCESS) {
             /* XXX: Do we need to log something here? */
-            ap_log_error(APLOG_MARK, APLOG_NOTICE|APLOG_NOERRNO, 0, server,
-                          "add_balancer_node: Can't create lock for balancer");
+            ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, server,
+                         "add_balancer_node: Can't create lock for balancer");
         }
         balancer->workers = apr_array_make(conf->pool, 5, sizeof(proxy_worker *));
         strncpy(balancer->s->name, name, PROXY_BALANCER_MAX_NAME_SIZE - 1);
         /* XXX: TODO we should have our own lbmethod(s), this one is the mod_proxy_balancer default one! */
         balancer->lbmethod = ap_lookup_provider(PROXY_LBMETHOD, "byrequests", "0");
-    } else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG|APLOG_NOERRNO, 0, server,
-                      "add_balancer_node: Using balancer %s", name);
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG | APLOG_NOERRNO, 0, server, "add_balancer_node: Using balancer %s", name);
     }
 
     if (balancer && balancer->workers->nelts == 0) {
         /* Logic to copy the shared memory information to the balancer */
         balancerinfo_t *balan = read_balancer_name(&balancer->s->name[11], pool);
         if (balan == NULL)
-            return balancer; /* Done broken */
+            return balancer;    /* Done broken */
         /* StickySession, StickySessionRemove we hack it via the lbpname (16 bytes) */
         if (!balan->StickySession)
             strcpy(balancer->s->lbpname, MC_NOT_STICKY);
         else
-            strcpy(balancer->s->lbpname, MC_STICKY); /* default is Sticky */
+            strcpy(balancer->s->lbpname, MC_STICKY);    /* default is Sticky */
+
         if (balan->StickySessionRemove)
             strcpy(balancer->s->lbpname, MC_REMOVE_SESSION);
+
         strncpy(balancer->s->sticky, balan->StickySessionCookie, PROXY_BALANCER_MAX_STICKY_SIZE - 1);
         balancer->s->sticky[PROXY_BALANCER_MAX_STICKY_SIZE - 1] = '\0';
         strncpy(balancer->s->sticky_path, balan->StickySessionPath, PROXY_BALANCER_MAX_STICKY_SIZE - 1);
@@ -688,25 +700,25 @@ static void reuse_balancer(proxy_balancer *balancer, char *name, apr_pool_t *poo
             changed = -1;
         }
         if (strcmp(balan->StickySessionCookie, balancer->s->sticky) != 0) {
-            strncpy(balancer->s->sticky , balan->StickySessionCookie, PROXY_BALANCER_MAX_STICKY_SIZE - 1);
+            strncpy(balancer->s->sticky, balan->StickySessionCookie, PROXY_BALANCER_MAX_STICKY_SIZE - 1);
             balancer->s->sticky[PROXY_BALANCER_MAX_STICKY_SIZE - 1] = '\0';
             changed = -1;
         }
         if (strcmp(balan->StickySessionPath, balancer->s->sticky_path) != 0) {
-            strncpy(balancer->s->sticky_path , balan->StickySessionPath, PROXY_BALANCER_MAX_STICKY_SIZE - 1);
+            strncpy(balancer->s->sticky_path, balan->StickySessionPath, PROXY_BALANCER_MAX_STICKY_SIZE - 1);
             balancer->s->sticky_path[PROXY_BALANCER_MAX_STICKY_SIZE - 1] = '\0';
             changed = -1;
         }
-        balancer->s->timeout =  balan->Timeout;
+        balancer->s->timeout = balan->Timeout;
         balancer->s->max_attempts = balan->Maxattempts;
         balancer->s->max_attempts_set = 1;
         if (changed) {
             /* log a warning */
-            ap_log_error(APLOG_MARK, APLOG_NOTICE|APLOG_NOERRNO, 0, s,
-                         "Balancer %s changed" , &balancer->s->name[11]);
+            ap_log_error(APLOG_MARK, APLOG_NOTICE | APLOG_NOERRNO, 0, s, "Balancer %s changed", &balancer->s->name[11]);
         }
     }
 }
+
 /*
  * Adds the balancers and the workers to the VirtualHosts corresponding to node
  * Note that the calling routine should lock before calling us.
@@ -718,19 +730,19 @@ static void add_balancers_workers(nodeinfo_t *node, char *ptr_node, apr_pool_t *
 {
     server_rec *s = main_server;
     char *name = apr_pstrcat(pool, "balancer://", node->mess.balancer, NULL);
-            
+
     while (s) {
         void *sconf = s->module_config;
-        proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
+        proxy_server_conf *conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
         proxy_balancer *balancer = ap_proxy_get_balancer(pool, conf, name, 0);
 
-        if (!balancer && (creat_bal == CREAT_NONE ||
-            (creat_bal == CREAT_ROOT && s != main_server))) {
+        if (!balancer && (creat_bal == CREAT_NONE || (creat_bal == CREAT_ROOT && s != main_server))) {
             s = s->next;
             continue;
         }
-        if (!balancer)
+        if (!balancer) {
             balancer = add_balancer_node(node, conf, pool, s);
+        }
         else {
             /* We "reuse" the balancer */
             reuse_balancer(balancer, &balancer->s->name[11], pool, s);
@@ -756,17 +768,17 @@ static void add_balancers_workers(nodeinfo_t *node, char *ptr_node, apr_pool_t *
 static void add_balancers_workers_for_server(nodeinfo_t *node, char *ptr_node, apr_pool_t *pool, server_rec *s)
 {
     char *name = apr_pstrcat(pool, "balancer://", node->mess.balancer, NULL);
-            
+
     void *sconf = s->module_config;
-    proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
+    proxy_server_conf *conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
     proxy_balancer *balancer = ap_proxy_get_balancer(pool, conf, name, 0);
 
-    if (!balancer && (creat_bal == CREAT_NONE ||
-        (creat_bal == CREAT_ROOT && s != main_server))) {
+    if (!balancer && (creat_bal == CREAT_NONE || (creat_bal == CREAT_ROOT && s != main_server))) {
         return;
     }
-    if (!balancer)
+    if (!balancer) {
         balancer = add_balancer_node(node, conf, pool, s);
+    }
     else {
         /* We "reuse" the balancer */
         reuse_balancer(balancer, &balancer->s->name[11], pool, s);
@@ -777,7 +789,8 @@ static void add_balancers_workers_for_server(nodeinfo_t *node, char *ptr_node, a
 
 
 /* the worker corresponding to the id, note that we need to compare the shared memory pointer too */
-static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, proxy_worker_shared *stat, nodeinfo_t *node)
+static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, proxy_worker_shared *stat,
+                                             nodeinfo_t *node)
 {
     int i;
     char *ptr = conf->balancers->elts;
@@ -789,7 +802,7 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
         char *ptrw;
         proxy_balancer *balancer = (proxy_balancer *) ptr;
         ptrw = balancer->workers->elts;
-        for (j = 0; j < balancer->workers->nelts; j++,  ptrw = ptrw + sizew) {
+        for (j = 0; j < balancer->workers->nelts; j++, ptrw = ptrw + sizew) {
             proxy_worker **worker = (proxy_worker **) ptrw;
             proxy_cluster_helper *helper = (proxy_cluster_helper *) (*worker)->context;
             if ((*worker)->s == stat && helper->index == id) {
@@ -798,11 +811,10 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
                 char sport[7];
                 apr_snprintf(sport, sizeof(sport), "%d", (*worker)->s->port);
                 if (strcmp((*worker)->s->scheme, node->mess.Type) ||
-                    compare_hostname((*worker)->s->hostname, node->mess.Host) ||
-                    strcmp(sport, node->mess.Port)) {
+                    compare_hostname((*worker)->s->hostname, node->mess.Host) || strcmp(sport, node->mess.Port)) {
                     (*worker)->s->index = 0;
                     /* XXX: broken  ap_my_generation--; mark old generation that will recreate the process */
-                    continue; /* skip it */
+                    continue;   /* skip it */
                 }
 
                 return *worker;
@@ -818,18 +830,18 @@ static proxy_worker *get_worker_from_id_stat(proxy_server_conf *conf, int id, pr
 static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_pool_t *pool, server_rec *server)
 {
     int i;
-    char *pptr = (char *) node;
+    char *pptr = (char *)node;
     proxy_cluster_helper *helper;
     proxy_worker *worker;
     pptr = pptr + node->offset;
 
     worker = get_worker_from_id_stat(conf, node->mess.id, (proxy_worker_shared *) pptr, node);
-    (void) pool;
+    (void)pool;
 
     if (!worker) {
         /* XXX: Another process may use it, can't do: node_storage->remove_node(node); */
-        return 0; /* Done */
-                    /* Here we loop through our workers not need to check that the worker->s is OK */
+        return 0;               /* Done */
+        /* Here we loop through our workers not need to check that the worker->s is OK */
     }
 
     /* prevent other threads using it */
@@ -841,12 +853,12 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
     helper = (proxy_cluster_helper *) worker->context;
     if (helper) {
         i = helper->count_active;
-    } else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                     "remove_workers_node (helper is NULL)");
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "remove_workers_node (helper is NULL)");
     }
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-             "remove_workers_node (helper) count_active: %d JVMRoute: %s", i, node->mess.JVMRoute);
+                 "remove_workers_node (helper) count_active: %d JVMRoute: %s", i, node->mess.JVMRoute);
 
     if (i == 0) {
         /* The worker already comes from the apr_array of the balancer */
@@ -858,16 +870,20 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, server,
                      "remove_workers_node... scheme %s hostname %s port %d route %s name (%s):(%s) id (%d:%d)",
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                      stat->scheme, stat->hostname_ex, stat->port, stat->route, stat->name, helper->shared->name, stat->index, helper->index);
+                     stat->scheme, stat->hostname_ex, stat->port, stat->route, stat->name, helper->shared->name,
+                     stat->index, helper->index);
 #else
-                      stat->scheme, stat->hostname, stat->port, stat->route, stat->name, helper->shared->name, stat->index, helper->index);
+                     stat->scheme, stat->hostname, stat->port, stat->route, stat->name, helper->shared->name,
+                     stat->index, helper->index);
 #endif
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, server,
                      "remove_workers_node... restored: scheme %s hostname %s port %d route %s name %s id:%d",
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                      worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route, worker->s->name, worker->s->index);
+                     worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route, worker->s->name,
+                     worker->s->index);
 #else
-                      worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route, worker->s->name, worker->s->index);
+                     worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route, worker->s->name,
+                     worker->s->index);
 #endif
         /* XXX : look bad with new logic!!!! memcpy(worker->s, stat, sizeof(proxy_worker_shared)); */
         ap_assert(worker->s->port != 0);
@@ -879,28 +895,31 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
             worker->s->status |= PROXY_WORKER_STOPPED;
         }
 
-        return (0);
-    } else {
+        return 0;
+    }
+    else {
         node->mess.lastcleantry = apr_time_now();
-        return (1); /* We should retry later */
+        return 1;             /* We should retry later */
     }
 }
+
 /*
  * Create/Remove workers corresponding to updated nodes.
  * NOTE: It is called from proxy_cluster_watchdog_func and other locations
  *       It shouldn't call worker_nodes_are_updated() because there may be several VirtualHosts.
  */
-static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server, int check, proxy_node_table *node_table)
+static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server, int check,
+                                proxy_node_table *node_table)
 {
     int i;
     unsigned int last;
-    (void) conf;
+    (void)conf;
 
     if (node_table == NULL)
         return;
 
     /* Check if we have to do something */
-    if (check) { 
+    if (check) {
         last = node_storage->worker_nodes_need_update(main_server, pool);
         /* nodes_need_update will return 1 if last_updated is zero: first time we are called */
         if (last == 0) {
@@ -910,21 +929,19 @@ static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, serve
 
     /* XXX: How to skip the balancer that aren't controled by mod_manager */
 
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-             "update_workers_node starting");
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "update_workers_node starting");
 
     /* Only process the nodes that have been updated since our last update */
     for (i = 0; i < node_table->sizenode; i++) {
         nodeinfo_t *ou = &node_table->node_info[i];
-        if (ou->mess.remove) 
+        if (ou->mess.remove)
             continue;
         if (node_table->ptr_node[i] == NULL)
             continue;
         add_balancers_workers_for_server(ou, node_table->ptr_node[i], pool, server);
-    } 
+    }
 
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-             "update_workers_node done");
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "update_workers_node done");
 }
 
 /*
@@ -932,13 +949,11 @@ static void update_workers_node(proxy_server_conf *conf, apr_pool_t *pool, serve
  * XXX: ajp_handle_cping_cpong should come from a provider as
  * it is already in modules/proxy/ajp_utils.c
  */
-static apr_status_t ajp_handle_cping_cpong(apr_socket_t *sock,
-                                           request_rec *r,
-                                           apr_interval_time_t timeout)
+static apr_status_t ajp_handle_cping_cpong(apr_socket_t *sock, request_rec *r, apr_interval_time_t timeout)
 {
     char buf[5];
     apr_size_t written = 5;
-    apr_interval_time_t org; 
+    apr_interval_time_t org;
     apr_status_t status;
     apr_status_t rv;
 
@@ -951,50 +966,39 @@ static apr_status_t ajp_handle_cping_cpong(apr_socket_t *sock,
 
     status = apr_socket_send(sock, buf, &written);
     if (status != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server,
-                      "ajp_cping_cpong(): send failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server, "ajp_cping_cpong(): send failed");
         return status;
     }
     status = apr_socket_timeout_get(sock, &org);
     if (status != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server,
-                      "ajp_cping_cpong(): apr_socket_timeout_get failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server, "ajp_cping_cpong(): apr_socket_timeout_get failed");
         return status;
     }
     status = apr_socket_timeout_set(sock, timeout);
     written = 5;
     status = apr_socket_recv(sock, buf, &written);
     if (status != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server,
-               "ajp_cping_cpong: apr_socket_recv failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server, "ajp_cping_cpong: apr_socket_recv failed");
         goto cleanup;
     }
-    if (buf[0] != 0x41 || buf[1] != 0x42 || buf[2] != 0 || buf[3] != 1  || buf[4] != (unsigned char)9) {
+    if (buf[0] != 0x41 || buf[1] != 0x42 || buf[2] != 0 || buf[3] != 1 || buf[4] != (unsigned char)9) {
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-               "ajp_cping_cpong: awaited CPONG, received %02x %02x %02x %02x %02x",
-               buf[0] & 0xFF,
-               buf[1] & 0xFF,
-               buf[2] & 0xFF,
-               buf[3] & 0xFF,
-               buf[4] & 0xFF);
+                     "ajp_cping_cpong: awaited CPONG, received %02x %02x %02x %02x %02x",
+                     buf[0] & 0xFF, buf[1] & 0xFF, buf[2] & 0xFF, buf[3] & 0xFF, buf[4] & 0xFF);
         status = APR_EGENERAL;
     }
-cleanup:
+  cleanup:
     rv = apr_socket_timeout_set(sock, org);
     if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-               "ajp_cping_cpong: apr_socket_timeout_set failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server, "ajp_cping_cpong: apr_socket_timeout_set failed");
         return rv;
     }
 
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "ajp_cping_cpong: Done");
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "ajp_cping_cpong: Done");
     return status;
 }
 
-static
-apr_status_t ap_proxygetline(apr_bucket_brigade *bb, char *s, int n, request_rec *r,
-                             int fold, int *writen)
+static apr_status_t ap_proxygetline(apr_bucket_brigade *bb, char *s, int n, request_rec *r, int fold, int *writen)
 {
     char *tmp_s = s;
     apr_status_t rv;
@@ -1004,10 +1008,12 @@ apr_status_t ap_proxygetline(apr_bucket_brigade *bb, char *s, int n, request_rec
     apr_brigade_cleanup(bb);
 
     if (rv == APR_SUCCESS) {
-        *writen = (int) len;
-    } else if (rv == APR_ENOSPC) {
+        *writen = (int)len;
+    }
+    else if (rv == APR_ENOSPC) {
         *writen = n;
-    } else {
+    }
+    else {
         *writen = -1;
     }
 
@@ -1024,51 +1030,49 @@ static request_rec *ap_proxy_make_fake_req(conn_rec *c, request_rec *r)
 
     rp = apr_pcalloc(pool, sizeof(*r));
 
-    rp->pool            = pool;
-    rp->status          = HTTP_OK;
+    rp->pool = pool;
+    rp->status = HTTP_OK;
 
-    rp->headers_in      = apr_table_make(pool, 50);
-    rp->subprocess_env  = apr_table_make(pool, 50);
-    rp->headers_out     = apr_table_make(pool, 12);
+    rp->headers_in = apr_table_make(pool, 50);
+    rp->subprocess_env = apr_table_make(pool, 50);
+    rp->headers_out = apr_table_make(pool, 12);
     rp->err_headers_out = apr_table_make(pool, 5);
-    rp->notes           = apr_table_make(pool, 5);
+    rp->notes = apr_table_make(pool, 5);
 
     rp->server = r->server;
     rp->log = r->log;
     rp->proxyreq = r->proxyreq;
     rp->request_time = r->request_time;
-    rp->connection      = c;
-    rp->output_filters  = c->output_filters;
-    rp->input_filters   = c->input_filters;
-    rp->proto_output_filters  = c->output_filters;
-    rp->proto_input_filters   = c->input_filters;
+    rp->connection = c;
+    rp->output_filters = c->output_filters;
+    rp->input_filters = c->input_filters;
+    rp->proto_output_filters = c->output_filters;
+    rp->proto_input_filters = c->input_filters;
     rp->useragent_ip = c->client_ip;
     rp->useragent_addr = c->client_addr;
 
-    rp->request_config  = ap_create_request_config(pool);
+    rp->request_config = ap_create_request_config(pool);
     proxy_run_create_req(r, rp);
 
     return rp;
 }
+
 /*
  * Do a ping/pong to the node
  */
-static apr_status_t http_handle_cping_cpong(proxy_conn_rec *p_conn,
-                                           request_rec *r,
-                                           apr_interval_time_t timeout)
+static apr_status_t http_handle_cping_cpong(proxy_conn_rec *p_conn, request_rec *r, apr_interval_time_t timeout)
 {
     char *srequest;
     char buffer[HUGE_STRING_LEN];
     int len;
     apr_status_t status, rv;
-    apr_interval_time_t org; 
+    apr_interval_time_t org;
     apr_bucket_brigade *header_brigade, *tmp_bb;
     apr_bucket *e;
     request_rec *rp;
 
     srequest = apr_pstrcat(r->pool, "OPTIONS * HTTP/1.0\r\nUser-Agent: ",
-                           ap_get_server_banner(),
-                           " (internal mod_cluster connection)\r\n\r\n", NULL);
+                           ap_get_server_banner(), " (internal mod_cluster connection)\r\n\r\n", NULL);
     header_brigade = apr_brigade_create(r->pool, p_conn->connection->bucket_alloc);
     e = apr_bucket_pool_create(srequest, strlen(srequest), r->pool, p_conn->connection->bucket_alloc);
     APR_BRIGADE_INSERT_TAIL(header_brigade, e);
@@ -1078,16 +1082,14 @@ static apr_status_t http_handle_cping_cpong(proxy_conn_rec *p_conn,
     status = ap_pass_brigade(p_conn->connection->output_filters, header_brigade);
     apr_brigade_cleanup(header_brigade);
     if (status != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server,
-                      "http_cping_cpong(): send failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server, "http_cping_cpong(): send failed");
         p_conn->close = 1;
         return status;
     }
 
     status = apr_socket_timeout_get(p_conn->sock, &org);
     if (status != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server,
-                      "http_cping_cpong(): apr_socket_timeout_get failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server, "http_cping_cpong(): apr_socket_timeout_get failed");
         p_conn->close = 1;
         return status;
     }
@@ -1101,26 +1103,22 @@ static apr_status_t http_handle_cping_cpong(proxy_conn_rec *p_conn,
     while (1) {
         ap_proxygetline(tmp_bb, buffer, sizeof(buffer), rp, 0, &len);
         if (len <= 0)
-           break;
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "http_cping_cpong: received %s", buffer);
+            break;
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "http_cping_cpong: received %s", buffer);
         status = APR_SUCCESS;
     }
     if (status != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server,
-               "http_cping_cpong: ap_getline failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, status, r->server, "http_cping_cpong: ap_getline failed");
     }
     rv = apr_socket_timeout_set(p_conn->sock, org);
     if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-               "http_cping_cpong: apr_socket_timeout_set failed");
+        ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server, "http_cping_cpong: apr_socket_timeout_set failed");
         p_conn->close = 1;
         return rv;
     }
 
     p_conn->close = 1;
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "http_cping_cpong: Done");
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "http_cping_cpong: Done");
     return status;
 }
 
@@ -1136,19 +1134,16 @@ static apr_status_t proxy_cluster_try_pingpong(request_rec *r, proxy_worker *wor
     apr_uri_t *uri;
     char *scheme = worker->s->scheme;
     int is_ssl = 0;
-    (void) ping; (void) workertimeout;
+    (void)ping;
+    (void)workertimeout;
 
     if ((strcasecmp(scheme, "HTTPS") == 0 ||
-        strcasecmp(scheme, "WSS") == 0 ||
-        strcasecmp(scheme, "WS") == 0 ||
-        strcasecmp(scheme, "HTTP") == 0) &&
-        !enable_options)
-    {
+         strcasecmp(scheme, "WSS") == 0 ||
+         strcasecmp(scheme, "WS") == 0 || strcasecmp(scheme, "HTTP") == 0) && !enable_options) {
         /* we cant' do CPING/CPONG so we just return OK */
         return APR_SUCCESS;
     }
-    if (strcasecmp(scheme, "HTTPS") == 0 ||
-        strcasecmp(scheme, "WSS") == 0 ) {
+    if (strcasecmp(scheme, "HTTPS") == 0 || strcasecmp(scheme, "WSS") == 0) {
 
         if (!ap_proxy_ssl_enable(NULL)) {
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
@@ -1174,13 +1169,10 @@ static apr_status_t proxy_cluster_try_pingpong(request_rec *r, proxy_worker *wor
     }
 
     /* Step One: Determine Who To Connect To */
-    uri = apr_palloc(r->pool, sizeof(*uri)); /* We don't use it anyway */
+    uri = apr_palloc(r->pool, sizeof(*uri));    /* We don't use it anyway */
     server_portstr[0] = '\0';
     status = ap_proxy_determine_connection(r->pool, r, conf, worker, backend,
-                                           uri, &locurl,
-                                           NULL, 0,
-                                           server_portstr,
-                                           sizeof(server_portstr));
+                                           uri, &locurl, NULL, 0, server_portstr, sizeof(server_portstr));
     if (status != OK) {
         ap_proxy_release_connection(scheme, backend, r->server);
         return status;
@@ -1197,50 +1189,46 @@ static apr_status_t proxy_cluster_try_pingpong(request_rec *r, proxy_worker *wor
     /* Do nothing: 2.4.x has the ping_timeout and conn_timeout */
     timeout = worker->s->ping_timeout;
     if (timeout <= 0)
-        timeout =  apr_time_from_sec(10); /* 10 seconds */
+        timeout = apr_time_from_sec(10);        /* 10 seconds */
 
     /* Step Two: Make the Connection */
     status = ap_proxy_connect_backend(scheme, backend, worker, r->server);
     /* Do nothing: 2.4.x has the ping_timeout and conn_timeout */
     if (status != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "proxy_cluster_try_pingpong: can't connect to backend");
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_try_pingpong: can't connect to backend");
         ap_proxy_release_connection(scheme, backend, r->server);
         return status;
-    } else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "proxy_cluster_try_pingpong: connected to backend");
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_try_pingpong: connected to backend");
     }
 
     if (strcasecmp(scheme, "AJP") == 0) {
         status = ajp_handle_cping_cpong(backend->sock, r, timeout);
         if (status != APR_SUCCESS) {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy_cluster_try_pingpong: cping_cpong failed");
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_try_pingpong: cping_cpong failed");
             backend->close = 1;
         }
-        
-    } else {
+
+    }
+    else {
         /* non-AJP connections */
         if (!backend->connection) {
-            if ((status = ap_proxy_connection_create(scheme, backend,
-                                                     (conn_rec *) NULL, r->server)) == OK) {
+            if ((status = ap_proxy_connection_create(scheme, backend, (conn_rec *) NULL, r->server)) == OK) {
                 if (is_ssl) {
-                    apr_table_set(backend->connection->notes, "proxy-request-hostname",
-                                  uri->hostname);
+                    apr_table_set(backend->connection->notes, "proxy-request-hostname", uri->hostname);
                 }
-            } else {
+            }
+            else {
                 ap_proxy_release_connection(scheme, backend, r->server);
                 return status;
             }
         }
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                "proxy_cluster_try_pingpong: trying %s"
-                , backend->connection->client_ip);
+                     "proxy_cluster_try_pingpong: trying %s", backend->connection->client_ip);
         status = http_handle_cping_cpong(backend, r, timeout);
         if (status != APR_SUCCESS) {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy_cluster_try_pingpong: cping_cpong failed");
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_try_pingpong: cping_cpong failed");
             backend->close = 1;
         }
     }
@@ -1256,16 +1244,15 @@ static apr_status_t read_node_worker(int id, nodeinfo_t **node, proxy_worker *wo
     if (status != APR_SUCCESS)
         return status;
     apr_snprintf(sport, sizeof(sport), "%d", worker->s->port);
-    if (strcmp(worker->s->scheme, (* node)->mess.Type) ||
-        compare_hostname(worker->s->hostname, (* node)->mess.Host) ||
-        strcmp(sport, (* node)->mess.Port)) {
+    if (strcmp(worker->s->scheme, (*node)->mess.Type) ||
+        compare_hostname(worker->s->hostname, (*node)->mess.Host) || strcmp(sport, (*node)->mess.Port)) {
         /* for some reasons it is not the right node */
         return APR_NOTFOUND;
     }
     return APR_SUCCESS;
 }
 
-static void* APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data)
+static void *APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data)
 {
     apr_status_t rv;
     char sport[7];
@@ -1273,7 +1260,7 @@ static void* APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data
     apr_pool_t *rrp;
     request_rec *rnew;
 
-    watchdog_thread_args_t *targs = (watchdog_thread_args_t *)data;
+    watchdog_thread_args_t *targs = (watchdog_thread_args_t *) data;
     proxy_worker *worker = targs->worker;
     apr_pool_t *pool = targs->pool;
     proxy_server_conf *conf = targs->conf;
@@ -1287,7 +1274,7 @@ static void* APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data
     if (strchr(worker->s->hostname, ':') != NULL)
         url = apr_pstrcat(pool, worker->s->scheme, "://[", worker->s->hostname, "]:", sport, "/", NULL);
     else
-        url = apr_pstrcat(pool, worker->s->scheme, "://", worker->s->hostname,  ":", sport, "/", NULL);
+        url = apr_pstrcat(pool, worker->s->scheme, "://", worker->s->hostname, ":", sport, "/", NULL);
 
     apr_pool_create(&rrp, pool);
     apr_pool_tag(rrp, "subrequest");
@@ -1311,7 +1298,7 @@ static void* APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data
     /* We have checked the worker... check if we were told to stop */
     if (child_stopping) {
         return APR_SUCCESS;
-    } 
+    }
 
     ap_assert(node_storage->lock_nodes() == APR_SUCCESS);
     if (read_node_worker(id, &ou, worker) != APR_SUCCESS) {
@@ -1329,8 +1316,9 @@ static void* APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data
             /* Failing for 5 minutes: time to mark it removed */
             ou->mess.remove = 1;
             ou->updatetime = now;
-        } 
-    } else {
+        }
+    }
+    else {
         ou->mess.num_failure_idle = 0;
     }
 
@@ -1358,7 +1346,7 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
     /* update lbstatus if needed */
     for (i = 0; i < size; i++) {
         nodeinfo_t *ou;
-        ap_assert (node_storage->lock_nodes() == APR_SUCCESS);
+        ap_assert(node_storage->lock_nodes() == APR_SUCCESS);
         /* Check if we are told to stop */
         if (child_stopping) {
             node_storage->unlock_nodes();
@@ -1378,7 +1366,7 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
             int elected, oldelected;
             apr_off_t read, oldread;
             proxy_worker_shared *stat;
-            char *ptr = (char *) ou;
+            char *ptr = (char *)ou;
 
             ptr = ptr + ou->offset;
             stat = (proxy_worker_shared *) ptr;
@@ -1397,7 +1385,7 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
                 /* worker->s->retries is the number of retries that have occured */
                 /* it is set to zero when the back-end is back to normal.        */
                 /* worker->s->retries is also set to zero is a connection is     */
-                /* establish so we use read to check for changes                 */ 
+                /* establish so we use read to check for changes                 */
                 char sport[7];
                 watchdog_thread_args_t targs;
                 proxy_worker *worker;
@@ -1405,23 +1393,21 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
 
                 if (worker == NULL) {
                     node_storage->unlock_nodes();
-                    continue; /* skip it */
+                    continue;   /* skip it */
                 }
                 apr_snprintf(sport, sizeof(sport), "%d", worker->s->port);
 
                 if (strcmp(worker->s->scheme, ou->mess.Type) ||
-                    compare_hostname(worker->s->hostname, ou->mess.Host) ||
-                    strcmp(sport, ou->mess.Port)) {
+                    compare_hostname(worker->s->hostname, ou->mess.Host) || strcmp(sport, ou->mess.Port)) {
                     node_storage->unlock_nodes();
                     /* the worker doesn't correspond to the node something is very broken */
                     ap_assert(0);
-                    continue; /* won't reach this one... */
+                    continue;   /* won't reach this one... */
                 }
 
                 /* Here we should decide about using hcheck result or a request that pings the node */
                 if (proxyhctemplate != NULL) {
-                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                                 "update_workers_lbstatus Using hcheck!");
+                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "update_workers_lbstatus Using hcheck!");
                     if (worker->s->status & PROXY_WORKER_NOT_USABLE_BITMAP) {
                         /* marked errored by hcheck */
                         ou->mess.num_failure_idle++;
@@ -1430,14 +1416,15 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
                             ou->mess.remove = 1;
                             ou->updatetime = now;
                         }
-                    } else {
+                    }
+                    else {
                         ou->mess.num_failure_idle = 0;
                     }
                     node_storage->unlock_nodes();
-                    continue; /* Done in this case */
-                } else {
-                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                                 "update_workers_lbstatus Using old logic!");
+                    continue;   /* Done in this case */
+                }
+                else {
+                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "update_workers_lbstatus Using old logic!");
                 }
                 node_storage->unlock_nodes();
 
@@ -1447,8 +1434,7 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
                 }
 
                 /* We need threads to process that "blocking" logic */
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                                 "update_workers_lbstatus Using old logic!!!!");
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "update_workers_lbstatus Using old logic!!!!");
 #if MC_USE_THREADS
                 if (mc_thread_pool) {
                     apr_status_t res;
@@ -1466,14 +1452,15 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
                         targs_ptr->now = now;
                         targs_ptr->id = id[i];
                         res = apr_thread_pool_push(mc_thread_pool, check_proxy_worker,
-                                                   (void *) targs_ptr, APR_THREAD_TASK_PRIORITY_NORMAL, NULL);
+                                                   (void *)targs_ptr, APR_THREAD_TASK_PRIORITY_NORMAL, NULL);
                         if (res == APR_SUCCESS) {
                             /* Early return. Task was scheduled! */
                             return;
                         }
                         /* Log about failed scheduling and execute without threads below. */
                         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "thread push was NOT successful: %d", res);
-                    } else {
+                    }
+                    else {
                         ap_log_error(APLOG_MARK, APLOG_ERR, 0, server, "Memory allocation for thread args failed");
                     }
                     /* Thread alloc or push failed, so run it without threads!
@@ -1490,20 +1477,22 @@ static void update_workers_lbstatus(proxy_server_conf *conf, apr_pool_t *pool, s
                 targs.now = now;
                 targs.id = id[i];
 
-                check_proxy_worker(NULL, (void *) &targs);
+                check_proxy_worker(NULL, (void *)&targs);
 
                 /* We have checked the worker... check if we were told to stop */
                 if (child_stopping) {
                     return;
                 }
-            } else {
+            }
+            else {
                 ou->mess.num_failure_idle = 0;
                 node_storage->unlock_nodes();
             }
-        }  else {
-           node_storage->unlock_nodes();
         }
-    } 
+        else {
+            node_storage->unlock_nodes();
+        }
+    }
 }
 
 /*
@@ -1513,7 +1502,8 @@ static void remove_timeout_sessionid(proxy_server_conf *conf, apr_pool_t *pool, 
 {
     int *id, size, i;
     apr_time_t now;
-    (void) conf; (void) server;
+    (void)conf;
+    (void)server;
 
     now = apr_time_sec(apr_time_now());
 
@@ -1534,8 +1524,8 @@ static void remove_timeout_sessionid(proxy_server_conf *conf, apr_pool_t *pool, 
         if (ou->updatetime < (now - TIMESESSIONID)) {
             /* Remove it */
             sessionid_storage->remove_sessionid(ou);
-        } 
-    } 
+        }
+    }
 }
 
 /*
@@ -1562,25 +1552,23 @@ static void remove_timeout_domain(apr_pool_t *pool)
         if (ou->updatetime < (now - TIMEDOMAIN)) {
             /* Remove it */
             domain_storage->remove_domain(ou);
-        } 
-    } 
+        }
+    }
 }
 
 /*
  * Check that the worker corresponds to a node that belongs to the same domain according to the JVMRoute.
- */ 
-static int isnode_domain_ok(request_rec *r, nodeinfo_t *node,
-                             const char *domain)
+ */
+static int isnode_domain_ok(request_rec *r, nodeinfo_t *node, const char *domain)
 {
-    (void) r;
+    (void)r;
 #if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "isnode_domain_ok: domain %s:%s", domain, node->mess.Domain);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "isnode_domain_ok: domain %s:%s", domain, node->mess.Domain);
 #endif
     if (domain == NULL)
-        return 1; /* OK no domain in the corresponding to the SESSIONID */
+        return 1;               /* OK no domain in the corresponding to the SESSIONID */
     if (strcmp(node->mess.Domain, domain) == 0)
-        return 1; /* OK */
+        return 1;               /* OK */
     return 0;
 }
 
@@ -1592,9 +1580,9 @@ static int isnode_domain_ok(request_rec *r, nodeinfo_t *node,
  * We also try the domain.
  */
 static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, proxy_server_conf *conf,
-                                         request_rec *r, const char *domain, int failoverdomain,
-                                         proxy_vhost_table *vhost_table,
-                                         proxy_context_table *context_table, proxy_node_table *node_table)
+                                                   request_rec *r, const char *domain, int failoverdomain,
+                                                   proxy_vhost_table *vhost_table,
+                                                   proxy_context_table *context_table, proxy_node_table *node_table)
 {
     int i, hash = 0;
     proxy_worker *mycandidate = NULL;
@@ -1616,14 +1604,12 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
     workers = apr_pcalloc(r->pool, sizeof(proxy_worker *) * balancer->workers->nelts);
 #if HAVE_CLUSTER_EX_DEBUG
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "proxy: Entering byrequests for CLUSTER (%s) failoverdomain:%d",
-                 balancer->s->name,
-                 failoverdomain);
+                 "proxy: Entering byrequests for CLUSTER (%s) failoverdomain:%d", balancer->s->name, failoverdomain);
 #endif
 
     /* create workers for new nodes */
     if (!cache_share_for) {
-        volatile apr_status_t rv; 
+        volatile apr_status_t rv;
         rv = node_storage->lock_nodes();
         ap_assert(rv == APR_SUCCESS);
         update_workers_node(conf, r->pool, r->server, 1, node_table);
@@ -1653,21 +1639,22 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
             if (!worker->s || !worker->context) {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                             "proxy: byrequests balancer %s skipping BAD worker %s", balancer->s->name, worker->s ? worker->s->name_ex : "NULL");
+                             "proxy: byrequests balancer %s skipping BAD worker %s", balancer->s->name,
+                             worker->s ? worker->s->name_ex : "NULL");
 #else
-                             "proxy: byrequests balancer %s skipping BAD worker %s", balancer->s->name, worker->s ? worker->s->name : "NULL");
+                             "proxy: byrequests balancer %s skipping BAD worker %s", balancer->s->name,
+                             worker->s ? worker->s->name : "NULL");
 #endif
                 continue;
             }
             if (helper->index == 0) {
                 ap_assert(0);
-                continue; /* marked removed */
+                continue;       /* marked removed */
             }
             if (helper->index != worker->s->index) {
                 /* something is very bad */
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                             "proxy: byrequests balancer skipping BAD worker");
-                continue; /* probably used by different worker */
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: byrequests balancer skipping BAD worker");
+                continue;       /* probably used by different worker */
             }
 
             /* standby logic
@@ -1692,28 +1679,28 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
                 node_context *best1;
                 if (best == NULL) {
                     apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", "");
-                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                         "proxy: byrequests balancer FAILED");
+                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: byrequests balancer FAILED");
                     return NULL;
                 }
                 best1 = best;
 
-                while ((*best1).node != -1) {
-                    if ((*best1).node == worker->s->index) break;
+                while (best1->node != -1) {
+                    if (best1->node == worker->s->index)
+                        break;
                     best1++;
                 }
-                if ((*best1).node == -1)
-                    continue; /* not found */
+                if (best1->node == -1)
+                    continue;   /* not found */
 
                 nodecontext = best1;
 
                 /* Let's do the table read only now after we know the worker is usable and matches */
                 if (read_node_worker(worker->s->index, &node, worker) != APR_SUCCESS)
-                    continue; /* Can't read node */
-                pptr = (char *) node;
+                    continue;   /* Can't read node */
+                pptr = (char *)node;
                 pptr = pptr + node->offset;
                 if (worker->s != (proxy_worker_shared *) pptr)
-                    continue; /* wrong shared memory address */
+                    continue;   /* wrong shared memory address */
 
                 if (!checked_domain) {
                     /* First try only nodes in the domain */
@@ -1726,13 +1713,15 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
                 if (worker->s->lbfactor == 0 && checking_standby) {
                     mycandidate = worker;
                     mynodecontext = nodecontext;
-                    break; /* Done */
-                } else {
+                    break;      /* Done */
+                }
+                else {
                     if (!mycandidate) {
                         mycandidate = worker;
                         mynodecontext = nodecontext;
                         node1 = node;
-                    } else {
+                    }
+                    else {
                         int lbstatus, lbstatus1;
 
                         /* Let's avoid repeat reads of mycandidate through our loop iterations */
@@ -1743,11 +1732,12 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
                             }
                         }
 
-                        lbstatus1 = ((mycandidate->s->elected - node1->mess.oldelected) * 1000)/mycandidate->s->lbfactor;
-                        lbstatus  = ((worker->s->elected - node->mess.oldelected) * 1000)/worker->s->lbfactor;
+                        lbstatus1 =
+                            ((mycandidate->s->elected - node1->mess.oldelected) * 1000) / mycandidate->s->lbfactor;
+                        lbstatus = ((worker->s->elected - node->mess.oldelected) * 1000) / worker->s->lbfactor;
                         lbstatus1 = lbstatus1 + mycandidate->s->lbstatus;
                         lbstatus = lbstatus + worker->s->lbstatus;
-                        if (lbstatus1> lbstatus) {
+                        if (lbstatus1 > lbstatus) {
                             mycandidate = worker;
                             mynodecontext = nodecontext;
                             node1 = node;
@@ -1769,12 +1759,13 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
                 hash += session_id[i];
             }
             mycandidate = workers[hash % workers_length];
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "Using deterministic failover target: %s", mycandidate->s->route);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "Using deterministic failover target: %s",
+                         mycandidate->s->route);
         }
         if (mycandidate)
             break;
         if (failoverdomain)
-             break; /* We only failover in the domain */
+            break;              /* We only failover in the domain */
         if (checked_domain) {
             checked_standby = checking_standby++;
         }
@@ -1786,18 +1777,17 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
         if (!checked_domain)
             apr_table_setn(r->notes, "session-domain-ok", "1");
         mycandidate->s->elected++;
-        apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", apr_psprintf(r->pool, "%d", (*mynodecontext).context));
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                             "proxy: byrequests balancer DONE (%s)",
+        apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", apr_psprintf(r->pool, "%d", mynodecontext->context));
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: byrequests balancer DONE (%s)",
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                             mycandidate->s->name_ex);
+                     mycandidate->s->name_ex);
 #else
-                             mycandidate->s->name);
+                     mycandidate->s->name);
 #endif
-    } else {
+    }
+    else {
         apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", "");
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                             "proxy: byrequests balancer FAILED");
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: byrequests balancer FAILED");
     }
     return mycandidate;
 }
@@ -1827,10 +1817,10 @@ static int proxy_node_isup(request_rec *r, int id, int load)
         return 500;
 
     /* Calculate the address of our shared memory that corresponds to the stat info of the worker */
-    ptr = (char *) node;
+    ptr = (char *)node;
     ptr = ptr + node->offset;
     stat = (proxy_worker_shared *) ptr;
-    ptr = (char *) node;
+    ptr = (char *)node;
 
     /* create the balancers and workers (that could be the first time) */
     rv = node_storage->lock_nodes();
@@ -1838,7 +1828,7 @@ static int proxy_node_isup(request_rec *r, int id, int load)
     add_balancers_workers(node, ptr, r->pool);
     node_storage->unlock_nodes();
 
-    /* search for the worker in the VirtualHosts */ 
+    /* search for the worker in the VirtualHosts */
     while (s) {
         void *sconf = s->module_config;
         conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
@@ -1863,25 +1853,25 @@ static int proxy_node_isup(request_rec *r, int id, int load)
             if (worker->s->status & PROXY_WORKER_NOT_USABLE_BITMAP) {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
                              "proxy_cluster_isup: health check says PROXY_WORKER_IN_ERROR");
-                return  500;
-            } else {
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                             "proxy_cluster_isup: health check says OK");
+                return 500;
             }
-        } else {
+            else {
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_isup: health check says OK");
+            }
+        }
+        else {
             char sport[7];
             char *url;
             apr_snprintf(sport, sizeof(sport), "%d", worker->s->port);
             if (strchr(worker->s->hostname, ':') != NULL)
                 url = apr_pstrcat(r->pool, worker->s->scheme, "://[", worker->s->hostname, "]:", sport, "/", NULL);
             else
-                url = apr_pstrcat(r->pool, worker->s->scheme, "://", worker->s->hostname,  ":" , sport, "/", NULL);
-            worker->s->error_time = 0; /* Force retry now */
+                url = apr_pstrcat(r->pool, worker->s->scheme, "://", worker->s->hostname, ":", sport, "/", NULL);
+            worker->s->error_time = 0;  /* Force retry now */
             rv = proxy_cluster_try_pingpong(r, worker, url, conf, node->mess.ping, node->mess.timeout);
             if (rv != APR_SUCCESS) {
                 worker->s->status |= PROXY_WORKER_IN_ERROR;
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                             "proxy_cluster_isup: pingpong %s failed", url);
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_isup: pingpong %s failed", url);
                 return 500;
             }
         }
@@ -1906,6 +1896,7 @@ static int proxy_node_isup(request_rec *r, int id, int load)
     }
     return 0;
 }
+
 static int proxy_host_isup(request_rec *r, char *scheme, char *host, char *port)
 {
     apr_socket_t *sock;
@@ -1915,40 +1906,38 @@ static int proxy_host_isup(request_rec *r, char *scheme, char *host, char *port)
 
     rv = apr_socket_create(&sock, APR_INET, SOCK_STREAM, 0, r->pool);
     if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "proxy_host_isup: pingpong (apr_socket_create) failed");
-        return 500; 
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_host_isup: pingpong (apr_socket_create) failed");
+        return 500;
     }
     rv = apr_sockaddr_info_get(&to, host, APR_INET, nport, 0, r->pool);
     if (rv != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
                      "proxy_host_isup: pingpong (apr_sockaddr_info_get(%s, %d)) failed", host, nport);
-        return 500; 
+        return 500;
     }
 
     rv = apr_socket_connect(sock, to);
     if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "proxy_host_isup: pingpong (apr_socket_connect) failed");
-        return 500; 
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_host_isup: pingpong (apr_socket_connect) failed");
+        return 500;
     }
 
     /* XXX: For the moment we support only AJP */
     if (strcasecmp(scheme, "AJP") == 0) {
         rv = ajp_handle_cping_cpong(sock, r, apr_time_from_sec(10));
         if (rv != APR_SUCCESS) {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy_host_isup: cping_cpong failed");
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_host_isup: cping_cpong failed");
             return 500;
         }
-    } else {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy_host_isup: %s no yet supported", scheme);
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_host_isup: %s no yet supported", scheme);
     }
 
     apr_socket_close(sock);
     return 0;
 }
+
 static proxy_worker *searchworker(request_rec *r, char *bal, char *ptr, int *id, proxy_server_conf **the_conf)
 {
     /* search for the worker in the VirtualHosts */
@@ -1972,27 +1961,26 @@ static proxy_worker *searchworker(request_rec *r, char *bal, char *ptr, int *id,
                 if (worker->s->index != 0) {
                     *id = worker->s->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker %s: worker->s->index: %d the_conf %ld", ptr, *id, (uintptr_t) conf );
+                                 "searchworker %s: worker->s->index: %d the_conf %ld", ptr, *id, (uintptr_t) conf);
                     *the_conf = conf;
-                    return worker; /* Done current index */
+                    return worker;      /* Done current index */
                 }
                 helper = (proxy_cluster_helper *) worker->context;
                 if (helper && helper->index != 0) {
                     *id = helper->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker %s: helper->index %d the_conf %ld", ptr, *id, (uintptr_t) conf );
+                                 "searchworker %s: helper->index %d the_conf %ld", ptr, *id, (uintptr_t) conf);
                     *the_conf = conf;
-                    return worker; /* Done previous index */
+                    return worker;      /* Done previous index */
                 }
                 if (helper && helper->shared) {
                     *id = helper->shared->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker %s: helper->shared->index %d the_conf %ld", ptr, *id, (uintptr_t) conf );
+                                 "searchworker %s: helper->shared->index %d the_conf %ld", ptr, *id, (uintptr_t) conf);
                     *the_conf = conf;
-                    return worker; /* our index was saved when we remove... */
+                    return worker;      /* our index was saved when we remove... */
                 }
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                             "searchworker %s: FAILED", ptr);
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "searchworker %s: FAILED", ptr);
                 return NULL;
             }
         }
@@ -2002,7 +1990,8 @@ static proxy_worker *searchworker(request_rec *r, char *bal, char *ptr, int *id,
     return NULL;
 }
 
-static proxy_worker * proxy_node_getid(request_rec *r, char *balancername, char *scheme, char *host, char *port, int *id, proxy_server_conf **the_conf)
+static proxy_worker *proxy_node_getid(request_rec *r, char *balancername, char *scheme, char *host, char *port, int *id,
+                                      proxy_server_conf **the_conf)
 {
     proxy_worker *worker = NULL;
     char *ptr, *url, *bal;
@@ -2011,12 +2000,11 @@ static proxy_worker * proxy_node_getid(request_rec *r, char *balancername, char 
     ptr = normalize_workername(r->pool, url);
     if (ptr == NULL) {
         *id = 0;
-        ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-                     "proxy_node_getid: normalize_workername returns NULL");
-        return NULL; /* Should not happend */
+        ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server, "proxy_node_getid: normalize_workername returns NULL");
+        return NULL;            /* Should not happend */
     }
     bal = apr_pstrcat(r->pool, "balancer://", balancername, NULL);
-    
+
     /* search for the worker in the VirtualHosts */
     worker = searchworker(r, bal, url, id, the_conf);
 
@@ -2024,8 +2012,7 @@ static proxy_worker * proxy_node_getid(request_rec *r, char *balancername, char 
         *id = 0;
         return NULL;
     }
-    ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-                 "proxy_node_getid: the_conf %ld", (uintptr_t) *the_conf);
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server, "proxy_node_getid: the_conf %ld", (uintptr_t) *the_conf);
     return worker;
 }
 
@@ -2042,22 +2029,22 @@ static int proxy_node_get_free_id(request_rec *r, int node_table_size)
         void *sconf = s->module_config;
         proxy_balancer *balancer;
         proxy_server_conf *conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
-        balancer = (proxy_balancer *)conf->balancers->elts;
+        balancer = (proxy_balancer *) conf->balancers->elts;
         for (i = 0; i < conf->balancers->nelts; i++, balancer++) {
             int j;
             proxy_worker **workers;
-            workers = (proxy_worker **)balancer->workers->elts;
+            workers = (proxy_worker **) balancer->workers->elts;
             for (j = 0; j < balancer->workers->nelts; j++, workers++) {
                 volatile proxy_worker *worker = *workers;
                 proxy_cluster_helper *helper;
                 helper = (proxy_cluster_helper *) worker->context;
-                ap_assert(helper); /* we are in trouble ... */
+                ap_assert(helper);      /* we are in trouble ... */
                 if (worker->s->index != 0) {
                     free_id[worker->s->index] = worker->s->index;
                 }
                 if (helper && helper->index != 0) {
                     free_id[helper->index] = helper->index;
-                } 
+                }
             }
         }
         s = s->next;
@@ -2065,38 +2052,39 @@ static int proxy_node_get_free_id(request_rec *r, int node_table_size)
 
     /* Add the ones used according to the node table */
     num_used_id = node_storage->get_ids_used_node(used_id);
-    for (free_i=0; free_i<num_used_id; free_i++) {
+    for (free_i = 0; free_i < num_used_id; free_i++) {
         free_id[used_id[free_i]] = used_id[free_i];
     }
-    
-    for (free_i=1; free_i<node_table_size; free_i++) {
+
+    for (free_i = 1; free_i < node_table_size; free_i++) {
         if (free_id[free_i] == 0) {
             return free_i;
         }
     }
 
-    return 0; /* nothing in workers any value is OK */
+    return 0;                   /* nothing in workers any value is OK */
 }
 
 static void init_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_worker *worker, proxy_server_conf *the_conf)
 {
     worker->s->status = PROXY_WORKER_INITIALIZED;
-    strncpy(worker->s->route, node->mess.JVMRoute, sizeof( worker->s->route));
-    worker->s->route[sizeof(worker->s->route)-1] = '\0';
+    strncpy(worker->s->route, node->mess.JVMRoute, sizeof(worker->s->route));
+    worker->s->route[sizeof(worker->s->route) - 1] = '\0';
     strncpy(worker->s->upgrade, node->mess.Upgrade, sizeof(worker->s->upgrade));
-    worker->s->upgrade[sizeof(worker->s->upgrade)-1] = '\0';
+    worker->s->upgrade[sizeof(worker->s->upgrade) - 1] = '\0';
     strncpy(worker->s->secret, node->mess.AJPSecret, sizeof(worker->s->secret));
-    worker->s->secret[sizeof(worker->s->secret)-1] = '\0';
-    if (node->mess.ResponseFieldSize>0) {
-       worker->s->response_field_size = node->mess.ResponseFieldSize;
-       worker->s->response_field_size_set = 1;
-    } else {
-       worker->s->response_field_size_set = 0;
+    worker->s->secret[sizeof(worker->s->secret) - 1] = '\0';
+    if (node->mess.ResponseFieldSize > 0) {
+        worker->s->response_field_size = node->mess.ResponseFieldSize;
+        worker->s->response_field_size_set = 1;
+    }
+    else {
+        worker->s->response_field_size_set = 0;
     }
     /* XXX: We need that information from TC */
     worker->s->redirect[0] = '\0';
     worker->s->lbstatus = 0;
-    worker->s->lbfactor = -1; /* prevent using the node using status message */
+    worker->s->lbfactor = -1;   /* prevent using the node using status message */
 
     /* add health check */
     worker->s->updated = apr_time_now();
@@ -2104,7 +2092,9 @@ static void init_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_worker
         add_hcheck(server, the_conf, worker);
     }
 }
-static void reenable_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_worker *worker, nodeinfo_t *nodeinfo, proxy_server_conf *the_conf)
+
+static void reenable_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_worker *worker, nodeinfo_t *nodeinfo,
+                                  proxy_server_conf *the_conf)
 {
     char *ptr;
     proxy_cluster_helper *helper;
@@ -2115,7 +2105,7 @@ static void reenable_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_wo
     /* XXX: BAD IDEA!!! helper->shared = worker->s; */
     helper->isinnodes = 1;
     /* XXX: BAD IDEA!! helper->index = node->mess.id; */
-    ptr = (char *) node;
+    ptr = (char *)node;
     ptr = ptr + node->offset;
     worker->s = (proxy_worker_shared *) ptr;
     /* merge the "new" node information */
@@ -2125,8 +2115,7 @@ static void reenable_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_wo
 /*
  * For the provider
  */
-static const struct balancer_method balancerhandler =
-{
+static const struct balancer_method balancerhandler = {
     proxy_node_isup,
     proxy_host_isup,
     proxy_node_getid,
@@ -2138,16 +2127,16 @@ static int node_has_workers(server_rec *server, proxy_server_conf *conf, int id)
 {
     int i;
     proxy_balancer *balancer;
-    balancer = (proxy_balancer *)conf->balancers->elts;
+    balancer = (proxy_balancer *) conf->balancers->elts;
     for (i = 0; i < conf->balancers->nelts; i++, balancer++) {
         int j;
         proxy_worker **workers;
-        workers = (proxy_worker **)balancer->workers->elts;
+        workers = (proxy_worker **) balancer->workers->elts;
         for (j = 0; j < balancer->workers->nelts; j++, workers++) {
             volatile proxy_worker *worker = *workers;
             proxy_cluster_helper *helper;
             helper = (proxy_cluster_helper *) worker->context;
-            ap_assert(helper); /* we are in trouble ... */
+            ap_assert(helper);  /* we are in trouble ... */
             if (helper->index == id) {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                              "remove_removed_node %d for REMOVED node_has_workers %d", id, getpid());
@@ -2155,7 +2144,7 @@ static int node_has_workers(server_rec *server, proxy_server_conf *conf, int id)
             }
         }
     }
-   
+
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                  "remove_removed_node %d for REMOVED node_has_workers NO WORKERS %d", id, getpid());
     return 0;
@@ -2170,7 +2159,7 @@ static void remove_removed_node(apr_pool_t *pool, proxy_server_conf *conf, serve
     apr_time_t now = apr_time_now();
     /* read the ident of the nodes */
     size = node_storage->get_max_size_node();
-    (void) server;
+    (void)server;
 
     if (size == 0)
         return;
@@ -2180,19 +2169,20 @@ static void remove_removed_node(apr_pool_t *pool, proxy_server_conf *conf, serve
         nodeinfo_t *ou;
         if (node_storage->read_node(id[i], &ou) != APR_SUCCESS)
             continue;
-        if (strcmp(ou->mess.JVMRoute, "REMOVED") == 0 &&
-            (now - ou->updatetime) >= wait_for_remove) {
+        if (strcmp(ou->mess.JVMRoute, "REMOVED") == 0 && (now - ou->updatetime) >= wait_for_remove) {
             if (node_has_workers(server, conf, ou->mess.id)) {
-                ou->updatetime = now; 
+                ou->updatetime = now;
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                         "remove_removed_node %d for REMOVED wait %d", ou->mess.id, getpid());
-            } else {
+                             "remove_removed_node %d for REMOVED wait %d", ou->mess.id, getpid());
+            }
+            else {
                 ou->mess.num_remove_check++;
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                         "remove_removed_node %d %s for REMOVED done %d", ou->mess.id, ou->mess.Port, getpid());
+                             "remove_removed_node %d %s for REMOVED done %d", ou->mess.id, ou->mess.Port, getpid());
                 if (ou->mess.num_remove_check > 10) {
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                             "remove_removed_node %d %s for REMOVED done (DONE) %d", ou->mess.id, ou->mess.Port, getpid());
+                                 "remove_removed_node %d %s for REMOVED done (DONE) %d", ou->mess.id, ou->mess.Port,
+                                 getpid());
                     node_storage->remove_node(ou->mess.id);
                 }
             }
@@ -2216,7 +2206,7 @@ static void remove_removed_node(apr_pool_t *pool, proxy_server_conf *conf, serve
             }
             /* remove the node from the shared memory */
             ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-                         "remove_removed_node: %d %s %s %d" , ou->mess.id, ou->mess.JVMRoute, ou->mess.Port, getpid());
+                         "remove_removed_node: %d %s %s %d", ou->mess.id, ou->mess.JVMRoute, ou->mess.Port, getpid());
             node_storage->remove_host_context(ou->mess.id, pool);
 
             strcpy(ou->mess.JVMRoute, "REMOVED");
@@ -2224,10 +2214,11 @@ static void remove_removed_node(apr_pool_t *pool, proxy_server_conf *conf, serve
 
             /* prevent real remove until processes don't have the node in workers */
             ou->updatetime = now;
-            ou->mess.num_remove_check = 0; 
+            ou->mess.num_remove_check = 0;
         }
     }
 }
+
 /* remote workers corresponding to removed nodes, we should be locked before calling it */
 static void remove_workers_nodes(proxy_server_conf *conf, apr_pool_t *pool, server_rec *server)
 {
@@ -2249,6 +2240,7 @@ static void remove_workers_nodes(proxy_server_conf *conf, apr_pool_t *pool, serv
         }
     }
 }
+
 /* Called by mc_watchdog_callback every n seconds */
 /* it is called for the main server, we need to loop on all servers */
 static void proxy_cluster_watchdog_func(server_rec *s, apr_pool_t *pool)
@@ -2261,7 +2253,7 @@ static void proxy_cluster_watchdog_func(server_rec *s, apr_pool_t *pool)
     proxy_node_table *node_table = NULL;
 
     if (!conf)
-       return;
+        return;
 
     /* check if we need to update. */
     last = node_storage->worker_nodes_need_update(s, pool);
@@ -2281,19 +2273,21 @@ static void proxy_cluster_watchdog_func(server_rec *s, apr_pool_t *pool)
                     update_context_table_cached(cached_context_table, context_storage);
                     update_balancer_table_cached(cached_balancer_table, balancer_storage);
                     update_node_table_cached(cached_node_table, node_storage);
-                } else {
+                }
+                else {
                     apr_pool_create(&cached_pool, conf->pool);
                     cached_vhost_table = read_vhost_table(cached_pool, host_storage, 1);
                     cached_context_table = read_context_table(cached_pool, context_storage, 1);
                     cached_balancer_table = read_balancer_table(cached_pool, balancer_storage, 1);
                     cached_node_table = read_node_table(cached_pool, node_storage, 1);
-                    ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
+                    ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
                                  "cached_pool: should have been created in proxy_cluster_child_init!");
                 }
                 node_storage->unlock_nodes();
             }
             node_table = cached_node_table;
-        } else {
+        }
+        else {
             apr_status_t rv = node_storage->lock_nodes();
             ap_assert(rv == APR_SUCCESS);
             if (child_stopping) {
@@ -2347,50 +2341,48 @@ static void proxy_cluster_watchdog_func(server_rec *s, apr_pool_t *pool)
 }
 
 
-static apr_status_t mc_watchdog_callback(int state, void *data,
-                                         apr_pool_t *pool)
+static apr_status_t mc_watchdog_callback(int state, void *data, apr_pool_t *pool)
 {
     apr_status_t res = APR_SUCCESS;
-    server_rec *s = (server_rec *)data;
+    server_rec *s = (server_rec *) data;
     switch (state) {
-        case AP_WATCHDOG_STATE_STARTING:
+    case AP_WATCHDOG_STATE_STARTING:
 #if MC_USE_THREADS
-            if (mc_thread_pool_size && mc_thread_pool == NULL) {
-                res = apr_thread_pool_create(&mc_thread_pool, mc_thread_pool_size,
-                                             mc_thread_pool_size, s->process->pool);
-                if (res != APR_SUCCESS) {
-                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s,
-                                 "apr_thread_pool_create failed, threads will not be used");
-                    mc_thread_pool = NULL;
-                }
-            } else {
-                mc_thread_pool = NULL;
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "Threads are not used");
-            }
-#endif
-            break;
-
-        case AP_WATCHDOG_STATE_RUNNING:
-            if (s) {
-               apr_time_t wait = cache_share_for;
-               /* It is called for every server defined in httpd */
-               proxy_cluster_watchdog_func(s, pool);
-               /* set the next call back to cache_share_for or 1 if zero */
-               if (!wait)
-                   wait = apr_time_from_sec(1);
-               mc_watchdog_set_interval(watchdog, wait, s, mc_watchdog_callback);
-            }
-            break;
-
-        case AP_WATCHDOG_STATE_STOPPING:
-#if MC_USE_THREADS
-            res = apr_thread_pool_destroy(mc_thread_pool);
+        if (mc_thread_pool_size && mc_thread_pool == NULL) {
+            res = apr_thread_pool_create(&mc_thread_pool, mc_thread_pool_size, mc_thread_pool_size, s->process->pool);
             if (res != APR_SUCCESS) {
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "apr_thread_pool_destroy failed");
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "apr_thread_pool_create failed, threads will not be used");
+                mc_thread_pool = NULL;
             }
+        }
+        else {
             mc_thread_pool = NULL;
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "Threads are not used");
+        }
 #endif
-            break;
+        break;
+
+    case AP_WATCHDOG_STATE_RUNNING:
+        if (s) {
+            apr_time_t wait = cache_share_for;
+            /* It is called for every server defined in httpd */
+            proxy_cluster_watchdog_func(s, pool);
+            /* set the next call back to cache_share_for or 1 if zero */
+            if (!wait)
+                wait = apr_time_from_sec(1);
+            mc_watchdog_set_interval(watchdog, wait, s, mc_watchdog_callback);
+        }
+        break;
+
+    case AP_WATCHDOG_STATE_STOPPING:
+#if MC_USE_THREADS
+        res = apr_thread_pool_destroy(mc_thread_pool);
+        if (res != APR_SUCCESS) {
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, s, "apr_thread_pool_destroy failed");
+        }
+        mc_thread_pool = NULL;
+#endif
+        break;
     }
     return res;
 }
@@ -2405,7 +2397,7 @@ static void proxy_cluster_child_stopping(apr_pool_t *pool, int graceful)
  * Create a thread per process to make maintenance task.
  * and the mutex of the node creation.
  */
-static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
+static void proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
 {
     apr_status_t rv;
     void *sconf = s->module_config;
@@ -2414,12 +2406,12 @@ static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
     main_server = s;
 
     /* moved to mod_manager
-    rv = apr_thread_mutex_create(&lock, APR_THREAD_MUTEX_DEFAULT, p);
-    if (rv != APR_SUCCESS) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_child_init: apr_thread_mutex_create failed");
-    }
-    */
+       rv = apr_thread_mutex_create(&lock, APR_THREAD_MUTEX_DEFAULT, p);
+       if (rv != APR_SUCCESS) {
+       ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
+       "proxy_cluster_child_init: apr_thread_mutex_create failed");
+       }
+     */
 
     rv = node_storage->lock_nodes();
     ap_assert(rv == APR_SUCCESS);
@@ -2435,10 +2427,11 @@ static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
             cached_balancer_table = read_balancer_table(cached_pool, balancer_storage, 1);
             cached_node_table = read_node_table(cached_pool, node_storage, 1);
             node_table = cached_node_table;
-        } else {
+        }
+        else {
             node_table = read_node_table(pool, node_storage, 0);
         }
-        
+
         while (s) {
             sconf = s->module_config;
             conf = (proxy_server_conf *)
@@ -2454,19 +2447,19 @@ static void  proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
     node_storage->unlock_nodes();
 }
 
-static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
-                                     apr_pool_t *ptemp, server_rec *main_s)
+static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *ptemp, server_rec *main_s)
 {
-    APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) *mc_watchdog_get_instance;
-    APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;
+    APR_OPTIONAL_FN_TYPE(ap_watchdog_get_instance) * mc_watchdog_get_instance;
+    APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) * mc_watchdog_register_callback;
     server_rec *s = main_s;
     void *sconf = s->module_config;
-    proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
+    proxy_server_conf *conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
     int sizew = conf->workers->elt_size;
     int sizeb = conf->balancers->elt_size;
     int idx;
     int has_static_workers = 0;
-    (void) plog; (void) ptemp;
+    (void)plog;
+    (void)ptemp;
 
     if (sizew != sizeof(proxy_worker) || sizeb != sizeof(proxy_balancer)) {
         ap_version_t version;
@@ -2474,8 +2467,8 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
 
         ap_log_error(APLOG_MARK, APLOG_WARNING, 0, s,
                      "httpd version %d.%d.%d doesn't match version %d.%d.%d used by mod_proxy_cluster.c",
-                      version.major, version.minor, version.patch,
-                      AP_SERVER_MAJORVERSION_NUMBER, AP_SERVER_MINORVERSION_NUMBER, AP_SERVER_PATCHLEVEL_NUMBER);
+                     version.major, version.minor, version.patch,
+                     AP_SERVER_MAJORVERSION_NUMBER, AP_SERVER_MINORVERSION_NUMBER, AP_SERVER_PATCHLEVEL_NUMBER);
     }
     if (SIZEOFSCORE <= sizeof(proxy_worker_shared)) {
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, s,
@@ -2486,7 +2479,7 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
 
     /* Check that the mod_proxy_balancer.c is not loaded */
     if (ap_find_linked_module("mod_proxy_balancer.c") != NULL) {
-       ap_log_error(APLOG_MARK, APLOG_ERR, 0, s,
+        ap_log_error(APLOG_MARK, APLOG_ERR, 0, s,
                      "Module mod_proxy_balancer is loaded"
                      " it must be removed  in order for mod_proxy_cluster to function properly");
         return HTTP_INTERNAL_SERVER_ERROR;
@@ -2494,17 +2487,15 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
 
     /* if we have a proxyhctemplate check for the template or failed */
     if (proxyhctemplate != NULL) {
-       if (ap_find_linked_module("mod_proxy_hcheck.c") == NULL) {
-          ap_log_error(APLOG_MARK, APLOG_ERR, 0, s,
-                       "UseProxyHCTemplate requires mod_proxy_hcheck");
-           return HTTP_INTERNAL_SERVER_ERROR;
-       }
-       if (set_worker_hc_param_f  == NULL) {
-          ap_log_error(APLOG_MARK, APLOG_ERR, 0, s,
-                       "UseProxyHCTemplate can't be validated");
-           return HTTP_INTERNAL_SERVER_ERROR;
-       }
-       /* get mod_proxy_hcheck.c validating the string... */
+        if (ap_find_linked_module("mod_proxy_hcheck.c") == NULL) {
+            ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, "UseProxyHCTemplate requires mod_proxy_hcheck");
+            return HTTP_INTERNAL_SERVER_ERROR;
+        }
+        if (set_worker_hc_param_f == NULL) {
+            ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, "UseProxyHCTemplate can't be validated");
+            return HTTP_INTERNAL_SERVER_ERROR;
+        }
+        /* get mod_proxy_hcheck.c validating the string... */
     }
 
     /* check for static workers and warn if that is the case */
@@ -2512,20 +2503,20 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
         int i;
         proxy_balancer *balancer;
         void *sconf = s->module_config;
-        conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
-        balancer = (proxy_balancer *)conf->balancers->elts;
+        conf = (proxy_server_conf *) ap_get_module_config(sconf, &proxy_module);
+        balancer = (proxy_balancer *) conf->balancers->elts;
         for (i = 0; i < conf->balancers->nelts; i++, balancer++) {
             int j;
             proxy_worker **workers;
-            workers = (proxy_worker **)balancer->workers->elts;
+            workers = (proxy_worker **) balancer->workers->elts;
             for (j = 0; j < balancer->workers->nelts; j++, workers++) {
-                 proxy_worker *worker = *workers;
-                 ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
-                              "%s BalancerMember are NOT supported %s", balancer->s->name, worker->s->name);
-                 has_static_workers = 1;
+                proxy_worker *worker = *workers;
+                ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
+                             "%s BalancerMember are NOT supported %s", balancer->s->name, worker->s->name);
+                has_static_workers = 1;
             }
         }
-    s = s->next;
+        s = s->next;
     }
     s = main_s;
     if (has_static_workers) {
@@ -2533,53 +2524,51 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
         return !OK;
     }
 
-    node_storage = ap_lookup_provider("manager" , "shared", "0");
+    node_storage = ap_lookup_provider("manager", "shared", "0");
     if (node_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for nodes");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for nodes");
         return !OK;
     }
-    host_storage = ap_lookup_provider("manager" , "shared", "1");
+    host_storage = ap_lookup_provider("manager", "shared", "1");
     if (host_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for hosts");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for hosts");
         return !OK;
     }
-    context_storage = ap_lookup_provider("manager" , "shared", "2");
+    context_storage = ap_lookup_provider("manager", "shared", "2");
     if (context_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for contexts");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for contexts");
         return !OK;
     }
-    balancer_storage = ap_lookup_provider("manager" , "shared", "3");
+    balancer_storage = ap_lookup_provider("manager", "shared", "3");
     if (balancer_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for balancers");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for balancers");
         return !OK;
     }
-    sessionid_storage = ap_lookup_provider("manager" , "shared", "4");
+    sessionid_storage = ap_lookup_provider("manager", "shared", "4");
     if (sessionid_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for sessionids");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for sessionids");
         return !OK;
     }
     /* if Maxsessionid = 0 switch of the sessionid storing logic */
     if (!sessionid_storage->get_max_size_sessionid()) {
-        sessionid_storage = NULL; /* don't use it */
+        sessionid_storage = NULL;       /* don't use it */
     }
 
-    domain_storage = ap_lookup_provider("manager" , "shared", "5");
+    domain_storage = ap_lookup_provider("manager", "shared", "5");
     if (domain_storage == NULL) {
-        ap_log_error(APLOG_MARK, APLOG_ERR|APLOG_NOERRNO, 0, s,
-                    "proxy_cluster_post_config: Can't find mod_manager for domains");
+        ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s,
+                     "proxy_cluster_post_config: Can't find mod_manager for domains");
         return !OK;
     }
     if (!ap_proxy_retry_worker_fn) {
-        ap_proxy_retry_worker_fn =
-                APR_RETRIEVE_OPTIONAL_FN(ap_proxy_retry_worker);
+        ap_proxy_retry_worker_fn = APR_RETRIEVE_OPTIONAL_FN(ap_proxy_retry_worker);
         if (!ap_proxy_retry_worker_fn) {
-            ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
-                         "mod_proxy must be loaded for mod_proxy_cluster");
+            ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, "mod_proxy must be loaded for mod_proxy_cluster");
             return !OK;
         }
     }
@@ -2588,12 +2577,10 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
     ap_add_version_component(p, MOD_CLUSTER_EXPOSED_VERSION);
 
     if (ap_state_query(AP_SQ_MAIN_STATE) == AP_SQ_MS_CREATE_PRE_CONFIG) {
-        ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
-                     "No watchdog for %d", getpid());
+        ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, "No watchdog for %d", getpid());
         return OK;
     }
-    ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
-                 "watchdog for %d", getpid());
+    ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s, "watchdog for %d", getpid());
 
     /* add our watchdog callback */
     mc_watchdog_get_instance = APR_RETRIEVE_OPTIONAL_FN(ap_watchdog_get_instance);
@@ -2605,22 +2592,15 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
         return !OK;
     }
     /* get watchdog to create a thread for each of our children */
-    if (mc_watchdog_get_instance(&watchdog,
-                                  LB_CLUSTER_WATHCHDOG_NAME,
-                                  0, 0, p)) {
+    if (mc_watchdog_get_instance(&watchdog, LB_CLUSTER_WATHCHDOG_NAME, 0, 0, p)) {
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03263)
-                     "Failed to create watchdog instance (%s)",
-                     LB_CLUSTER_WATHCHDOG_NAME);
+                     "Failed to create watchdog instance (%s)", LB_CLUSTER_WATHCHDOG_NAME);
         return !OK;
     }
 
-    if (mc_watchdog_register_callback(watchdog,
-            AP_WD_TM_SLICE,
-            s,
-            mc_watchdog_callback)) {
+    if (mc_watchdog_register_callback(watchdog, AP_WD_TM_SLICE, s, mc_watchdog_callback)) {
         ap_log_error(APLOG_MARK, APLOG_CRIT, 0, s, APLOGNO(03264)
-                     "Failed to register watchdog callback (%s)",
-                     LB_CLUSTER_WATHCHDOG_NAME);
+                     "Failed to register watchdog callback (%s)", LB_CLUSTER_WATHCHDOG_NAME);
         return !OK;
     }
 
@@ -2630,10 +2610,11 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog,
 }
 
 /* pre_config for the health check part */
-static int proxy_cluster_pre_config(apr_pool_t *pconf, apr_pool_t *plog,
-                               apr_pool_t *ptemp)
+static int proxy_cluster_pre_config(apr_pool_t *pconf, apr_pool_t *plog, apr_pool_t *ptemp)
 {
-    (void) pconf; (void) plog; (void) ptemp;
+    (void)pconf;
+    (void)plog;
+    (void)ptemp;
 
 #if MC_USE_THREADS
     mc_thread_pool = NULL;
@@ -2667,7 +2648,8 @@ static int proxy_cluster_trans(request_rec *r)
         context_table = cached_context_table;
         balancer_table = cached_balancer_table;
         node_table = cached_node_table;
-    } else {
+    }
+    else {
         volatile apr_status_t rv;
         rv = node_storage->lock_nodes();
         ap_assert(rv == APR_SUCCESS);
@@ -2681,14 +2663,14 @@ static int proxy_cluster_trans(request_rec *r)
         node_storage->unlock_nodes();
     }
 
-    apr_table_setn(r->notes, "vhost-table",  (char *) vhost_table);
-    apr_table_setn(r->notes, "context-table",  (char *) context_table);
-    apr_table_setn(r->notes, "balancer-table",  (char *) balancer_table);
-    apr_table_setn(r->notes, "node-table",  (char *) node_table);
+    apr_table_setn(r->notes, "vhost-table", (char *)vhost_table);
+    apr_table_setn(r->notes, "context-table", (char *)context_table);
+    apr_table_setn(r->notes, "balancer-table", (char *)balancer_table);
+    apr_table_setn(r->notes, "node-table", (char *)node_table);
 
     ap_log_rerror(APLOG_MARK, APLOG_TRACE8, 0, r,
-                "proxy_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s",
-                 r->proxyreq, r->filename, r->handler, r->uri, r->args, r->unparsed_uri);
+                  "proxy_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s",
+                  r->proxyreq, r->filename, r->handler, r->uri, r->args, r->unparsed_uri);
 
     balancer = get_route_balancer(r, conf, vhost_table, context_table, balancer_table, node_table, use_alias);
     if (!balancer) {
@@ -2706,9 +2688,10 @@ static int proxy_cluster_trans(request_rec *r)
             if (!enc) {
                 rv = ap_proxy_trans_match(r, dconf->alias, dconf);
                 if (rv != HTTP_CONTINUE) {
-                   ap_log_rerror(APLOG_MARK, APLOG_TRACE3, 0, r,
-                                "proxy_cluster_trans ap_proxy_trans_match(dconf) matches or reject %s  to %s", r->uri, r->filename);
-                    return rv; /* Done */
+                    ap_log_rerror(APLOG_MARK, APLOG_TRACE3, 0, r,
+                                  "proxy_cluster_trans ap_proxy_trans_match(dconf) matches or reject %s  to %s", r->uri,
+                                  r->filename);
+                    return rv;  /* Done */
                 }
             }
         }
@@ -2721,9 +2704,10 @@ static int proxy_cluster_trans(request_rec *r)
             if (!enc) {
                 rv = ap_proxy_trans_match(r, ent, dconf);
                 if (rv != HTTP_CONTINUE) {
-                   ap_log_rerror(APLOG_MARK, APLOG_TRACE3, 0, r,
-                                "proxy_cluster_trans ap_proxy_trans_match(conf) matches or reject %s  to %s", r->uri, r->filename);
-                    return rv; /* Done */
+                    ap_log_rerror(APLOG_MARK, APLOG_TRACE3, 0, r,
+                                  "proxy_cluster_trans ap_proxy_trans_match(conf) matches or reject %s  to %s", r->uri,
+                                  r->filename);
+                    return rv;  /* Done */
                 }
             }
         }
@@ -2736,24 +2720,23 @@ static int proxy_cluster_trans(request_rec *r)
         if (use_nocanon) {
             apr_table_setn(r->notes, "proxy-nocanon", "1");
             use_uri = r->unparsed_uri;
-        } else {
+        }
+        else {
             use_uri = r->uri;
-        } 
-        if (strncmp(use_uri, "balancer://",11))
-            r->filename =  apr_pstrcat(r->pool, "proxy:balancer://", balancer, use_uri, NULL);
+        }
+        if (strncmp(use_uri, "balancer://", 11))
+            r->filename = apr_pstrcat(r->pool, "proxy:balancer://", balancer, use_uri, NULL);
         else
-            r->filename =  apr_pstrcat(r->pool, "proxy:", use_uri, NULL);
+            r->filename = apr_pstrcat(r->pool, "proxy:", use_uri, NULL);
         r->handler = "proxy-server";
         r->proxyreq = PROXYREQ_REVERSE;
-        ap_log_rerror(APLOG_MARK, APLOG_TRACE3, 0, r,
-                    "proxy_cluster_trans using %s uri: %s",
-                     balancer, r->filename);
-        return OK; /* Mod_proxy will process it */
+        ap_log_rerror(APLOG_MARK, APLOG_TRACE3, 0, r, "proxy_cluster_trans using %s uri: %s", balancer, r->filename);
+        return OK;              /* Mod_proxy will process it */
     }
- 
+
     ap_log_rerror(APLOG_MARK, APLOG_TRACE8, 0, r,
-                "proxy_cluster_trans DECLINED %s uri: %s unparsed_uri: %s",
-                 balancer ? balancer : "", r->filename, r->unparsed_uri);
+                  "proxy_cluster_trans DECLINED %s uri: %s unparsed_uri: %s",
+                  balancer ? balancer : "", r->filename, r->unparsed_uri);
     return DECLINED;
 }
 
@@ -2771,13 +2754,13 @@ static int proxy_cluster_canon(request_rec *r, char *url)
 
     if (strncasecmp(url, "balancer:", 9) == 0) {
         url += 9;
-    } else {
+    }
+    else {
         return DECLINED;
     }
 
 #if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_NOERRNO|APLOG_DEBUG, 0, r->server,
-                    "proxy_cluster_canon url: %s", url);
+    ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, r->server, "proxy_cluster_canon url: %s", url);
 #endif
 
     /* do syntatic check.
@@ -2785,29 +2768,26 @@ static int proxy_cluster_canon(request_rec *r, char *url)
      */
     err = ap_proxy_canon_netloc(r->pool, &url, NULL, NULL, &host, &port);
     if (err) {
-        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
-                      "error parsing URL %s: %s",
-                      url, err);
+        ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "error parsing URL %s: %s", url, err);
         return HTTP_BAD_REQUEST;
     }
     /*
      * now parse path/search args, according to rfc1738:
      * process the path. With proxy-noncanon set (by
      * mod_proxy) we use the raw, unparsed uri
-    */
+     */
     if (apr_table_get(r->notes, "proxy-nocanon")) {
-        path = url;   /* this is the raw path */
+        path = url;             /* this is the raw path */
     }
     else {
-        path = ap_proxy_canonenc(r->pool, url, strlen(url), enc_path, 0,
-                                 r->proxyreq);
+        path = ap_proxy_canonenc(r->pool, url, strlen(url), enc_path, 0, r->proxyreq);
         search = r->args;
     }
     if (path == NULL)
         return HTTP_BAD_REQUEST;
 
     r->filename = apr_pstrcat(r->pool, "proxy:balancer://", host,
-            "/", path, (search) ? "?" : "", (search) ? search : "", NULL);
+                              "/", path, (search) ? "?" : "", (search) ? search : "", NULL);
 
     r->path_info = apr_pstrcat(r->pool, "/", path, NULL);
 
@@ -2821,9 +2801,9 @@ static int proxy_cluster_canon(request_rec *r, char *url)
             ap_get_module_config(sconf, &proxy_module);
 
         proxy_vhost_table *vhost_table = (proxy_vhost_table *) apr_table_get(r->notes, "vhost-table");
-        proxy_context_table *context_table  = (proxy_context_table *) apr_table_get(r->notes, "context-table");
-        proxy_balancer_table *balancer_table  = (proxy_balancer_table *) apr_table_get(r->notes, "balancer-table");
-        proxy_node_table *node_table  = (proxy_node_table *) apr_table_get(r->notes, "node-table");
+        proxy_context_table *context_table = (proxy_context_table *) apr_table_get(r->notes, "context-table");
+        proxy_balancer_table *balancer_table = (proxy_balancer_table *) apr_table_get(r->notes, "balancer-table");
+        proxy_node_table *node_table = (proxy_node_table *) apr_table_get(r->notes, "node-table");
 
         if (!vhost_table)
             vhost_table = read_vhost_table(r->pool, host_storage, 0);
@@ -2850,14 +2830,13 @@ static int proxy_cluster_canon(request_rec *r, char *url)
 static proxy_worker *find_route_worker(request_rec *r,
                                        proxy_balancer *balancer, const char *route,
                                        proxy_vhost_table *vhost_table,
-                                       proxy_context_table *context_table,
-                                       proxy_node_table *node_table)
+                                       proxy_context_table *context_table, proxy_node_table *node_table)
 {
     int i;
     int checking_standby;
     int checked_standby;
     int sizew = balancer->workers->elt_size;
-    
+
     proxy_worker *worker;
     node_context *nodecontext;
 
@@ -2870,12 +2849,11 @@ static proxy_worker *find_route_worker(request_rec *r,
             proxy_cluster_helper *helper = (*run)->context;
             worker = *run;
             if (index != helper->index) {
-                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                              "proxy: find_route_worker skipping BAD worker");
-                 continue; /* skip it */
+                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: find_route_worker skipping BAD worker");
+                continue;       /* skip it */
             }
             if (index == 0)
-                continue; /* marked removed */
+                continue;       /* marked removed */
 
             if ((checking_standby ? !PROXY_WORKER_IS_STANDBY(worker) : PROXY_WORKER_IS_STANDBY(worker)))
                 continue;
@@ -2885,14 +2863,19 @@ static proxy_worker *find_route_worker(request_rec *r,
                     /* The context may not be available */
                     nodeinfo_t *node;
                     if (read_node_worker(index, &node, worker) != APR_SUCCESS)
-                        return NULL; /* can't read node */
-                    if ((nodecontext = context_host_ok(r, balancer, index, use_alias, vhost_table, context_table, node_table)) != NULL) {
-                        apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", apr_psprintf(r->pool, "%d", (*nodecontext).context));
+                        return NULL;    /* can't read node */
+                    if ((nodecontext =
+                         context_host_ok(r, balancer, index, use_alias, vhost_table, context_table,
+                                         node_table)) != NULL) {
+                        apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID",
+                                       apr_psprintf(r->pool, "%d", nodecontext->context));
                         return worker;
-                    } else {
-                        return NULL; /* application has been removed from the node */
                     }
-                } else {
+                    else {
+                        return NULL;    /* application has been removed from the node */
+                    }
+                }
+                else {
                     /*
                      * If the worker is in error state run
                      * retry on that worker. It will be marked as
@@ -2902,17 +2885,22 @@ static proxy_worker *find_route_worker(request_rec *r,
                      */
                     ap_proxy_retry_worker_fn("BALANCER", worker, r->server);
                     if (PROXY_WORKER_IS_USABLE(worker)) {
-                            /* The context may not be available */
-                            nodeinfo_t *node;
-                            if (node_storage->read_node(index, &node) != APR_SUCCESS)
-                                return NULL; /* can't read node */
-                            if ((nodecontext = context_host_ok(r, balancer, index, use_alias, vhost_table, context_table, node_table)) != NULL) {
-                                apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", apr_psprintf(r->pool, "%d", (*nodecontext).context));
-                                return worker;
-                            } else {
-                                return NULL; /* application has been removed from the node */
-                            }
-                    } else {
+                        /* The context may not be available */
+                        nodeinfo_t *node;
+                        if (node_storage->read_node(index, &node) != APR_SUCCESS)
+                            return NULL;        /* can't read node */
+                        if ((nodecontext =
+                             context_host_ok(r, balancer, index, use_alias, vhost_table, context_table,
+                                             node_table)) != NULL) {
+                            apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID",
+                                           apr_psprintf(r->pool, "%d", nodecontext->context));
+                            return worker;
+                        }
+                        else {
+                            return NULL;        /* application has been removed from the node */
+                        }
+                    }
+                    else {
                         /*
                          * We have a worker that is unusable.
                          * It can be in error or disabled, but in case
@@ -2924,7 +2912,7 @@ static proxy_worker *find_route_worker(request_rec *r,
                         if (*worker->s->redirect) {
                             proxy_worker *rworker = NULL;
                             rworker = find_route_worker(r, balancer, worker->s->redirect,
-                                    vhost_table, context_table, node_table);
+                                                        vhost_table, context_table, node_table);
                             /* Check if the redirect worker is usable */
                             if (rworker && !PROXY_WORKER_IS_USABLE(rworker)) {
                                 /*
@@ -2940,12 +2928,16 @@ static proxy_worker *find_route_worker(request_rec *r,
                                 /* The context may not be available */
                                 nodeinfo_t *node;
                                 if (node_storage->read_node(index, &node) != APR_SUCCESS)
-                                    return NULL; /* can't read node */
-                                if ((nodecontext = context_host_ok(r, balancer, index, use_alias, vhost_table, context_table, node_table)) != NULL) {
-                                    apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", apr_psprintf(r->pool, "%d", (*nodecontext).context));
+                                    return NULL;        /* can't read node */
+                                if ((nodecontext =
+                                     context_host_ok(r, balancer, index, use_alias, vhost_table, context_table,
+                                                     node_table)) != NULL) {
+                                    apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID",
+                                                   apr_psprintf(r->pool, "%d", nodecontext->context));
                                     return rworker;
-                                } else {
-                                    return NULL; /* application has been removed from the node */
+                                }
+                                else {
+                                    return NULL;        /* application has been removed from the node */
                                 }
                             }
                         }
@@ -2968,15 +2960,15 @@ static proxy_worker *find_session_route(proxy_balancer *balancer,
                                         char **url,
                                         const char **domain,
                                         proxy_vhost_table *vhost_table,
-                                        proxy_context_table *context_table,
-                                        proxy_node_table *node_table)
+                                        proxy_context_table *context_table, proxy_node_table *node_table)
 {
     proxy_worker *worker = NULL;
-    (void) url;
+    (void)url;
 
 #if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "find_session_route: sticky %s sticky_path: %s sticky_force: %d", balancer->s->sticky, balancer->s->sticky_path, balancer->s->sticky_force);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                 "find_session_route: sticky %s sticky_path: %s sticky_force: %d", balancer->s->sticky,
+                 balancer->s->sticky_path, balancer->s->sticky_force);
 #endif
     if (balancer->s->sticky[0] == '\0' || balancer->s->sticky_path[0] == '\0')
         return NULL;
@@ -2987,12 +2979,11 @@ static proxy_worker *find_session_route(proxy_balancer *balancer,
     /* We already should have the route in the notes for the trans() */
     *route = apr_table_get(r->notes, "session-route");
     if (*route && (**route)) {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "cluster: Using route %s", *route);
-    } else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster: Using route %s", *route);
+    }
+    else {
 #if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "cluster:No route found");
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster:No route found");
 #endif
         return NULL;
     }
@@ -3013,8 +3004,7 @@ static proxy_worker *find_session_route(proxy_balancer *balancer,
          */
         apr_table_setn(r->subprocess_env, "BALANCER_ROUTE_CHANGED", "1");
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "proxy: CLUSTER: Route changed from %s to %s",
-                     *route, worker->s->route);
+                     "proxy: CLUSTER: Route changed from %s to %s", *route, worker->s->route);
     }
     return worker;
 }
@@ -3022,28 +3012,24 @@ static proxy_worker *find_session_route(proxy_balancer *balancer,
 static proxy_worker *find_best_worker(proxy_balancer *balancer, proxy_server_conf *conf,
                                       request_rec *r, const char *domain, int failoverdomain,
                                       proxy_vhost_table *vhost_table,
-                                      proxy_context_table *context_table,
-                                      proxy_node_table *node_table,
-                                      int recurse)
+                                      proxy_context_table *context_table, proxy_node_table *node_table, int recurse)
 {
     proxy_worker *candidate = NULL;
     apr_status_t rv;
 
     if ((rv = PROXY_THREAD_LOCK(balancer)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, r->server,
-        "proxy: CLUSTER: (%s). Lock failed for find_best_worker()",
-         balancer->s->name
-         );
+                     "proxy: CLUSTER: (%s). Lock failed for find_best_worker()", balancer->s->name);
         return NULL;
     }
 
-    candidate = internal_find_best_byrequests(balancer, conf, r, domain, failoverdomain, vhost_table, context_table, node_table);
+    candidate =
+        internal_find_best_byrequests(balancer, conf, r, domain, failoverdomain, vhost_table, context_table,
+                                      node_table);
 
     if ((rv = PROXY_THREAD_UNLOCK(balancer)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, r->server,
-        "proxy: CLUSTER: (%s). Unlock failed for find_best_worker()",
-         balancer->s->name
-         );
+                     "proxy: CLUSTER: (%s). Unlock failed for find_best_worker()", balancer->s->name);
     }
 
     if (candidate == NULL) {
@@ -3069,7 +3055,7 @@ static proxy_worker *find_best_worker(proxy_balancer *balancer, proxy_server_con
                 apr_sleep(step);
                 /* Try again */
                 if ((candidate = find_best_worker(balancer, conf, r,
-                        domain, failoverdomain, vhost_table, context_table, node_table, 0)))
+                                                  domain, failoverdomain, vhost_table, context_table, node_table, 0)))
                     break;
                 tval += step;
             }
@@ -3079,8 +3065,7 @@ static proxy_worker *find_best_worker(proxy_balancer *balancer, proxy_server_con
     return candidate;
 }
 
-static int rewrite_url(request_rec *r, proxy_worker *worker,
-                        char **url)
+static int rewrite_url(request_rec *r, proxy_worker *worker, char **url)
 {
     const char *scheme = strstr(*url, "://");
     const char *path = NULL;
@@ -3091,8 +3076,7 @@ static int rewrite_url(request_rec *r, proxy_worker *worker,
     /* we break the URL into host, port, uri */
     if (!worker) {
         return ap_proxyerror(r, HTTP_BAD_REQUEST, apr_pstrcat(r->pool,
-                             "missing worker. URI cannot be parsed: ", *url,
-                             NULL));
+                                                              "missing worker. URI cannot be parsed: ", *url, NULL));
     }
 
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
@@ -3131,7 +3115,7 @@ static void remove_session_route(request_rec *r, const char *name)
                 /* We have it */
                 *start = '\0';
                 r->filename = apr_pstrcat(r->pool, filename, path, NULL);
-                return; 
+                return;
             }
         }
     }
@@ -3139,12 +3123,9 @@ static void remove_session_route(request_rec *r, const char *name)
 
     if ((readcookies = apr_table_get(r->headers_in, "Cookie"))) {
         cookies = apr_pstrdup(r->pool, readcookies);
-        for (start_cookie = ap_strstr(cookies, name); start_cookie;
-             start_cookie = ap_strstr(start_cookie + 1, name)) {
+        for (start_cookie = ap_strstr(cookies, name); start_cookie; start_cookie = ap_strstr(start_cookie + 1, name)) {
             if (start_cookie == cookies ||
-                start_cookie[-1] == ';' ||
-                start_cookie[-1] == ',' ||
-                isspace(start_cookie[-1])) {
+                start_cookie[-1] == ';' || start_cookie[-1] == ',' || isspace(start_cookie[-1])) {
 
                 start = start_cookie;
                 if (start_cookie != cookies &&
@@ -3166,7 +3147,7 @@ static void remove_session_route(request_rec *r, const char *name)
 
                     cookie = cookies;
                     *start = '\0';
-                    cookies = apr_pstrcat(r->pool, cookie , end_cookie, NULL);
+                    cookies = apr_pstrcat(r->pool, cookie, end_cookie, NULL);
                     apr_table_setn(r->headers_in, "Cookie", cookies);
                 }
             }
@@ -3182,7 +3163,7 @@ static void upd_context_count(const char *id, int val, server_rec *s)
 {
     int ident = atoi(id);
     contextinfo_t *context;
-    (void) s;
+    (void)s;
 
     if (context_storage->read_context(ident, &context) == APR_SUCCESS) {
         context->nbrequests = context->nbrequests + val;
@@ -3192,7 +3173,7 @@ static void upd_context_count(const char *id, int val, server_rec *s)
 static apr_status_t decrement_busy_count(void *worker_)
 {
     proxy_worker *worker = worker_;
-    
+
     if (worker->s->busy) {
         worker->s->busy--;
     }
@@ -3204,9 +3185,7 @@ static apr_status_t decrement_busy_count(void *worker_)
  * Find a worker for mod_proxy logic
  */
 static int proxy_cluster_pre_request(proxy_worker **worker,
-                                      proxy_balancer **balancer,
-                                      request_rec *r,
-                                      proxy_server_conf *conf, char **url)
+                                     proxy_balancer **balancer, request_rec *r, proxy_server_conf *conf, char **url)
 {
     int access_status;
     proxy_worker *runtime;
@@ -3220,8 +3199,8 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
 
     /* the node should be filled in trans(). */
     proxy_vhost_table *vhost_table = (proxy_vhost_table *) apr_table_get(r->notes, "vhost-table");
-    proxy_context_table *context_table  = (proxy_context_table *) apr_table_get(r->notes, "context-table");
-    proxy_node_table *node_table  = (proxy_node_table *) apr_table_get(r->notes, "node-table");
+    proxy_context_table *context_table = (proxy_context_table *) apr_table_get(r->notes, "context-table");
+    proxy_node_table *node_table = (proxy_node_table *) apr_table_get(r->notes, "node-table");
 
     if (!vhost_table)
         vhost_table = read_vhost_table(r->pool, host_storage, 0);
@@ -3235,17 +3214,15 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
         ap_assert(rv == APR_SUCCESS);
         node_table = read_node_table(r->pool, node_storage, 0);
         node_storage->unlock_nodes();
-        }
+    }
 
     *worker = NULL;
     if (*balancer) {
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "proxy_cluster_pre_request: url %s balancer %s", *url,
-                     (*balancer)->s->name
-                     );
-    } else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                     "proxy_cluster_pre_request: url %s", *url);
+                     "proxy_cluster_pre_request: url %s balancer %s", *url, (*balancer)->s->name);
+    }
+    else {
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_pre_request: url %s", *url);
     }
     /* Step 1: check if the url is for us
      * The url we can handle starts with 'balancer://'
@@ -3254,21 +3231,20 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
      */
     if (*balancer) {
         /* Adjust the helper->count corresponding to the previous try */
-        const char *worker_name =  apr_table_get(r->subprocess_env, "BALANCER_WORKER_NAME");
+        const char *worker_name = apr_table_get(r->subprocess_env, "BALANCER_WORKER_NAME");
         if (worker_name && *worker_name) {
             int i;
             int sizew = (*balancer)->workers->elt_size;
             char *ptr = (*balancer)->workers->elts;
             unsigned int def = ap_proxy_hashfunc(worker_name, PROXY_HASHFUNC_DEFAULT);
             unsigned int fnv = ap_proxy_hashfunc(worker_name, PROXY_HASHFUNC_FNV);
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy_cluster_pre_request: worker %s", worker_name);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_pre_request: worker %s", worker_name);
             /* Ajust the context counter here */
             context_id = apr_table_get(r->subprocess_env, "BALANCER_CONTEXT_ID");
             rv = node_storage->lock_nodes();
             ap_assert(rv == APR_SUCCESS);
             if (context_id && *context_id) {
-               upd_context_count(context_id, -1, r->server);
+                upd_context_count(context_id, -1, r->server);
             }
             for (i = 0; i < (*balancer)->workers->nelts; i++, ptr = ptr + sizew) {
                 proxy_worker **run = (proxy_worker **) ptr;
@@ -3280,18 +3256,16 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
                 }
             }
             node_storage->unlock_nodes();
-        } else {
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy_cluster_pre_request: NO worker");
+        }
+        else {
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_pre_request: NO worker");
         }
     }
 
     /* TODO if we don't have a balancer but a route we should use it directly */
-    if (!*balancer &&
-        !(*balancer = ap_proxy_get_balancer(r->pool, conf, *url, 0))) {
+    if (!*balancer && !(*balancer = ap_proxy_get_balancer(r->pool, conf, *url, 0))) {
         apr_status_t rv;
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy_cluster_pre_request: NOT CREATED!!!");
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_pre_request: NOT CREATED!!!");
         /* May be the node has not been created yet */
         rv = node_storage->lock_nodes();
         ap_assert(rv == APR_SUCCESS);
@@ -3300,27 +3274,22 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
         node_storage->unlock_nodes();
         if (!(*balancer = ap_proxy_get_balancer(r->pool, conf, *url, 0))) {
             /* node_storage->unlock_nodes(); */
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy: CLUSTER no balancer for %s", *url);
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: CLUSTER no balancer for %s", *url);
             return DECLINED;
         }
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "proxy: CLUSTER balancer CREATED for %s", *url);
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: CLUSTER balancer CREATED for %s", *url);
     }
 
     /* Step 2: find the session route */
 
-    runtime = find_session_route(*balancer, r, &route, &sticky, url, &domain,
-            vhost_table, context_table, node_table);
+    runtime = find_session_route(*balancer, r, &route, &sticky, url, &domain, vhost_table, context_table, node_table);
 
     /* Lock the LoadBalancer
      * XXX: perhaps we need the process lock here
      */
     if ((rv = PROXY_THREAD_LOCK(*balancer)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, r->server,
-                     "proxy: CLUSTER: (%s). Lock failed for pre_request",
-                     (*balancer)->s->name
-                     );
+                     "proxy: CLUSTER: (%s). Lock failed for pre_request", (*balancer)->s->name);
         return DECLINED;
     }
     if (runtime) {
@@ -3336,40 +3305,33 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
              */
             ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
                          "proxy: CLUSTER: (%s). All workers are in error state for route (%s)",
-                         (*balancer)->s->name,
-                         route);
+                         (*balancer)->s->name, route);
             if ((rv = PROXY_THREAD_UNLOCK(*balancer)) != APR_SUCCESS) {
                 ap_log_error(APLOG_MARK, APLOG_ERR, rv, r->server,
-                             "proxy: CLUSTER: (%s). Unlock failed for pre_request",
-                             (*balancer)->s->name
-                             );
+                             "proxy: CLUSTER: (%s). Unlock failed for pre_request", (*balancer)->s->name);
             }
             return HTTP_SERVICE_UNAVAILABLE;
-        } else {
+        }
+        else {
             /* We try to to failover using another node in the domain */
-            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                         "mod_proxy_cluster: failover in domain");
+            ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "mod_proxy_cluster: failover in domain");
             failoverdomain = 1;
         }
     }
 
     if ((rv = PROXY_THREAD_UNLOCK(*balancer)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, r->server,
-                     "proxy: CLUSTER: (%s). Unlock failed for pre_request",
-                     (*balancer)->s->name
-                     );
+                     "proxy: CLUSTER: (%s). Unlock failed for pre_request", (*balancer)->s->name);
     }
     if (!*worker) {
         /* 
          * We have to failover (in domain only may be) or we don't use sticky sessions
          */
         runtime = find_best_worker(*balancer, conf, r, domain, failoverdomain,
-                vhost_table, context_table, node_table, 1);
+                                   vhost_table, context_table, node_table, 1);
         if (!runtime) {
             ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
-                         "proxy: CLUSTER: (%s). All workers are in error state",
-                         (*balancer)->s->name
-                         );
+                         "proxy: CLUSTER: (%s). All workers are in error state", (*balancer)->s->name);
 
             return HTTP_SERVICE_UNAVAILABLE;
         }
@@ -3385,28 +3347,27 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
             apr_table_setn(r->subprocess_env, "BALANCER_ROUTE_CHANGED", "1");
         }
         /* Use MC_R in lbpname to know if we have to remove the session information */
-        if (route && strcmp((*balancer)->s->lbpname, MC_REMOVE_SESSION) == 0 ) {
+        if (route && strcmp((*balancer)->s->lbpname, MC_REMOVE_SESSION) == 0) {
             /*
              * Failover to another domain. Remove sessionid information.
              */
-            const char *domain_ok =  apr_table_get(r->notes, "session-domain-ok");
+            const char *domain_ok = apr_table_get(r->notes, "session-domain-ok");
             if (!domain_ok) {
-                remove_session_route(r, sticky); 
+                remove_session_route(r, sticky);
             }
         }
         *worker = runtime;
     }
 
     (*worker)->s->busy++;
-    apr_pool_cleanup_register(r->pool, *worker, decrement_busy_count,
-                              apr_pool_cleanup_null);
+    apr_pool_cleanup_register(r->pool, *worker, decrement_busy_count, apr_pool_cleanup_null);
 
     /* Also mark the context here note that find_best_worker set BALANCER_CONTEXT_ID */
     context_id = apr_table_get(r->subprocess_env, "BALANCER_CONTEXT_ID");
     rv = node_storage->lock_nodes();
     ap_assert(rv == APR_SUCCESS);
     if (context_id && *context_id) {
-       upd_context_count(context_id, 1, r->server);
+        upd_context_count(context_id, 1, r->server);
     }
 
     /* Mark the worker used for the cleanup logic */
@@ -3448,9 +3409,7 @@ static int proxy_cluster_pre_request(proxy_worker **worker,
 }
 
 static int proxy_cluster_post_request(proxy_worker *worker,
-                                       proxy_balancer *balancer,
-                                       request_rec *r,
-                                       proxy_server_conf *conf)
+                                      proxy_balancer *balancer, request_rec *r, proxy_server_conf *conf)
 {
     proxy_cluster_helper *helper;
     const char *sessionid;
@@ -3460,13 +3419,13 @@ static int proxy_cluster_post_request(proxy_worker *worker,
     char *oroute;
     const char *context_id = apr_table_get(r->subprocess_env, "BALANCER_CONTEXT_ID");
     apr_status_t rv;
-    (void) conf; /* unused argument */
+    (void)conf;                 /* unused argument */
 
     /* Ajust the context counter here too */
     rv = node_storage->lock_nodes();
     ap_assert(rv == APR_SUCCESS);
     if (context_id && *context_id) {
-       upd_context_count(context_id, -1, r->server);
+        upd_context_count(context_id, -1, r->server);
     }
 
     /* mark the worker as not in use */
@@ -3477,9 +3436,7 @@ static int proxy_cluster_post_request(proxy_worker *worker,
 
 #if HAVE_CLUSTER_EX_DEBUG
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "proxy_cluster_post_request for (%s) %s",
-                  balancer->s->name, balancer->s->sticky
-                  );
+                 "proxy_cluster_post_request for (%s) %s", balancer->s->name, balancer->s->sticky);
 #endif
 
     if (sessionid_storage) {
@@ -3491,8 +3448,8 @@ static int proxy_cluster_post_request(proxy_worker *worker,
         }
         if (sticky != NULL) {
             cookie = get_cookie_param(r, sticky, 0);
-            sessionid =  apr_table_get(r->notes, "session-id");
-            route =  apr_table_get(r->notes, "session-route");
+            sessionid = apr_table_get(r->notes, "session-id");
+            route = apr_table_get(r->notes, "session-route");
             if (cookie) {
                 if (sessionid && strcmp(cookie, sessionid)) {
                     /* The cookie has changed, remove the old one and store the next one */
@@ -3505,7 +3462,7 @@ static int proxy_cluster_post_request(proxy_worker *worker,
                     ou.id = 0;
                     sessionid_storage->remove_sessionid(&ou);
                 }
-                if ((oroute = strchr(cookie, '.')) != NULL )
+                if ((oroute = strchr(cookie, '.')) != NULL)
                     oroute++;
                 route = oroute;
                 sessionid = cookie;
@@ -3525,9 +3482,7 @@ static int proxy_cluster_post_request(proxy_worker *worker,
         int i;
         if ((rv = PROXY_THREAD_LOCK(balancer)) != APR_SUCCESS) {
             ap_log_error(APLOG_MARK, APLOG_ERR, rv, r->server,
-                "proxy: BALANCER: (%s). Lock failed for post_request",
-                balancer->s->name
-                );
+                         "proxy: BALANCER: (%s). Lock failed for post_request", balancer->s->name);
             return HTTP_INTERNAL_SERVER_ERROR;
         }
         for (i = 0; i < balancer->errstatuses->nelts; i++) {
@@ -3535,9 +3490,7 @@ static int proxy_cluster_post_request(proxy_worker *worker,
             if (r->status == val) {
                 ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
                               "%s: Forcing worker (%s) into error state "
-                              "due to status code %d matching 'failonstatus' "
-                              "balancer parameter",
-                              balancer->s->name,
+                              "due to status code %d matching 'failonstatus' " "balancer parameter", balancer->s->name,
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                               worker->s->name_ex,
 #else
@@ -3551,16 +3504,12 @@ static int proxy_cluster_post_request(proxy_worker *worker,
         }
         if ((rv = PROXY_THREAD_UNLOCK(balancer)) != APR_SUCCESS) {
             ap_log_error(APLOG_MARK, APLOG_ERR, rv, r->server,
-                "proxy: BALANCER: (%s). Unlock failed for post_request",
-                balancer->s->name
-                );
+                         "proxy: BALANCER: (%s). Unlock failed for post_request", balancer->s->name);
         }
     }
 
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "proxy_cluster_post_request %d for (%s)", r->status,
-                 balancer->s->name
-                 );
+                 "proxy_cluster_post_request %d for (%s)", r->status, balancer->s->name);
 
     return OK;
 }
@@ -3570,8 +3519,8 @@ static int proxy_cluster_post_request(proxy_worker *worker,
  */
 static void proxy_cluster_hooks(apr_pool_t *p)
 {
-    static const char * const aszPre[]  = { "mod_manager.c", "mod_rewrite.c", NULL };
-    static const char * const aszSucc[] = { "mod_proxy.c", NULL };
+    static const char *const aszPre[] = { "mod_manager.c", "mod_rewrite.c", NULL };
+    static const char *const aszSucc[] = { "mod_proxy.c", NULL };
 
     ap_hook_post_config(proxy_cluster_post_config, NULL, NULL, APR_HOOK_MIDDLE);
     ap_hook_pre_config(proxy_cluster_pre_config, NULL, NULL, APR_HOOK_MIDDLE);
@@ -3586,7 +3535,7 @@ static void proxy_cluster_hooks(apr_pool_t *p)
     ap_hook_translate_name(proxy_cluster_trans, aszPre, aszSucc, APR_HOOK_FIRST);
 
     proxy_hook_canon_handler(proxy_cluster_canon, NULL, NULL, APR_HOOK_FIRST);
- 
+
     proxy_hook_pre_request(proxy_cluster_pre_request, NULL, NULL, APR_HOOK_FIRST);
     proxy_hook_post_request(proxy_cluster_post_request, NULL, NULL, APR_HOOK_FIRST);
 
@@ -3598,78 +3547,90 @@ static void proxy_cluster_hooks(apr_pool_t *p)
 
 static void *create_proxy_cluster_server_config(apr_pool_t *p, server_rec *s)
 {
-    (void) p; (void) s;
+    (void)p;
+    (void)s;
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_creatbal(cmd_parms *cmd, void *dummy, const char *arg)
+static const char *cmd_proxy_cluster_creatbal(cmd_parms *cmd, void *dummy, const char *arg)
 {
     int val = atoi(arg);
-    (void) cmd; (void) dummy;
+    (void)cmd;
+    (void)dummy;
 
     if (val < 0 || val > 2) {
         return "CreateBalancers must be one of: 0, 1 or 2";
-    } else {
+    }
+    else {
         creat_bal = val;
     }
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_use_alias(cmd_parms *cmd, void *dummy, const char *arg)
+static const char *cmd_proxy_cluster_use_alias(cmd_parms *cmd, void *dummy, const char *arg)
 {
-    (void) cmd; (void) dummy;
+    (void)cmd;
+    (void)dummy;
 
-   /* Cannot use AP_INIT_FLAG, to keep compatibility with versions <= 1.3.0. Final which accepted
-      only values 1 and 0. (see MODCLUSTER-403) */
-   if (strcasecmp(arg, "Off") == 0 || strcasecmp(arg, "0") == 0) {
-       use_alias = 0;
-   } else if (strcasecmp(arg, "On") == 0 || strcasecmp(arg, "1") == 0) {
-       use_alias = 1;
-   } else {
-       return "UseAlias must be either On or Off";
-   }
+    /* Cannot use AP_INIT_FLAG, to keep compatibility with versions <= 1.3.0. Final which accepted
+       only values 1 and 0. (see MODCLUSTER-403) */
+    if (strcasecmp(arg, "Off") == 0 || strcasecmp(arg, "0") == 0) {
+        use_alias = 0;
+    }
+    else if (strcasecmp(arg, "On") == 0 || strcasecmp(arg, "1") == 0) {
+        use_alias = 1;
+    }
+    else {
+        return "UseAlias must be either On or Off";
+    }
 
-   return NULL;
+    return NULL;
 }
 
-static const char*cmd_proxy_cluster_lbstatus_recalc_time(cmd_parms *cmd, void *dummy, const char *arg)
+static const char *cmd_proxy_cluster_lbstatus_recalc_time(cmd_parms *cmd, void *dummy, const char *arg)
 {
     int val = atoi(arg);
-    (void) cmd; (void) dummy;
+    (void)cmd;
+    (void)dummy;
 
     if (val < 0) {
         return "LBstatusRecalTime must be greater than 0";
-    } else {
+    }
+    else {
         lbstatus_recalc_time = apr_time_from_sec(val);
     }
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_wait_for_remove(cmd_parms *cmd, void *dummy, const char *arg)
+static const char *cmd_proxy_cluster_wait_for_remove(cmd_parms *cmd, void *dummy, const char *arg)
 {
     int val = atoi(arg);
-    (void) cmd; (void) dummy;
+    (void)cmd;
+    (void)dummy;
 
     if (val < 10) {
         return "WaitForRemove must be greater than 10";
-    } else {
+    }
+    else {
         wait_for_remove = apr_time_from_sec(val);
     }
     return NULL;
 }
 
-static const char*cmd_proxy_cluster_enable_options(cmd_parms *cmd, void *dummy, const char *args)
+static const char *cmd_proxy_cluster_enable_options(cmd_parms *cmd, void *dummy, const char *args)
 {
     char *val = ap_getword_conf(cmd->pool, &args);
-    (void) dummy;
+    (void)dummy;
 
     if (strcasecmp(val, "Off") == 0 || strcasecmp(val, "0") == 0) {
         /* Disables OPTIONS, overrides the default */
         enable_options = 0;
-    } else if (strcmp(val, "") == 0 || strcasecmp(val, "On") == 0 || strcasecmp(val, "1") == 0) {
+    }
+    else if (strcmp(val, "") == 0 || strcasecmp(val, "On") == 0 || strcasecmp(val, "1") == 0) {
         /* No param or explicitly set default */
         enable_options = -1;
-    } else {
+    }
+    else {
         return "EnableOptions must be either without value or On or Off";
     }
 
@@ -3679,54 +3640,58 @@ static const char*cmd_proxy_cluster_enable_options(cmd_parms *cmd, void *dummy, 
 static const char *cmd_proxy_cluster_deterministic_failover(cmd_parms *parms, void *mconfig, int on)
 {
     deterministic_failover = on;
-    (void) parms; (void) mconfig;
- 
+    (void)parms;
+    (void)mconfig;
+
     return NULL;
 }
 
 static const char *cmd_proxy_cluster_cache_shared_for(cmd_parms *cmd, void *dummy, const char *arg)
 {
     int val = atoi(arg);
-    (void) cmd; (void) dummy;
+    (void)cmd;
+    (void)dummy;
 
     if (val < 0) {
         return "CacheShareFor must be greater than 0";
-    } else {
+    }
+    else {
         cache_share_for = apr_time_from_sec(val);
     }
     return NULL;
 }
+
 static const char *cmd_proxy_cluster_proxyhctemplate(cmd_parms *cmd, void *dummy, const char *arg)
 {
-    (void) dummy;
+    (void)dummy;
 
     proxyhctemplate = apr_pstrdup(cmd->pool, arg);
     while (*arg) {
-       char *key, *val;
-       key = ap_getword_conf(cmd->pool, &arg);
-       val = strchr(key, '=');
-       if (!val) {
-            return "Invalid ProxyHCTemplate parameter. Parameter must be "
-                   "in the form 'key=value'";
+        char *key, *val;
+        key = ap_getword_conf(cmd->pool, &arg);
+        val = strchr(key, '=');
+        if (!val) {
+            return "Invalid ProxyHCTemplate parameter. Parameter must be " "in the form 'key=value'";
         }
         else
             *val++ = '\0';
         /* are we able to check more stuff? err= test() */
         if (set_worker_hc_param_f == NULL) {
             return "Can't check ProxyHCTemplate parameter, is proxy_hcheck_module loaded?";
-        } else {
-           proxy_worker worker;
-           proxy_worker_shared shared;
-           const char *err;
-           apr_pool_t *pool;
-           server_rec *s = cmd->server;
-           worker.s = &shared;
-           apr_pool_create(&pool, cmd->pool);
-           err =  set_worker_hc_param_f(pool, s, &worker, key, val, NULL);
-           apr_pool_destroy(pool);
-           if (err != NULL) {
-              return apr_psprintf(cmd->pool, "%s key: %s=%s", err, key, val);
-           }
+        }
+        else {
+            proxy_worker worker;
+            proxy_worker_shared shared;
+            const char *err;
+            apr_pool_t *pool;
+            server_rec *s = cmd->server;
+            worker.s = &shared;
+            apr_pool_create(&pool, cmd->pool);
+            err = set_worker_hc_param_f(pool, s, &worker, key, val, NULL);
+            apr_pool_destroy(pool);
+            if (err != NULL) {
+                return apr_psprintf(cmd->pool, "%s key: %s=%s", err, key, val);
+            }
         }
     }
     return NULL;
@@ -3734,7 +3699,8 @@ static const char *cmd_proxy_cluster_proxyhctemplate(cmd_parms *cmd, void *dummy
 
 static const char *cmd_proxy_cluster_use_nocanon(cmd_parms *parms, void *mconfig, int on)
 {
-    (void) parms; (void) mconfig;
+    (void)parms;
+    (void)mconfig;
     use_nocanon = on;
 
     return NULL;
@@ -3742,9 +3708,11 @@ static const char *cmd_proxy_cluster_use_nocanon(cmd_parms *parms, void *mconfig
 
 
 #if MC_USE_THREADS
-static const char *cmd_mc_thread_count(cmd_parms *cmd, void *dummy, const char *arg) {
+static const char *cmd_mc_thread_count(cmd_parms *cmd, void *dummy, const char *arg)
+{
     int size;
-    (void) cmd; (void) dummy;
+    (void)cmd;
+    (void)dummy;
     size = atoi(arg);
     if (size < 0) {
         return "Invalid value for ModProxyClusterThreadCount. Parameter has to be >= 0";
@@ -3755,87 +3723,66 @@ static const char *cmd_mc_thread_count(cmd_parms *cmd, void *dummy, const char *
 }
 #endif
 
-static const command_rec  proxy_cluster_cmds[] =
-{
-    AP_INIT_TAKE1(
-        "CreateBalancers",
-        cmd_proxy_cluster_creatbal,
-        NULL,
-        OR_ALL,
-        "CreateBalancers - Defined VirtualHosts where the balancers are created 0: All, 1: None, 2: Main (Default: 2 Main)"
-    ),
-    AP_INIT_TAKE1(
-        "UseAlias",
-        cmd_proxy_cluster_use_alias,
-        NULL,
-        OR_ALL,
-        "UseAlias - Check that the Alias corresponds to the ServerName Off: Don't check (ignore Aliases), On: Check aliases (Default: Off)"
-    ),
-    AP_INIT_TAKE1(
-        "LBstatusRecalTime",
-        cmd_proxy_cluster_lbstatus_recalc_time,
-        NULL,
-        OR_ALL,
-        "LBstatusRecalTime - Time interval in seconds for loadbalancing logic to recalculate the status of a node: (Default: 5 seconds)"
-    ),
-    AP_INIT_TAKE1(
-        "WaitBeforeRemove",
-        cmd_proxy_cluster_wait_for_remove,
-        NULL,
-        OR_ALL,
-        "WaitBeforeRemove - Time in seconds before a node removed is forgotten by httpd: (Default: 10 seconds)"
-    ),
+static const command_rec proxy_cluster_cmds[] = {
+    AP_INIT_TAKE1("CreateBalancers",
+                  cmd_proxy_cluster_creatbal,
+                  NULL,
+                  OR_ALL,
+                  "CreateBalancers - Defined VirtualHosts where the balancers are created 0: All, 1: None, 2: Main (Default: 2 Main)"),
+    AP_INIT_TAKE1("UseAlias",
+                  cmd_proxy_cluster_use_alias,
+                  NULL,
+                  OR_ALL,
+                  "UseAlias - Check that the Alias corresponds to the ServerName Off: Don't check (ignore Aliases), On: Check aliases (Default: Off)"),
+    AP_INIT_TAKE1("LBstatusRecalTime",
+                  cmd_proxy_cluster_lbstatus_recalc_time,
+                  NULL,
+                  OR_ALL,
+                  "LBstatusRecalTime - Time interval in seconds for loadbalancing logic to recalculate the status of a node: (Default: 5 seconds)"),
+    AP_INIT_TAKE1("WaitBeforeRemove",
+                  cmd_proxy_cluster_wait_for_remove,
+                  NULL,
+                  OR_ALL,
+                  "WaitBeforeRemove - Time in seconds before a node removed is forgotten by httpd: (Default: 10 seconds)"),
     /* This is not the ideal type, but it either takes no parameters (for backwards compatibility) or 1 flag argument. */
-    AP_INIT_RAW_ARGS(
-        "EnableOptions",
-         cmd_proxy_cluster_enable_options,
-         NULL,
-         OR_ALL,
-         "EnableOptions - Use OPTIONS with HTTP/HTTPS for CPING/CPONG. On: Use OPTIONS, Off: Do not use OPTIONS (Default: On)"
-    ),
-    AP_INIT_FLAG(
-        "DeterministicFailover",
-        cmd_proxy_cluster_deterministic_failover,
-        NULL,
-        OR_ALL,
-        "DeterministicFailover - controls whether a node upon failover is chosen deterministically (Default: Off)"
-    ),
-    AP_INIT_TAKE1(
-        "CacheShareFor",
-        cmd_proxy_cluster_cache_shared_for,
-        NULL,
-        OR_ALL,
-        "CacheShareFor - Time in seconds for how long the shared information is cached by httpd: (Default: 0 seconds, no-caching)"
-    ),
-    AP_INIT_RAW_ARGS(
-        "ModProxyClusterHCTemplate",
-        cmd_proxy_cluster_proxyhctemplate,
-        NULL,
-        OR_ALL,
-        "ModProxyClusterHCTemplate - Set of health check parameters to use with mod_proxy_cluster workers."
-    ),
-    AP_INIT_FLAG(
-        "UseNocanon",
-        cmd_proxy_cluster_use_nocanon,
-        NULL,
-        OR_ALL,
-        "UseNocanon - When no ProxyPass or ProxyMatch for the URL, passes the URL path \"raw\" to the backend (Default: Off)"
-    ),
+    AP_INIT_RAW_ARGS("EnableOptions",
+                     cmd_proxy_cluster_enable_options,
+                     NULL,
+                     OR_ALL,
+                     "EnableOptions - Use OPTIONS with HTTP/HTTPS for CPING/CPONG. On: Use OPTIONS, Off: Do not use OPTIONS (Default: On)"),
+    AP_INIT_FLAG("DeterministicFailover",
+                 cmd_proxy_cluster_deterministic_failover,
+                 NULL,
+                 OR_ALL,
+                 "DeterministicFailover - controls whether a node upon failover is chosen deterministically (Default: Off)"),
+    AP_INIT_TAKE1("CacheShareFor",
+                  cmd_proxy_cluster_cache_shared_for,
+                  NULL,
+                  OR_ALL,
+                  "CacheShareFor - Time in seconds for how long the shared information is cached by httpd: (Default: 0 seconds, no-caching)"),
+    AP_INIT_RAW_ARGS("ModProxyClusterHCTemplate",
+                     cmd_proxy_cluster_proxyhctemplate,
+                     NULL,
+                     OR_ALL,
+                     "ModProxyClusterHCTemplate - Set of health check parameters to use with mod_proxy_cluster workers."),
+    AP_INIT_FLAG("UseNocanon",
+                 cmd_proxy_cluster_use_nocanon,
+                 NULL,
+                 OR_ALL,
+                 "UseNocanon - When no ProxyPass or ProxyMatch for the URL, passes the URL path \"raw\" to the backend (Default: Off)"),
 #if MC_USE_THREADS
-    AP_INIT_TAKE1(
-        "ModProxyClusterThreadCount",
-        cmd_mc_thread_count,
-        NULL,
-        OR_ALL,
-        "ModProxyClusterThreadCount - Set custom size for the watchdog thread pool (Default: 16)"
-    ),
+    AP_INIT_TAKE1("ModProxyClusterThreadCount",
+                  cmd_mc_thread_count,
+                  NULL,
+                  OR_ALL,
+                  "ModProxyClusterThreadCount - Set custom size for the watchdog thread pool (Default: 16)"),
 #endif
     {NULL}
 };
 
 module AP_MODULE_DECLARE_DATA proxy_cluster_module = {
     STANDARD20_MODULE_STUFF,
-    NULL,    /* per-directory config creator */
+    NULL,                               /* per-directory config creator */
     NULL,                               /* dir config merger */
     create_proxy_cluster_server_config, /* server config creator */
     NULL,                               /* server config merger */


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/MODCLUSTER-783

I used `indent` with following options: `-i4 -npsl -di0 -br -nce -d0 -cli0 -npcs -nfc1 -nut -ncs -l120`.

The most of the changes are by `indent` itself, however, I removed some unnecessary parenthesis, inconsistent brackets, and made minor tweaks.

Please, I welcome any feedback.