### PR TITLE
Use AP_DECLARE_MODULE macro

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -4030,7 +4030,7 @@ static void *merge_manager_server_config(apr_pool_t *p, void *server1_conf, void
 
 /* Module declaration */
 
-module AP_MODULE_DECLARE_DATA manager_module = {
+AP_DECLARE_MODULE(manager) = {
     STANDARD20_MODULE_STUFF,
     NULL,
     NULL,

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -3694,7 +3694,7 @@ static const command_rec proxy_cluster_cmds[] = {
 };
 /* clang-format on */
 
-module AP_MODULE_DECLARE_DATA proxy_cluster_module = {
+AP_DECLARE_MODULE(proxy_cluster) = {
     STANDARD20_MODULE_STUFF,
     NULL,                               /* per-directory config creator */
     NULL,                               /* dir config merger */


### PR DESCRIPTION
It is equivalent to `AP_MODULE_DECLARE_DATA` used currently with the addition of setting the name of the module for the logs (see [the definition](https://github.com/apache/httpd/blob/21155482135ad2ba8e4bfc547dd6d6a0093d502f/include/http_config.h#L467)).