### PR TITLE
Move extra debug macro to the header file, fix logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ Tests
 
 The project contains some tests too. You can find them with a separate README in the `test` subdirectory.
 
+Debugging
+---------
+
+For the debugging, you can specify the `LogLevel` within you `httpd.conf` file. In case you want detailed logs,
+set the level to `DEBUG`. In case that would not be enough, `mod_proxy_cluster` uses messages with level
+up to `TRACE6`. Such a level of logging might result in huge and chaotic logs, so we advise you to set these
+level for the module only (see [this document](https://httpd.apache.org/docs/2.4/logs.html#permodule)).
+
+You can also get additional information in case you compile mod_proxy_cluster with `HAVE_CLUSTER_EX_DEBUG` macro
+set. That will make more information visible within mod_manager. It will also add more information to the context
+search, but bear in mind that this may affect the performance.
+
 Doxygen documentation
 ---------------------
 

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -186,8 +186,8 @@ static int lbmethod_cluster_trans(request_rec *r)
     }
 
 #if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server, "proxy_cluster_trans DECLINED %s uri: %s unparsed_uri: %s",
-                 balancer, r->filename, r->unparsed_uri);
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
+                 "proxy_cluster_trans DECLINED (no balancer) uri: %s unparsed_uri: %s", r->filename, r->unparsed_uri);
 #endif
     return DECLINED;
 }

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -143,19 +143,15 @@ static int lbmethod_cluster_trans(request_rec *r)
     const char *balancer;
     void *sconf = r->server->module_config;
     proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
-
-
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                 "lbmethod_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s", r->proxyreq, r->filename,
-                 r->handler, r->uri, r->args, r->unparsed_uri);
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "lbmethod_cluster_trans for %d", conf->balancers->nelts);
-#endif
-
     proxy_vhost_table *vhost_table = read_vhost_table(r->pool, host_storage, 0);
     proxy_context_table *context_table = read_context_table(r->pool, context_storage, 0);
     proxy_balancer_table *balancer_table = read_balancer_table(r->pool, balancer_storage, 0);
     proxy_node_table *node_table = read_node_table(r->pool, node_storage, 0);
+
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server,
+                 "lbmethod_cluster_trans for %d %s %s uri: %s args: %s unparsed_uri: %s", r->proxyreq, r->filename,
+                 r->handler, r->uri, r->args, r->unparsed_uri);
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "lbmethod_cluster_trans for %d", conf->balancers->nelts);
 
     apr_table_setn(r->notes, "vhost-table", (char *)vhost_table);
     apr_table_setn(r->notes, "context-table", (char *)context_table);
@@ -178,17 +174,13 @@ static int lbmethod_cluster_trans(request_rec *r)
         }
         r->handler = "proxy-server";
         r->proxyreq = PROXYREQ_REVERSE;
-#if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_trans using %s uri: %s", balancer,
+        ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "proxy_cluster_trans using %s uri: %s", balancer,
                      r->filename);
-#endif
         return OK; /* Mod_proxy will process it */
     }
 
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_ERR, 0, r->server,
+    ap_log_error(APLOG_MARK, APLOG_TRACE3, 0, r->server,
                  "proxy_cluster_trans DECLINED (no balancer) uri: %s unparsed_uri: %s", r->filename, r->unparsed_uri);
-#endif
     return DECLINED;
 }
 

--- a/native/common/common.c
+++ b/native/common/common.c
@@ -335,9 +335,7 @@ int hassession_byname(request_rec *r, int nodeid, const char *route, const proxy
 
     sessionid = cluster_get_sessionid(r, sticky, uri, &sticky_used);
     if (sessionid) {
-#if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "mod_proxy_cluster: found sessionid %s", sessionid);
-#endif
+        ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "mod_proxy_cluster: found sessionid %s", sessionid);
         return 1;
     }
     return 0;
@@ -391,9 +389,7 @@ node_context *find_node_context_host(request_rec *r, const proxy_balancer *balan
         int sizevhost;
         int *contextsok = apr_pcalloc(r->pool, sizeof(int) * sizecontext);
         const char *hostname = ap_get_server_name(r);
-#if HAVE_CLUSTER_EX_DEBUG
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_node_context_host: Host: %s", hostname);
-#endif
+        ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "find_node_context_host: Host: %s", hostname);
         sizevhost = vhost_table->sizevhost;
         for (i = 0; i < sizevhost; i++) {
             hostinfo_t *vhost = vhost_table->vhost_info + i;
@@ -420,8 +416,9 @@ node_context *find_node_context_host(request_rec *r, const proxy_balancer *balan
             continue;
         }
         context = &context_table->context_info[j];
-        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_node_context_host: %s node: %d vhost: %d context: %s",
-                     uri, context->node, context->vhost, context->context);
+        ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server,
+                     "find_node_context_host: %s node: %d vhost: %d context: %s", uri, context->node, context->vhost,
+                     context->context);
     }
 #endif
 
