### PR TITLE
Remove a dead code from mod_proxy_cluster

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1513,8 +1513,7 @@ static void remove_timeout_sessionid(proxy_server_conf *conf, apr_pool_t *pool, 
     size = sessionid_storage->get_max_size_sessionid();
     if (size == 0)
         return;
-    else
-        return;
+
     id = apr_pcalloc(pool, sizeof(int) * size);
     size = sessionid_storage->get_ids_used_sessionid(id);
 


### PR DESCRIPTION
I looked into #63, trying to remove the dead code. It seems that the whole function can be removed without affecting the functionality. Tests in the repository are passing. Also, the described behaviour in JIRA related to the fix that introduced the bug is still not reproducible with this change – the node gets flagged REMOVED with hung JVM (the actual removal then depends on `MaxConnectionsPerChild`).

Please, check that I am not missing something.