### PR TITLE
test: Set httpd container workid to Apache's root

### DIFF
--- a/test/httpd/Dockerfile
+++ b/test/httpd/Dockerfile
@@ -43,5 +43,6 @@ RUN for m in advertise mod_proxy_cluster balancers mod_manager; \
         cd $OLDPWD; \
     done;
 
-CMD /tmp/run.sh
+WORKDIR /usr/local/apache2
 
+CMD /tmp/run.sh


### PR DESCRIPTION
It's much more convenient in case you want to log and work within the container.