@@ -512,9 +509,7 @@ static apr_status_t find_nodedomain(request_rec *r, const char **domain, char *r
     (void)r;
 
     /* XXX JFCLERE!!!! domaininfo_t *dom; */
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_nodedomain: finding node for %s: %s", route, balancer);
-#endif
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "find_nodedomain: finding node for %s: %s", route, balancer);
     for (i = 0; i < node_table->sizenode; i++) {
         if (strcmp(node_table->node_info[i].mess.JVMRoute, route) == 0) {
             const nodeinfo_t *ou = &node_table->node_info[i];
@@ -527,9 +522,7 @@ static apr_status_t find_nodedomain(request_rec *r, const char **domain, char *r
         }
     }
 
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "find_nodedomain: finding domain for %s: %s", route, balancer);
-#endif
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "find_nodedomain: finding domain for %s: %s", route, balancer);
     /* We can't find the node, because it was removed... */
     /* XXX: we need a proxy_node_domain for that too!!!
        if (domain_storage->find_domain(&dom, route, balancer ) == APR_SUCCESS) {
@@ -588,14 +581,10 @@ const char *get_route_balancer(request_rec *r, const proxy_server_conf *conf, co
             }
             if (route && *route) {
                 const char *domain = NULL;
-#if HAVE_CLUSTER_EX_DEBUG
-                ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster: Found route %s", route);
-#endif
+                ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "cluster: Found route %s", route);
                 if (find_nodedomain(r, &domain, route, &balancer->s->name[11], node_table) == APR_SUCCESS) {
-#if HAVE_CLUSTER_EX_DEBUG
-                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster: Found balancer %s for %s",
+                    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "cluster: Found balancer %s for %s",
                                  &balancer->s->name[11], route);
-#endif
                     /* here we have the route and domain for find_session_route ... */
                     apr_table_setn(r->notes, "session-sticky", sticky_used);
                     apr_table_setn(r->notes, "session-route", route);
@@ -603,10 +592,8 @@ const char *get_route_balancer(request_rec *r, const proxy_server_conf *conf, co
                     apr_table_setn(r->subprocess_env, "BALANCER_SESSION_ROUTE", route);
                     apr_table_setn(r->subprocess_env, "BALANCER_SESSION_STICKY", sticky_used);
                     if (domain) {
-#if HAVE_CLUSTER_EX_DEBUG
-                        ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "cluster: Found domain %s for %s", domain,
+                        ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "cluster: Found domain %s for %s", domain,
                                      route);
-#endif
                         apr_table_setn(r->notes, "CLUSTER_DOMAIN", domain);
                     }
                     return &balancer->s->name[11];

--- a/native/include/mod_proxy_cluster.h
+++ b/native/include/mod_proxy_cluster.h
@@ -20,6 +20,9 @@
 
 #define MOD_CLUSTER_EXPOSED_VERSION "mod_cluster/2.0.0.Alpha1-SNAPSHOT"
 
+/* define HAVE_CLUSTER_EX_DEBUG to have extented debug in mod_cluster */
+#define HAVE_CLUSTER_EX_DEBUG       0
+
 /* We don't care about versions older then 2.4.x, i.e., MODULE_MAGIC_NUMBER_MAJOR < 20120211 */
 #if MODULE_MAGIC_NUMBER_MAJOR == 20120211 && MODULE_MAGIC_NUMBER_MINOR < 124
 #error Please update your HTTPD, mod_proxy_cluster requires version 2.4.53 or newer.

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -36,68 +36,65 @@
 
 #include "mod_proxy_cluster.h"
 
-#define DEFMAXCONTEXT         100
-#define DEFMAXNODE            20
-#define DEFMAXHOST            20
-#define DEFMAXSESSIONID       0 /* it has performance/security impact */
-#define MAXMESSSIZE           1024
+#define DEFMAXCONTEXT    100
+#define DEFMAXNODE       20
+#define DEFMAXHOST       20
+#define DEFMAXSESSIONID  0 /* it has performance/security impact */
+#define MAXMESSSIZE      1024
 
 /* Warning messages */
