### PR TITLE
mod_manager.c: Refactor part of `process_config`, remove one assert

### DIFF
--- a/native/mod_manager/node.c
+++ b/native/mod_manager/node.c
@@ -200,13 +200,14 @@ nodeinfo_t *read_node(mem_t *s, nodeinfo_t *node)
 
     if (node->mess.id == -1) {
         rv = s->storage->doall(s->slotmem, loc_read_node, node, s->p);
-        if (rv != APR_EEXIST) {
-            return NULL;
+        if (rv == APR_EEXIST) {
+            return node;
         }
-    }
-    rv = s->storage->dptr(s->slotmem, node->mess.id, (void **)&ou);
-    if (rv == APR_SUCCESS) {
-        return ou;
+    } else {
+        rv = s->storage->dptr(s->slotmem, node->mess.id, (void **)&ou);
+        if (rv == APR_SUCCESS) {
+            return ou;
+        }
     }
     return NULL;
 }


### PR DESCRIPTION
The removal of the assert changes the behaviour; instead of an empty response the server returns `500` now. You can check the behaviour by running httpd with mod_proxy_cluster on port `6666` and executing:

```sh
curl localhost:6666 -H "User-Agent: ClusterListener/1.0" -X CONFIG --data "JVMRoute=demo&Type=http"
curl localhost:6666 -H "User-Agent: ClusterListener/1.0" -X CONFIG --data "JVMRoute=test&ttl=300&Type=http"
```