### PR TITLE
Set MaxConnectionsPerChild to 16 for tests

### DIFF
--- a/test/native/httpd/install.sh
+++ b/test/native/httpd/install.sh
@@ -49,6 +49,12 @@ if [ -f /tmp/$FILECONF ]; then
   echo "Include conf/$FILECONF" >> /usr/local/apache2/conf/httpd.conf
 fi
 
+# With the default settings and recent changes c83aff820705cdf4a399c1d748d9cedb66593b9f,
+# removed nodes are hanging indefinitely in mod_cluster_manager whose outputs are parsed
+# by tests. Setting MaxConnectionPerChild will cause they get removed eventually without
+# a need to change tests.
+echo -e "\nMaxConnectionsPerChild    16"  >> /usr/local/apache2/conf/httpd.conf
+
 # start apache httpd server in foreground
 
 /usr/local/apache2/bin/apachectl start


### PR DESCRIPTION
With recent changes, for tests it is necessary to set MaxConnectionsPerChild so that nodes get removed.