### PR TITLE
test: Add a dependecy check for used commands

### DIFF
--- a/test/setup-dependencies.sh
+++ b/test/setup-dependencies.sh
@@ -1,3 +1,26 @@
+#!/usr/bin/sh
+
+# $1 is the command, $2 is the flag used for the check (--version by default)
+check_cmd() {
+if [ -z "$1" ]; then
+        echo "check_cmd called without arguments"
+        exit 11
+    fi
+
+    $1 ${2:-"--version"} > /dev/null 2>&1
+    if [ $? != 0 ]; then
+        echo "$1 is not available, please install $1"
+        exit 3
+    fi
+}
+
+# check that necessary tools and commands are available
+check_cmd ab "-V"
+for cmd in ss curl mvn docker jdb git
+do
+    check_cmd $cmd
+done
+
 # Run this from the same directory
 TEST_DIR=$(pwd)
 cd ../..


### PR DESCRIPTION
When I tried running the testsuite on a fresh system (ubuntu), I forgot to install `curl`. The testuite then failed because it assumed httpd was not ready, but in reality it was missing `curl`. This PR adds a check for the required commands into the dependencies setup.