### PR TITLE
Fix Conditional jump or move depends on uninitialised value(s) warning

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -2103,7 +2103,7 @@ static char *process_appl_cmd(request_rec *r, char **ptr, int status, int *errty
         char *s = hostinfo.host;
         unsigned j = 1;
         strncpy(hostinfo.host, vhost->host, HOSTALIASZ);
-        while (*s != ',' && j < sizeof(hostinfo.host)) {
+        while (*s != '\0' && *s != ',' && j < sizeof(hostinfo.host)) {
             j++;
             s++;
         }


### PR DESCRIPTION
The warning comes from valgrind and is imho relevant (although the functionality does not change). There is no point in going beyond `'\0'` if present.