### PR TITLE
Add Windows runner into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,4 +120,20 @@ jobs:
             make || exit 1; \
             cd ..; \
           done;
-
+  cmake-windows-latest:
+    runs-on: windows-latest
+    env:
+      APACHE_LOUNGE_DISTRO_VERSION: 2.4.57
+      HTTPD_DEV_HOME: '${{ github.workspace }}\httpd-apache-lounge\Apache24'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Developer Command Prompt for Microsoft Visual C++
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Get httpd
+        run: |
+          curl.exe --output "httpd-apache-lounge.zip" --url "https://www.apachelounge.com/download/VS16/binaries/httpd-${{ env.APACHE_LOUNGE_DISTRO_VERSION }}-win64-VS16.zip"
+          Expand-Archive -Path "httpd-apache-lounge.zip" -DestinationPath "httpd-apache-lounge"
+      - name: Build
+        run: |
+          ./native/scripts/windows-build.bat

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ native/*/configure
 test/java/node*/
 bin/
 target/
+
+# Folder usually used for CMake
+**/build

--- a/native/include/mod_proxy_cluster.h
+++ b/native/include/mod_proxy_cluster.h
@@ -30,8 +30,6 @@
 
 #define MOD_CLUSTER_EXPOSED_VERSION "mod_cluster/2.0.0.Alpha1-SNAPSHOT"
 
-APR_DECLARE_OPTIONAL_FN(apr_status_t, balancer_manage, (request_rec * r, apr_table_t *params));
-
 struct balancer_method
 {
     /**

--- a/native/mod_manager/mod_manager.h
+++ b/native/mod_manager/mod_manager.h
@@ -25,6 +25,10 @@
  * @version $Revision$
  */
 
+#include "apr_optional.h"
+
+APR_DECLARE_OPTIONAL_FN(apr_status_t, balancer_manage, (request_rec *, apr_table_t *));
+
 struct mem
 {
     ap_slotmem_instance_t *slotmem;

--- a/native/scripts/windows-build.bat
+++ b/native/scripts/windows-build.bat
@@ -1,0 +1,45 @@
+REM kudos to Michal Karm Babacek <karm@fedoraproject.org>
+REM this script is from (https://github.com/modcluster/ci.modcluster.io)
+
+REM You need to define HTTPD_DEV_HOME environment variable to point to
+REM your httpd's folder if you run this scirpt on you own.
+REM Also, don't forget to call vcvars64.bat if you run it locally.
+REM Otherwise you may not have your tools/environment set up properly.
+
+SetLocal EnableDelayedExpansion
+
+REM Note that some attributes cannot handle backslashes...
+SET WORKSPACE_POSSIX=%CD:\=/%
+
+REM CMake workspace
+mkdir %CD%\cmakebuild
+pushd %CD%\cmakebuild
+
+REM It is not a good idea to try to generate the mod_proxy.lib file, so:
+REM dumpbin /exports /nologo /out:!HTTPD_DEV_HOME!\lib\mod_proxy.def.tmp !HTTPD_DEV_HOME!\modules\mod_proxy.so
+REM IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+REM echo EXPORTS> !HTTPD_DEV_HOME!\lib\mod_proxy.def
+REM powershell -Command "(Get-Content !HTTPD_DEV_HOME!\lib\mod_proxy.def.tmp) ^| Foreach-Object {$_ -replace '.*\s(_?ap_proxy.*^|_?proxy_.*)$','$1'} ^| select-string -pattern '^^_?ap_proxy^|^^_?proxy_' ^| Add-    Content !HTTPD_DEV_HOME!\lib\mod_proxy.def"
+REM IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+REM lib /def:!HTTPD_DEV_HOME!\lib\mod_proxy.def /OUT:!HTTPD_DEV_HOME!\lib\mod_proxy.lib /MACHINE:X64 /NAME:mod_proxy.so
+REM IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+
+SET HTTPD_DEV_HOME_POSSIX=%HTTPD_DEV_HOME:\=/%
+
+cmake -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO ^
+-DCMAKE_C_FLAGS_RELWITHDEBINFO="/DWIN32 /D_WINDOWS /W3 /MD /Zi /O2 /Ob1 /DNDEBUG" ^
+-DCMAKE_C_FLAGS="/DWIN32 /D_WINDOWS /W3 /MD /Zi /O2 /Ob1 /DNDEBUG" ^
+-DAPR_LIBRARY=%HTTPD_DEV_HOME_POSSIX%/lib/libapr-1.lib ^
+-DAPR_INCLUDE_DIR=%HTTPD_DEV_HOME_POSSIX%/include/ ^
+-DAPACHE_INCLUDE_DIR=%HTTPD_DEV_HOME_POSSIX%/include/ ^
+-DAPRUTIL_LIBRARY=%HTTPD_DEV_HOME_POSSIX%/lib/libaprutil-1.lib ^
+-DAPRUTIL_INCLUDE_DIR=%HTTPD_DEV_HOME_POSSIX%/include/ ^
+-DAPACHE_LIBRARY=%HTTPD_DEV_HOME_POSSIX%/lib/libhttpd.lib ^
+-DPROXY_LIBRARY=%HTTPD_DEV_HOME_POSSIX%/lib/mod_proxy.lib ^
+%WORKSPACE_POSSIX%/native/
+
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+REM Compile
+nmake
+IF NOT %ERRORLEVEL% == 0 ( exit 1 )
+


### PR DESCRIPTION
In the past it occurred multiple times that a change was introduced that worked on Linux, but broke build on Windows. Now when we no longer use CI via Jenkins, we have limited ability to catch those changes. This PR adds windows runner (`cmake` using) into the CI.

Also, there is a fix that moves an optional function declaration into the correct file (it caused compilation on windows to fail).