### PR TITLE
Remove duplicate balancer_manage function declaration

### DIFF
--- a/native/mod_manager/mod_manager.h
+++ b/native/mod_manager/mod_manager.h
@@ -25,10 +25,6 @@
  * @version $Revision$
  */
 
-#include "apr_optional.h"
-
-APR_DECLARE_OPTIONAL_FN(apr_status_t, balancer_manage, (request_rec *, apr_table_t *));
-
 struct mem
 {
     ap_slotmem_instance_t *slotmem;


### PR DESCRIPTION
The function is already declared in other module and we do not implement it. We just use it if it's available – [see](https://github.com/modcluster/mod_proxy_cluster/blob/3811731187f39c8b8ce4c22b896c3c55a3c6425c/native/mod_manager/mod_manager.c#L707).