### PR TITLE
test: Add option to change tomcat conf files

### DIFF
--- a/test/includes/common.sh
+++ b/test/includes/common.sh
@@ -95,8 +95,15 @@ clean_and_exit() {
 #####################################################
 ### T O M C A T   H E L P E R   F U N C T I O N S ###
 #####################################################
+# Function that build a container. IMG variable is used for the container's tag.
+# By passing arguments you can change
+#       $1 tomcat version      (default is 8.5)
+#       $2 tomcat config file  (default is server.xml)
+#       $3 tomcat context file (default is context.xml)
 tomcat_create() {
-    docker build -t $IMG tomcat/ --build-arg TESTSUITE_TOMCAT_VERSION=${1:-8.5}
+    docker build -t $IMG tomcat/ --build-arg TESTSUITE_TOMCAT_VERSION=${1:-8.5} \
+                                 --build-arg TESTSUITE_TOMCAT_CONFIG=${2:-server.xml} \
+                                 --build-arg TESTSUITE_TOMCAT_CONTEXT=${3:-context.xml}
 }
 
 # Start tomcat$1 container on 127.0.0.$2

--- a/test/testsuite.sh
+++ b/test/testsuite.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/sh
+# exits with 0 if everything went well
+# exits with 1 if some test failed
+# exits with 2 if httpd container build failed
+# exits with 3 if tomcat container build failed
 
 # configuration of variables
 # if you want tests to pass much faster, decrease these values
@@ -35,8 +39,10 @@ httpd_create  > /dev/null 2>&1 || exit 2
 tomcat_create > /dev/null 2>&1 || exit 3
 
 # clean everything at first
-httpd_all_clean
-tomcat_all_remove
+echo -n "Cleaning possibly running containers..."
+httpd_all_clean   > /dev/null 2>&1
+tomcat_all_remove > /dev/null 2>&1
+echo " Done"
 
 res=0
 
@@ -73,6 +79,7 @@ if [ $res -eq 0 ]; then
     echo "Tests finished successfully!"
 else
     echo "Tests finished, but some failed."
+    res=1
 fi
 
 exit $res

--- a/test/tomcat/Dockerfile
+++ b/test/tomcat/Dockerfile
@@ -2,6 +2,9 @@ ARG TESTSUITE_TOMCAT_VERSION=8.5
 
 FROM tomcat:${TESTSUITE_TOMCAT_VERSION}
 
+ARG TESTSUITE_TOMCAT_CONFIG=server.xml
+ARG TESTSUITE_TOMCAT_CONTEXT=context.xml
+
 # install ss
 RUN apt update && apt install -y iproute2
 
@@ -9,8 +12,8 @@ WORKDIR /usr/local/tomcat
 
 COPY target/*.jar ./lib/
 COPY *.war ./
-COPY server.xml ./conf/
-COPY context.xml ./conf/
+COPY $TESTSUITE_TOMCAT_CONFIG  ./conf/server.xml
+COPY $TESTSUITE_TOMCAT_CONTEXT ./conf/context.xml
 COPY start.sh ./
 RUN chmod +x start.sh
 

--- a/test/tomcat/README.md
+++ b/test/tomcat/README.md
@@ -12,6 +12,11 @@ execute
 docker build -t tomcat . --build-arg TESTSUITE_TOMCAT_VERSION=10.1
 ```
 
+There are two other build arguments you can pass to control the server's
+configuration files. The first one is `TESTSUITE_TOMCAT_CONFIG` with default
+value set to `server.xml`, the second is `TESTSUITE_TOMCAT_CONTEXT` that is
+set to `context.xml` by default.
+
 # Run image
 **Note the ENV variables:**
 


### PR DESCRIPTION
close #141. Introduces two variables for server.xml and context.xml by which you can control which files will be used. This does not introduces separate files for each supported version as it is not needed now.