### PR TITLE
CI: Run httpd with mod_proxy_cluster even on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
     runs-on: windows-latest
     env:
       APACHE_LOUNGE_DISTRO_VERSION: 2.4.57
-      HTTPD_DEV_HOME: '${{ github.workspace }}\httpd-apache-lounge\Apache24'
+      HTTPD_DEV_HOME: 'C:\Apache24'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -186,10 +186,29 @@ jobs:
       - name: Get httpd
         run: |
           curl.exe --output "httpd-apache-lounge.zip" --url "https://www.apachelounge.com/download/VS16/binaries/httpd-${{ env.APACHE_LOUNGE_DISTRO_VERSION }}-win64-VS16.zip"
-          Expand-Archive -Path "httpd-apache-lounge.zip" -DestinationPath "httpd-apache-lounge"
+          Expand-Archive -Path "httpd-apache-lounge.zip" -DestinationPath "C:\"
       - name: Build
         run: |
           ./native/scripts/windows-build.bat
+          cp cmakebuild/modules/*.so C:/Apache24/modules/
+      - name: Fix and prepare config files
+        run: |
+          cp test\httpd\mod_proxy_cluster.conf ${{ env.HTTPD_DEV_HOME }}\conf\mod_proxy_cluster.conf
+          echo "LogLevel debug"                      >> ${{ env.HTTPD_DEV_HOME }}\conf\mod_proxy_cluster.conf
+          echo "Include conf/mod_proxy_cluster.conf" >> ${{ env.HTTPD_DEV_HOME }}\conf\httpd.conf
+          (Get-Content ${{ env.HTTPD_DEV_HOME }}\conf\httpd.conf) | %{$_ -replace "Listen 80","Listen 8000"} | Set-Content -Path ${{ env.HTTPD_DEV_HOME }}\conf\httpd.conf
+      - name: Run
+        run: |
+          Start-Process -FilePath ${{ env.HTTPD_DEV_HOME }}\bin\httpd.exe
+          curl --fail --max-time 10 http://localhost:8000
+          curl --fail --max-time 10 http://localhost:6666/mod_cluster_manager
+      - name: Preserve logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: Windows logs
+          path: C:\Apache24\logs\
+          retention-days: 7
 
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
   cmake-windows-latest:
     runs-on: windows-latest
     env:
-      APACHE_LOUNGE_DISTRO_VERSION: 2.4.58-240131
+      APACHE_LOUNGE_DISTRO_VERSION: 2.4.59-240404
       HTTPD_DEV_HOME: 'C:\Apache24'
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
   cmake-windows-latest:
     runs-on: windows-latest
     env:
-      APACHE_LOUNGE_DISTRO_VERSION: 2.4.57
+      APACHE_LOUNGE_DISTRO_VERSION: 2.4.58-240131
       HTTPD_DEV_HOME: 'C:\Apache24'
     steps:
       - name: Checkout
@@ -185,7 +185,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
       - name: Get httpd
         run: |
-          curl.exe --output "httpd-apache-lounge.zip" --url "https://www.apachelounge.com/download/VS16/binaries/httpd-${{ env.APACHE_LOUNGE_DISTRO_VERSION }}-win64-VS16.zip"
+          curl.exe --output "httpd-apache-lounge.zip" --url "https://www.apachelounge.com/download/VS17/binaries/httpd-${{ env.APACHE_LOUNGE_DISTRO_VERSION }}-win64-VS17.zip"
           Expand-Archive -Path "httpd-apache-lounge.zip" -DestinationPath "C:\"
       - name: Build
         run: |


### PR DESCRIPTION
We only build the project on Windows. That means we might (and we did)  miss errors that would be detected when we would run httpd with mod_proxy_cluster. This PR extends the Windows job and after building mod_proxy_cluster runs it trying two request through `curl`.

I open this as a draft, because it's failing currently (and the error is at our side, without loading mod_proxy_cluster and the second `curl` it works). 
