### PR TITLE
test: Fix wrong path and unnecessary sed for tomcat container

### DIFF
--- a/test/tomcat/start.sh
+++ b/test/tomcat/start.sh
@@ -6,9 +6,6 @@ sed -i "s/proxy_port/${cluster_port:-6666}/g" ./conf/server.xml
 sed -i "s/proxy_address/${cluster_address:-127.0.0.1}/g" ./conf/server.xml
 sed -i "s/proxy_address/${cluster_address:-127.0.0.1}/g" ./conf/context.xml
 
-conPort=$(expr 8080 + ${tomcat_port_offset:-0})
-sed -i "s/changeMe/$conPort/" ./conf/server.xml
-
 if [ ! -z ${jvm_route} ]; then
   sed -i "/<Engine name=\"Catalina\"/c\<Engine name=\"Catalina\" defaultHost=\"localhost\" jvmRoute=\"${jvm_route}\">" ./conf/server.xml
 fi
@@ -16,5 +13,4 @@ fi
 # copy webapp war file.
 mv *.war webapps/ || true
 
-catalina.sh run
-
+bin/catalina.sh run


### PR DESCRIPTION
The conPort is no longer used. And `bin/catalina.sh` is the right part (see the conf above or WORKDIR in the dockerfile).