### PR TITLE
Testsuite tweaks

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -77,7 +77,11 @@ as `miniserver.py`. Execute it simply as `./includes/miniserver.py <port-number>
 You must have `httpd` with `mod_proxy_cluster` running.
 
 # Testing the lbmethod and mod_proxy_balancer
-Just run the test with CONF=httpd/mod_lbmethod_cluster.conf
+
+There are a few tests run with lbmethod and mod_proxy_balancer in the testsuite. If you want
+to run a particular test with such configuration, execute the test with `MPC_CONF` variable
+set to the included configuration, e.g.,
+
 ```
-MPC_CONF=httpd/mod_lbmethod_cluster.conf sh testsuite.sh
+MPC_CONF=httpd/mod_lbmethod_cluster.conf <test you want to run>
 ```

--- a/test/includes/common.sh
+++ b/test/includes/common.sh
@@ -26,7 +26,7 @@ run_test() {
     if [ $DEBUG ]; then
         local httpd_cont=$(docker ps -a | grep $HTTPD_IMG | cut -f 1 -d' ')
         docker logs  $httpd_cont > "logs/${2:-$1}-httpd.log" 2>&1
-        docker cp ${httpd_cont}:/usr/local/apache2/logs/access_log "logs/${2:-$1}-httpd_access.log" > /dev/null
+        docker cp ${httpd_cont}:/usr/local/apache2/logs/access_log "logs/${2:-$1}-httpd_access.log" 2> /dev/null || true
     fi
     # Clean all after run
     httpd_all_clean > /dev/null 2>&1

--- a/test/setup-dependencies.sh
+++ b/test/setup-dependencies.sh
@@ -2,20 +2,20 @@
 TEST_DIR=$(pwd)
 cd ../..
 # get websocket demo repository
-if [ ! -d httpd_websocket ]; then
-    git clone https://github.com/jfclere/httpd_websocket
+if [ ! -d httpd_websocket-testsuite ]; then
+    git clone https://github.com/jfclere/httpd_websocket httpd_websocket-testsuite
 fi
-cd httpd_websocket
+cd httpd_websocket-testsuite
 git pull --rebase
 mvn install || exit 1
 cp target/websocket-hello-0.0.1.war $TEST_DIR/tomcat/
 cd ..
 
 # get mod_cluster (Java/Tomcat part)
-if [ ! -d mod_cluster ]; then
-    git clone https://github.com/modcluster/mod_cluster
+if [ ! -d mod_cluster-testsuite ]; then
+    git clone https://github.com/modcluster/mod_cluster mod_cluster-testsuite
 fi
-cd mod_cluster
+cd mod_cluster-testsuite
 git pull --rebase
 mvn install || exit 2
 cd $TEST_DIR

--- a/test/testsuite.sh
+++ b/test/testsuite.sh
@@ -85,6 +85,20 @@ res=$(expr $res + $?)
 run_test MODCLUSTER-794/testit.sh   "MODCLUSTER-794"
 res=$(expr $res + $?)
 
+MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test basetests.sh "Basic tests with mod_proxy_balancer"
+res=$(expr $res + $?)
+MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-640/testit.sh   "MODCLUSTER-640 with mod_proxy_balancer"
+res=$(expr $res + $?)
+MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-734/testit.sh   "MODCLUSTER-734 with mod_proxy_balancer"
+res=$(expr $res + $?)
+MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-755/testit.sh   "MODCLUSTER-755 with mod_proxy_balancer"
+res=$(expr $res + $?)
+MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-785/testit.sh   "MODCLUSTER-785 with mod_proxy_balancer"
+res=$(expr $res + $?)
+MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-794/testit.sh   "MODCLUSTER-794 with mod_proxy_balancer"
+res=$(expr $res + $?)
+
+
 echo "Clean remaining httpd containers"
 httpd_all_clean 
 


### PR DESCRIPTION
 * add lbmethos + mod_proxy_cluster directly into the testsuite (so it is not needed to run tests separately)
 * change naming of the directories for dependencies (so it won't interfere with already checked-out directories for development)
 * fix test fail in case access_log is missing