-#define SBALBAD               "Balancer name contained an upper case character. We will use \"%s\" instead."
+#define SBALBAD          "Balancer name contained an upper case character. We will use \"%s\" instead."
 
 /* Error messages */
-#define TYPESYNTAX            1
-#define SMESPAR               "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements."
-#define SBALBIG               "SYNTAX: Balancer field too big"
-#define SBAFBIG               "SYNTAX: A field is too big"
-#define SROUBIG               "SYNTAX: JVMRoute field too big"
-#define SROUBAD               "SYNTAX: JVMRoute can't be empty"
-#define SDOMBIG               "SYNTAX: LBGroup field too big"
-#define SHOSBIG               "SYNTAX: Host field too big"
-#define SPORBIG               "SYNTAX: Port field too big"
-#define STYPBIG               "SYNTAX: Type field too big"
-#define SALIBAD               "SYNTAX: Alias without Context"
-#define SCONBAD               "SYNTAX: Context without Alias"
-#define SBADFLD               "SYNTAX: Invalid field \"%s\" in message"
-#define SMISFLD               "SYNTAX: Mandatory field(s) missing in message"
-#define SCMDUNS               "SYNTAX: Command is not supported"
-#define SMULALB               "SYNTAX: Only one Alias in APP command"
-#define SMULCTB               "SYNTAX: Only one Context in APP command"
-#define SREADER               "SYNTAX: %s can't read POST data"
+#define TYPESYNTAX       1
+#define SMESPAR          "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements."
+#define SBALBIG          "SYNTAX: Balancer field too big"
+#define SBAFBIG          "SYNTAX: A field is too big"
+#define SROUBIG          "SYNTAX: JVMRoute field too big"
+#define SROUBAD          "SYNTAX: JVMRoute can't be empty"
+#define SDOMBIG          "SYNTAX: LBGroup field too big"
+#define SHOSBIG          "SYNTAX: Host field too big"
+#define SPORBIG          "SYNTAX: Port field too big"
+#define STYPBIG          "SYNTAX: Type field too big"
+#define SALIBAD          "SYNTAX: Alias without Context"
+#define SCONBAD          "SYNTAX: Context without Alias"
+#define SBADFLD          "SYNTAX: Invalid field \"%s\" in message"
+#define SMISFLD          "SYNTAX: Mandatory field(s) missing in message"
+#define SCMDUNS          "SYNTAX: Command is not supported"
+#define SMULALB          "SYNTAX: Only one Alias in APP command"
+#define SMULCTB          "SYNTAX: Only one Context in APP command"
+#define SREADER          "SYNTAX: %s can't read POST data"
 
-#define SJIDBIG               "SYNTAX: JGroupUuid field too big"
-#define SJDDBIG               "SYNTAX: JGroupData field too big"
-#define SJIDBAD               "SYNTAX: JGroupUuid can't be empty"
+#define SJIDBIG          "SYNTAX: JGroupUuid field too big"
+#define SJDDBIG          "SYNTAX: JGroupData field too big"
+#define SJIDBAD          "SYNTAX: JGroupUuid can't be empty"
 
-#define TYPEMEM               2
-#define MNODEUI               "MEM: Can't update or insert node with \"%s\" JVMRoute"
-#define MNODERM               "MEM: Old node with \"%s\" JVMRoute still exists"
-#define MBALAUI               "MEM: Can't update or insert balancer for node with \"%s\" JVMRoute"
-#define MNODERD               "MEM: Can't read node with \"%s\" JVMRoute"
-#define MHOSTRD               "MEM: Can't read host alias for node with \"%s\" JVMRoute"
-#define MHOSTUI               "MEM: Can't update or insert host alias for node with \"%s\" JVMRoute"
-#define MCONTUI               "MEM: Can't update or insert context for node with \"%s\" JVMRoute"
-#define MJBIDRD               "MEM: Can't read JGroupId"
-#define MJBIDUI               "MEM: Can't update or insert JGroupId"
-#define MNODEET               "MEM: Another for the same worker already exist"
+#define TYPEMEM          2
+#define MNODEUI          "MEM: Can't update or insert node with \"%s\" JVMRoute"
+#define MNODERM          "MEM: Old node with \"%s\" JVMRoute still exists"
+#define MBALAUI          "MEM: Can't update or insert balancer for node with \"%s\" JVMRoute"
+#define MNODERD          "MEM: Can't read node with \"%s\" JVMRoute"
+#define MHOSTRD          "MEM: Can't read host alias for node with \"%s\" JVMRoute"
+#define MHOSTUI          "MEM: Can't update or insert host alias for node with \"%s\" JVMRoute"
+#define MCONTUI          "MEM: Can't update or insert context for node with \"%s\" JVMRoute"
+#define MJBIDRD          "MEM: Can't read JGroupId"
+#define MJBIDUI          "MEM: Can't update or insert JGroupId"
+#define MNODEET          "MEM: Another for the same worker already exist"
 
 /* Protocol version supported */
