### PR TITLE
Make httpd's install script fail if branch does not exist

### DIFF
--- a/test/native/httpd/install.sh
+++ b/test/native/httpd/install.sh
@@ -29,7 +29,8 @@ git clone $SOURCES
 DIRSOURCES=`filename $SOURCES`
 echo "DIRSOURCES: $DIRSOURCES"
 cd $DIRSOURCES
-git checkout $BRANCH
+# exit if branch does not exist, because main would be used otherwise
+git checkout $BRANCH || exit 1
 cd ..
 for dir in `echo $DIRSOURCES/native/mod_cluster_slotmem $DIRSOURCES/native/mod_manager $DIRSOURCES/native/mod_proxy_cluster`
 do


### PR DESCRIPTION
Our testing httpd image has  a variable `BRANCH` by which one can specify a source branch for mod_proxy_cluster. However, if a branch of the given name does not exist, `git checkout` command fails and tests continue on the default main branch. This can lead to false positive/negative tests results.

This PR changes the behaviour – the script now fails in case the checkout is not successful making the image stop.