### PR TITLE
Fix C++ style comments error with C89/C90

### DIFF
--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -272,14 +272,14 @@ static const char *cmd_advertise_h(cmd_parms *cmd, void *dummy, const char *arg)
     return NULL;
 }
 
-// clang-format off
+/* clang-format off */
 #define MA_ADVERTISE_SERVER_FMT \
         "HTTP/1.0 %s" CRLF \
         "Date: %s" CRLF \
         "Sequence: %" APR_INT64_T_FMT CRLF \
         "Digest: %s" CRLF \
         "Server: %s" CRLF
-// clang-format on
+/* clang-format on */
 
 static const char *hex = "0123456789abcdef";
 

--- a/native/mod_cluster_slotmem/sharedmem_util.c
+++ b/native/mod_cluster_slotmem/sharedmem_util.c
@@ -595,7 +595,7 @@ static int ap_slotmem_get_max_size(ap_slotmem_t *score)
     return score->num;
 }
 
-// clang-format off
+/* clang-format off */
 static const slotmem_storage_method storage = {
     &ap_slotmem_do,
     &ap_slotmem_create,
@@ -608,7 +608,7 @@ static const slotmem_storage_method storage = {
     &ap_slotmem_lock,
     &ap_slotmem_unlock,
 };
-// clang-format on
+/* clang-format on */
 
 /* make the storage usuable from outside
  * and initialise the global pool */

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -356,7 +356,7 @@ static apr_status_t loc_unlock_contexts(void)
     return apr_global_mutex_unlock(context_mutex);
 }
 
-// clang-format off
+/* clang-format off */
 static const struct context_storage_method context_storage = {
     loc_read_context,
     loc_get_ids_used_context,
@@ -364,7 +364,7 @@ static const struct context_storage_method context_storage = {
     loc_lock_contexts,
     loc_unlock_contexts
 };
-// clang-format on
+/* clang-format on */
 
 /*
  * routines for the host_storage_method
@@ -475,7 +475,7 @@ static apr_status_t loc_find_domain(domaininfo_t **domain, const char *route, co
     return find_domain(domainstatsmem, domain, route, balancer);
 }
 
-// clang-format off
+/* clang-format off */
 static const struct domain_storage_method domain_storage = {
     loc_read_domain,
     loc_get_ids_used_domain,
@@ -484,7 +484,7 @@ static const struct domain_storage_method domain_storage = {
     loc_insert_update_domain,
     loc_find_domain,
 };
-// clang-format on
+/* clang-format on */
 
 /* helper for the handling of the Alias: host1,... Context: context1,... */
 struct cluster_host

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2115,7 +2115,7 @@ static void reenable_proxy_worker(server_rec *server, nodeinfo_t *node, proxy_wo
 /*
  * For the provider
  */
-// clang-format off
+/* clang-format off */
 static const struct balancer_method balancerhandler = {
     proxy_node_isup,
     proxy_host_isup,
@@ -2123,7 +2123,7 @@ static const struct balancer_method balancerhandler = {
     reenable_proxy_worker,
     proxy_node_get_free_id
 };
-// clang-format on
+/* clang-format on */
 
 static int node_has_workers(server_rec *server, proxy_server_conf *conf, int id)
 {
@@ -3709,7 +3709,7 @@ static const char *cmd_mc_thread_count(cmd_parms *cmd, void *dummy, const char *
 }
 #endif
 
-// clang-format off
+/* clang-format off */
 static const command_rec proxy_cluster_cmds[] = {
     AP_INIT_TAKE1("CreateBalancers", cmd_proxy_cluster_creatbal, NULL, OR_ALL,
                   "CreateBalancers - Defined VirtualHosts where the balancers are created 0: All, 1: None, 2: Main "
@@ -3742,7 +3742,7 @@ static const command_rec proxy_cluster_cmds[] = {
 #endif
     {NULL}
 };
-// clang-format on
+/* clang-format on */
 
 module AP_MODULE_DECLARE_DATA proxy_cluster_module = {
     STANDARD20_MODULE_STUFF,


### PR DESCRIPTION
Fix an error with older C standard introduced with style guide.