### PR TITLE
CI: Change package name for docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup dependencies
         run: |
-          sudo apt update -y
-          sudo apt install -y moby* maven git curl iproute2
+          sudo apt-get update -y
+          sudo apt-get install -y docker maven git curl iproute2
           cd test
           sh setup-dependencies.sh
       - name: Setup images


### PR DESCRIPTION
For some reason the current way stopped working (e.g., [here](https://github.com/modcluster/mod_proxy_cluster/actions/runs/5852618025/job/16318039134?pr=137)).