-#define VERSION_PROTOCOL      "0.2.1"
+#define VERSION_PROTOCOL "0.2.1"
 
 /* Internal substitution for node commands */
-#define NODE_COMMAND          "/NODE_COMMAND"
+#define NODE_COMMAND     "/NODE_COMMAND"
 
 /* range of the commands */
-#define RANGECONTEXT          0
-#define RANGENODE             1
-#define RANGEDOMAIN           2
-
-/* define HAVE_CLUSTER_EX_DEBUG to have extented debug in mod_cluster */
-#define HAVE_CLUSTER_EX_DEBUG 0
+#define RANGECONTEXT     0
+#define RANGENODE        1
+#define RANGEDOMAIN      2
 
 /* define content-type */
-#define TEXT_PLAIN            1
-#define TEXT_XML              2
+#define TEXT_PLAIN       1
+#define TEXT_XML         2
 
 /* Data structure for shared memory block */
 typedef struct version_data
@@ -2877,8 +2874,8 @@ static void manager_domain(request_rec *r, int reduce_display)
         if (get_domain(domainstatsmem, &ou, id[i]) != APR_SUCCESS) {
             continue;
         }
-        ap_rprintf(r, "dom: %.*s route: %.*s balancer: %.*s\n", sizeof(ou->domain), ou->domain, sizeof(ou->JVMRoute),
-                   ou->JVMRoute, sizeof(ou->balancer), ou->balancer);
+        ap_rprintf(r, "dom: %.*s route: %.*s balancer: %.*s\n", DOMAINNDSZ, ou->domain, JVMROUTESZ, ou->JVMRoute,
+                   BALANCERSZ, ou->balancer);
     }
     ap_rprintf(r, "</pre>");
 }

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -2850,9 +2850,9 @@ static void manager_sessionid(request_rec *r)
     ap_rprintf(r, "</pre>");
 }
 
-#if HAVE_CLUSTER_EX_DEBUG
 static void manager_domain(request_rec *r, int reduce_display)
 {
+#if HAVE_CLUSTER_EX_DEBUG
     int size, i;
     int *id;
 
@@ -2878,8 +2878,8 @@ static void manager_domain(request_rec *r, int reduce_display)
                    BALANCERSZ, ou->balancer);
     }
     ap_rprintf(r, "</pre>");
-}
 #endif
+}
 
 static int count_sessionid(request_rec *r, const char *route)
 {
@@ -3297,9 +3297,8 @@ static int manager_info(request_rec *r)
     if (sizesessionid) {
         manager_sessionid(r);
     }
-#if HAVE_CLUSTER_EX_DEBUG
+
     manager_domain(r, mconf->reduce_display);
-#endif
 
     ap_rputs("</body></html>\n", r);
     return OK;

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1485,9 +1485,7 @@ static void remove_timeout_domain(apr_pool_t *pool)
 static int isnode_domain_ok(const request_rec *r, const nodeinfo_t *node, const char *domain)
 {
     (void)r;
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "isnode_domain_ok: domain %s:%s", domain, node->mess.Domain);
-#endif
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "isnode_domain_ok: domain %s:%s", domain, node->mess.Domain);
     if (domain == NULL) {
         return 1; /* OK no domain in the corresponding to the SESSIONID */
     }
@@ -1630,11 +1628,9 @@ static proxy_worker *internal_find_best_byrequests(const proxy_balancer *balance
     const char *session_id;
 
     workers = apr_pcalloc(r->pool, sizeof(proxy_worker *) * balancer->workers->nelts);
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server,
                  "internal_find_best_byrequests: Entering byrequests for CLUSTER (%s) failoverdomain:%d",
                  balancer->s->name, failoverdomain);
