### PR TITLE
Remove unreachable code, fix version check

### DIFF
--- a/native/include/mod_proxy_cluster.h
+++ b/native/include/mod_proxy_cluster.h
@@ -31,7 +31,7 @@
 #define MOD_CLUSTER_EXPOSED_VERSION "mod_cluster/2.0.0.Alpha1-SNAPSHOT"
 
 /* We don't care about versions older then 2.4.x, i.e., MODULE_MAGIC_NUMBER_MAJOR < 20120211 */
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR <= 124
+#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR < 124
 #error Please update your HTTPD, mod_proxy_cluster requires version 2.4.53 or newer.
 #endif
 

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -226,12 +226,7 @@ static void add_hcheck(server_rec *s, proxy_server_conf *conf, proxy_worker *wor
                 ap_log_error(APLOG_MARK, APLOG_ERR | APLOG_NOERRNO, 0, s, "%s key: %s=%s", err, key, val);
             }
             ap_log_error(APLOG_MARK, APLOG_NOERRNO | APLOG_DEBUG, 0, s, "hcheck %s=%s add to worker %s", key, val,
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                         worker->s->name_ex
-#else
-                         worker->s->name
-#endif
-            );
+                         worker->s->name_ex);
         }
     }
 }
@@ -399,26 +394,16 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
                     }
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                                  "Created: REUSING %s (scheme: %s hostname %s port %d route %s name %s) cleaning...",
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                                  url, worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route,
                                  worker->s->name_ex);
-#else
-                                 url, worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route,
-                                 worker->s->name);
-#endif
                 }
                 return APR_SUCCESS; /* Done Already existing */
             } else {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                              "Created: can't reuse worker as it is for %s (scheme: %s hostname %s port %d route %s "
                              "name %s) cleaning...",
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                              url, worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route,
                              worker->s->name_ex);
-#else
-                             url, worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route,
-                             worker->s->name);
-#endif
                 ptr = ptr_node;
                 ptr = ptr + node->offset;
                 shared = worker->s;
@@ -457,35 +442,21 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
     helper->isinnodes = 1;
 
     /* Changing the shared memory requires locking it... */
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
     if (strncmp(worker->s->name_ex, shared->name_ex, sizeof(worker->s->name_ex))) {
-#else
-    if (strncmp(worker->s->name, shared->name, sizeof(worker->s->name))) {
-#endif
         /* We will modify it only is the name has changed to minimize access */
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                     "Created: worker for %s arranging shared memory %s:%s", url, worker->s->name_ex, shared->name_ex);
-#else
-                     "Created: worker for %s arranging shared memory %s:%s", url, worker->s->name, shared->name);
-#endif
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: worker for %s arranging shared memory %s:%s", url,
+                     worker->s->name_ex, shared->name_ex);
         worker->s->was_malloced = 0; /* Prevent mod_proxy to free it */
         worker->s->index = node->mess.id;
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
         strncpy(worker->s->name_ex, shared->name_ex, sizeof(worker->s->name_ex));
-#else
-        strncpy(worker->s->name, shared->name, sizeof(worker->s->name));
-#endif
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                      "Created: worker for %s arranging shared memory hostname %s:%s", url, worker->s->hostname,
                      shared->hostname);
         strncpy(worker->s->hostname, shared->hostname, sizeof(worker->s->hostname));
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                      "Created: worker for %s arranging shared memory hostname_ex %s:%s", url, worker->s->hostname_ex,
                      shared->hostname_ex);
         strncpy(worker->s->hostname_ex, shared->hostname_ex, sizeof(worker->s->hostname_ex));
-#endif
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: worker for %s arranging shared memory scheme %s:%s",
                      url, worker->s->scheme, shared->scheme);
         strncpy(worker->s->scheme, shared->scheme, sizeof(worker->s->scheme));
@@ -529,12 +500,8 @@ static apr_status_t create_worker(proxy_server_conf *conf, proxy_balancer *balan
             add_hcheck(server, conf, worker);
         }
     } else {
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                     "Created: worker for %s shared memory  OK %s:%s", url, worker->s->name_ex, shared->name_ex);
-#else
-                     "Created: worker for %s shared memory  OK %s:%s", url, worker->s->name, shared->name);
-#endif
+        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server, "Created: worker for %s shared memory  OK %s:%s", url,
+                     worker->s->name_ex, shared->name_ex);
         worker->s->was_malloced = 0; /* Prevent mod_proxy to free it */
     }
 
