### PR TITLE
Add checks for supported HTTPD version

### DIFF
--- a/native/include/mod_proxy_cluster.h
+++ b/native/include/mod_proxy_cluster.h
@@ -30,6 +30,11 @@
 
 #define MOD_CLUSTER_EXPOSED_VERSION "mod_cluster/2.0.0.Alpha1-SNAPSHOT"
 
+/* We don't care about versions older then 2.4.x, i.e., MODULE_MAGIC_NUMBER_MAJOR < 20120211 */
+#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR <= 124
+#error Please update your HTTPD, mod_proxy_cluster requires version 2.4.53 or newer.
+#endif
+
 struct balancer_method
 {
     /**

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2478,6 +2478,14 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t
                      "httpd version %d.%d.%d doesn't match version %d.%d.%d used by mod_proxy_cluster.c", version.major,
                      version.minor, version.patch, AP_SERVER_MAJORVERSION_NUMBER, AP_SERVER_MINORVERSION_NUMBER,
                      AP_SERVER_PATCHLEVEL_NUMBER);
+
+        if (version.major < 2 || (version.major == 2 && version.minor < 4) ||
+            (version.major == 2 && version.minor == 4 && version.patch < 53)) {
+            ap_log_error(APLOG_MARK, APLOG_ERR, 0, s,
+                         "Unsupported version (%d.%d.%d) of httpd detected, 2.4.53 or newer is required", version.major,
+                         version.minor, version.patch);
+            return !OK;
+        }
     }
     if (SIZEOFSCORE <= sizeof(proxy_worker_shared)) {
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, s, "SIZEOFSCORE too small for mod_proxy shared stat structure %d <= %ld",


### PR DESCRIPTION
Now, compilation is going to fail in case the version is not supported. In case someone tries to load the module with unsupported version, it won't succeed either.