### PR TITLE
Add build with httpd in dev mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,24 @@ jobs:
             rm diff.txt || true # we don't fail if the file does not exist
           done;
           exit $code
+  make-httpd-maintainer-mode:
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/mod_cluster/ci-httpd-dev
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          cd native
+          for module in advertise/ mod_*; do \
+            cd $module; \
+            sh buildconf; \
+            ./configure  --with-apxs=/usr/local/apache2/bin/apxs; \
+            make || exit 1; \
+            cd ..; \
+          done;
 

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1261,8 +1261,6 @@ static void *APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data
     apr_pool_t *rrp;
     request_rec *rnew;
 
-    (void)thread;
-
     watchdog_thread_args_t *targs = (watchdog_thread_args_t *)data;
     proxy_worker *worker = targs->worker;
     apr_pool_t *pool = targs->pool;
@@ -1272,6 +1270,7 @@ static void *APR_THREAD_FUNC check_proxy_worker(apr_thread_t *thread, void *data
     apr_time_t now = targs->now;
     int id = targs->id;
 
+    (void)thread;
     apr_snprintf(sport, sizeof(sport), "%d", worker->s->port);
 
     if (strchr(worker->s->hostname, ':') != NULL)
@@ -2410,7 +2409,6 @@ static void proxy_cluster_child_stopping(apr_pool_t *pool, int graceful)
 static void proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
 {
     apr_status_t rv;
-    (void)p;
     void *sconf = s->module_config;
     proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
 
@@ -2425,6 +2423,8 @@ static void proxy_cluster_child_init(apr_pool_t *p, server_rec *s)
      */
 
     rv = node_storage->lock_nodes();
+
+    (void)p; /* unused argument */
     ap_assert(rv == APR_SUCCESS);
     if (conf && node_storage && node_storage->get_max_size_node()) {
         /* fill the cache and create pool */


### PR DESCRIPTION
There is difference in compilation between regular `make`/`cmake` and the same with `httpd` configured with `--enable-maintainer-mode` and some additional flags. For example, using C++ style comments is ok unless `httpd` is configured as stated above.

Therefore, I think it would be worth creating an image with httpd configured and compiled.

This Draft PR contains a possible solution (using `quay.io/vchlup/httpd-dev`); it is a draft because I think the image should be within the modcluster namespace/organization, not in mine.

The `Containerfile` I used for the image:

```Containerfile
FROM ubi9/ubi:latest
# install necessary tools (+ some useful ones too)
# RUN yum module enable subversion
RUN dnf update -y && dnf install -y git gcc make libtool python3 autoconf libxml2-devel pcre2-devel
# libxml workaround
RUN cd /usr/include/ && ln -s libxml2/libxml .
# get httpd and checkout the appropriate version
RUN git clone https://github.com/apache/httpd
WORKDIR /httpd/
RUN git checkout 2.4.57
# get apr library
RUN git clone https://github.com/apache/apr srclib/apr
# configure httpd
RUN export CFLAGS="-g"
# define APACHE_DIR variable
RUN echo "APACHE_DIR=/usr/local/apache2/" >> /root/.bashrc
RUN ./buildconf
RUN ./configure --prefix=/usr/local/apache2 --with-included-apr --enable-proxy-ajp --enable-maintainer-mode \
                --enable-so --enable-proxy --enable-proxy-http --enable-proxy-wstunned --enable-proxy-hcheck \
                --with-port=8000 --with-libxml2
# build httpd
RUN make
RUN make install
# start bash
CMD ["/bin/bash", "-c", "bash"]
```

The image is then created as usual with `podman build -t quay.io/namespace/image:tag`. After pushing, you have to allow reading (simply making it public seems the best option).

In my forked repository you can see the proposed job in action: [passed](https://github.com/jajik/mod_proxy_cluster/actions/runs/4945494403/jobs/8842400460), [failed](https://github.com/jajik/mod_proxy_cluster/actions/runs/4945560068/jobs/8842449631).

**Updated**: Now we're using ubi9 and `quay.io`.