@@ -865,22 +832,12 @@ static int remove_workers_node(nodeinfo_t *node, proxy_server_conf *conf, apr_po
         helper->isinnodes = 0;
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, server,
                      "remove_workers_node... scheme %s hostname %s port %d route %s name (%s):(%s) id (%d:%d)",
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                      stat->scheme, stat->hostname_ex, stat->port, stat->route, stat->name, helper->shared->name,
                      stat->index, helper->index);
-#else
-                     stat->scheme, stat->hostname, stat->port, stat->route, stat->name, helper->shared->name,
-                     stat->index, helper->index);
-#endif
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, server,
                      "remove_workers_node... restored: scheme %s hostname %s port %d route %s name %s id:%d",
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                      worker->s->scheme, worker->s->hostname_ex, worker->s->port, worker->s->route, worker->s->name,
                      worker->s->index);
-#else
-                     worker->s->scheme, worker->s->hostname, worker->s->port, worker->s->route, worker->s->name,
-                     worker->s->index);
-#endif
         /* XXX : look bad with new logic!!!! memcpy(worker->s, stat, sizeof(proxy_worker_shared)); */
         ap_assert(worker->s->port != 0);
 
@@ -1641,13 +1598,8 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
             helper = (proxy_cluster_helper *)worker->context;
             if (!worker->s || !worker->context) {
                 ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                              "proxy: byrequests balancer %s skipping BAD worker %s", balancer->s->name,
                              worker->s ? worker->s->name_ex : "NULL");
-#else
-                             "proxy: byrequests balancer %s skipping BAD worker %s", balancer->s->name,
-                             worker->s ? worker->s->name : "NULL");
-#endif
                 continue;
             }
             if (helper->index == 0) {
@@ -1787,11 +1739,7 @@ static proxy_worker *internal_find_best_byrequests(proxy_balancer *balancer, pro
         mycandidate->s->elected++;
         apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", apr_psprintf(r->pool, "%d", mynodecontext->context));
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: byrequests balancer DONE (%s)",
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
                      mycandidate->s->name_ex);
-#else
-                     mycandidate->s->name);
-#endif
     } else {
         apr_table_setn(r->subprocess_env, "BALANCER_CONTEXT_ID", "");
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy: byrequests balancer FAILED");
@@ -3086,11 +3034,7 @@ static int rewrite_url(request_rec *r, proxy_worker *worker, char **url)
                              apr_pstrcat(r->pool, "missing worker. URI cannot be parsed: ", *url, NULL));
     }
 
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
     *url = apr_pstrcat(r->pool, worker->s->name_ex, path, NULL);
-#else
-    *url = apr_pstrcat(r->pool, worker->s->name, path, NULL);
-#endif
 
     return OK;
 }
@@ -3401,11 +3345,7 @@ static int proxy_cluster_pre_request(proxy_worker **worker, proxy_balancer **bal
      */
     /* Add balancer/worker info to env. */
     apr_table_setn(r->subprocess_env, "BALANCER_NAME", (*balancer)->s->name);
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
     apr_table_setn(r->subprocess_env, "BALANCER_WORKER_NAME", (*worker)->s->name_ex);
-#else
-    apr_table_setn(r->subprocess_env, "BALANCER_WORKER_NAME", (*worker)->s->name);
-#endif
     apr_table_setn(r->subprocess_env, "BALANCER_WORKER_ROUTE", (*worker)->s->route);
 
     /* Rewrite the url from 'balancer://url'
@@ -3416,13 +3356,8 @@ static int proxy_cluster_pre_request(proxy_worker **worker, proxy_balancer **bal
     access_status = rewrite_url(r, *worker, url);
 
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "proxy_cluster_pre_request: balancer (%s) worker (%s) rewritten to %s",
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                 (*balancer)->s->name, (*worker)->s->name_ex,
-#else
-                 (*balancer)->s->name, (*worker)->s->name,
-#endif
-                 *url);
+                 "proxy_cluster_pre_request: balancer (%s) worker (%s) rewritten to %s", (*balancer)->s->name,
+                 (*worker)->s->name_ex, *url);
     return access_status;
 }
 
@@ -3511,13 +3446,7 @@ static int proxy_cluster_post_request(proxy_worker *worker, proxy_balancer *bala
                               "%s: Forcing worker (%s) into error state "
                               "due to status code %d matching 'failonstatus' "
                               "balancer parameter",
-                              balancer->s->name,
-#if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR >= 124
-                              worker->s->name_ex,
-#else
-                              worker->s->name,
-#endif
-                              val);
+                              balancer->s->name, worker->s->name_ex, val);
                 worker->s->status |= PROXY_WORKER_IN_ERROR;
                 worker->s->error_time = apr_time_now();
                 break;


### PR DESCRIPTION
The latest changes contain off-by-one error in the version check. Additionally, changes requiring at least version 2.4.53 permit us to simplify the code.