-#endif
 
     /* create workers for new nodes */
     if (!cache_share_for) {
@@ -2575,7 +2571,7 @@ static int proxy_cluster_trans(request_rec *r)
     apr_table_setn(r->notes, "balancer-table", (char *)balancer_table);
     apr_table_setn(r->notes, "node-table", (char *)node_table);
 
-    ap_log_rerror(APLOG_MARK, APLOG_TRACE8, 0, r, "proxy_cluster_trans: for %d %s %s uri: %s args: %s unparsed_uri: %s",
+    ap_log_rerror(APLOG_MARK, APLOG_TRACE6, 0, r, "proxy_cluster_trans: for %d %s %s uri: %s args: %s unparsed_uri: %s",
                   r->proxyreq, r->filename, r->handler, r->uri, r->args, r->unparsed_uri);
 
     balancer = get_route_balancer(r, conf, vhost_table, context_table, balancer_table, node_table, use_alias);
@@ -2637,7 +2633,7 @@ static int proxy_cluster_trans(request_rec *r)
         return OK; /* Mod_proxy will process it */
     }
 
-    ap_log_rerror(APLOG_MARK, APLOG_TRACE8, 0, r, "proxy_cluster_trans: DECLINED %s uri: %s unparsed_uri: %s",
+    ap_log_rerror(APLOG_MARK, APLOG_TRACE6, 0, r, "proxy_cluster_trans: DECLINED %s uri: %s unparsed_uri: %s",
                   balancer ? balancer : "", r->filename, r->unparsed_uri);
     return DECLINED;
 }
@@ -2659,9 +2655,7 @@ static int proxy_cluster_canon(request_rec *r, char *url)
     }
     url += 9;
 
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_canon url: %s", url);
-#endif
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "proxy_cluster_canon url: %s", url);
 
     /* do syntatic check.
      * We break the URL into host, port, path, search
@@ -2857,11 +2851,9 @@ static proxy_worker *find_session_route(const proxy_balancer *balancer, request_
     proxy_worker *worker = NULL;
     (void)url;
 
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server,
                  "find_session_route: sticky %s sticky_path: %s sticky_force: %d", balancer->s->sticky,
                  balancer->s->sticky_path, balancer->s->sticky_force);
-#endif
     if (balancer->s->sticky[0] == '\0' || balancer->s->sticky_path[0] == '\0') {
         return NULL;
     }
@@ -3315,10 +3307,8 @@ static int proxy_cluster_post_request(proxy_worker *worker, proxy_balancer *bala
 
     node_storage->unlock_nodes();
 
-#if HAVE_CLUSTER_EX_DEBUG
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_cluster_post_request: for (%s) %s", balancer->s->name,
+    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server, "proxy_cluster_post_request: for (%s) %s", balancer->s->name,
                  balancer->s->sticky);
-#endif
 
     if (sessionid_storage) {
 
@@ -3335,10 +3325,8 @@ static int proxy_cluster_post_request(proxy_worker *worker, proxy_balancer *bala
                 if (sessionid && strcmp(cookie, sessionid)) {
                     /* The cookie has changed, remove the old one and store the next one */
                     sessionidinfo_t ou;
-#if HAVE_CLUSTER_EX_DEBUG
-                    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
+                    ap_log_error(APLOG_MARK, APLOG_TRACE4, 0, r->server,
                                  "proxy_cluster_post_request: sessionid changed (%s to %s)", sessionid, cookie);
-#endif
                     strncpy(ou.sessionid, sessionid, SESSIONIDSZ);
                     ou.id = -1;
                     sessionid_storage->remove_sessionid(&ou);

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -42,18 +42,15 @@
 #include "apr_thread_pool.h"
 #endif
 
-/* define HAVE_CLUSTER_EX_DEBUG to have extented debug in mod_cluster */
-#define HAVE_CLUSTER_EX_DEBUG 0
-
 /* define OUR load balancer method names (lbpname), must start by MC */
 /* default behaviour be sticky StickySession="yes" */
-#define MC_STICKY             "MC"
+#define MC_STICKY         "MC"
 /* don't be STICKY use the best factor worker StickySession="no" */
-#define MC_NOT_STICKY         "MC_NS"
+#define MC_NOT_STICKY     "MC_NS"
 /* remove session information on fail-over StickySessionRemove="yes", implies StickySession="yes" */
-#define MC_REMOVE_SESSION     "MC_R"
+#define MC_REMOVE_SESSION "MC_R"
 /* Don't failover if the corresponding worker is failing StickySessionForce="yes", implies StickySession="yes" */
-#define MC_NO_FAILOVER        "MC_NF"
+#define MC_NO_FAILOVER    "MC_NF"
 
 #if APR_HAS_THREADS
 #ifndef MC_USE_THREADS


### PR DESCRIPTION
Two things here

* macro `HAVE_CLUSTER_EX_DEBUG` got moved to the header file where it belongs (that caused formatting to change a bit)
* fix a few warnings when the macro is defined (`int` vs `long` and null balancer)