### PR TITLE
Testsuite: Drop tomcat 8.5 and make tomcat 10.1 the default

### DIFF
--- a/test/includes/common.sh
+++ b/test/includes/common.sh
@@ -108,13 +108,18 @@ clean_and_exit() {
 #####################################################
 # Function that build a container. IMG variable is used for the container's tag.
 # By passing arguments you can change
-#       $1 tomcat version      (default is 8.5)
+#       $1 tomcat version      (default is 10.1, see tomcat/Dockerfile)
 #       $2 tomcat config file  (default is server.xml)
 #       $3 tomcat context file (default is context.xml)
 tomcat_create() {
-    docker build -t $IMG tomcat/ --build-arg TESTSUITE_TOMCAT_VERSION=${1:-8.5} \
-                                 --build-arg TESTSUITE_TOMCAT_CONFIG=${2:-server.xml} \
-                                 --build-arg TESTSUITE_TOMCAT_CONTEXT=${3:-context.xml}
+    if [ -z "$1" ]; then
+        docker build -t $IMG tomcat/ --build-arg TESTSUITE_TOMCAT_CONFIG=${2:-server.xml} \
+                                     --build-arg TESTSUITE_TOMCAT_CONTEXT=${3:-context.xml}
+    else
+        docker build -t $IMG tomcat/ --build-arg TESTSUITE_TOMCAT_VERSION=$1 \
+                                     --build-arg TESTSUITE_TOMCAT_CONFIG=${2:-server.xml} \
+                                     --build-arg TESTSUITE_TOMCAT_CONTEXT=${3:-context.xml}
+    fi
 }
 
 # Start tomcat$1 container on $2 or 127.0.0.$1 if $2 is not given.

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -29,7 +29,12 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.mod_cluster</groupId>
-            <artifactId>mod_cluster-container-tomcat-8.5</artifactId>
+            <artifactId>mod_cluster-container-tomcat-9.0</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.mod_cluster</groupId>
+            <artifactId>mod_cluster-container-tomcat-10.1</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/test/testsuite.sh
+++ b/test/testsuite.sh
@@ -64,7 +64,7 @@ res=0
 # IMG name might include specific version, we have to handle that
 IMG_NOVER=$(echo $IMG | cut -d: -f1)
 
-for tomcat_version in "8.5" "9.0" "10.1"
+for tomcat_version in "9.0" "10.1"
 do
     IMG="$IMG_NOVER:$tomcat_version" tomcat_create $tomcat_version > /dev/null 2>&1 || exit 3
     IMG="$IMG_NOVER:$tomcat_version" run_test basetests.sh "Basic tests with tomcat $tomcat_version"

--- a/test/tomcat/Dockerfile
+++ b/test/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-ARG TESTSUITE_TOMCAT_VERSION=8.5
+ARG TESTSUITE_TOMCAT_VERSION=10.1
 
 FROM tomcat:${TESTSUITE_TOMCAT_VERSION}
 
@@ -11,6 +11,7 @@ RUN apt update && apt install -y iproute2
 WORKDIR /usr/local/tomcat
 
 COPY target/*.jar ./lib/
+
 COPY $TESTSUITE_TOMCAT_CONFIG  ./conf/server.xml
 COPY $TESTSUITE_TOMCAT_CONTEXT ./conf/context.xml
 COPY start.sh ./

--- a/test/tomcat/start.sh
+++ b/test/tomcat/start.sh
@@ -10,7 +10,12 @@ if [ ! -z ${jvm_route} ]; then
   sed -i "/<Engine name=\"Catalina\"/c\<Engine name=\"Catalina\" defaultHost=\"localhost\" jvmRoute=\"${jvm_route}\">" ./conf/server.xml
 fi
 
-# copy webapp war file.
-mv *.war webapps/ || true
+ls lib/jakartaee-migration-*.jar
+if [ $? = 0 ]; then
+  rm lib/mod_cluster-container-tomcat-9.0-*.Final-SNAPSHOT.jar
+  mkdir webapps-javaee
+else
+  rm lib/mod_cluster-container-tomcat-10.1-*.Final-SNAPSHOT.jar
+fi
 
 bin/catalina.sh run

--- a/test/websocket/basic.sh
+++ b/test/websocket/basic.sh
@@ -19,8 +19,15 @@ tomcat_wait_for_n_nodes 2 || exit 1
 # Now try to test the websocket
 echo "Testing websocket"
 # The websocket-hello app is at: https://github.com/jfclere/httpd_websocket
-docker cp websocket/websocket-hello-0.0.1.war tomcat1:/usr/local/tomcat/webapps
-docker cp websocket/websocket-hello-0.0.1.war tomcat2:/usr/local/tomcat/webapps
+# we must check whether webapps-javaee exists, if yes, we mut use it becuase the app is javax
+docker exec tomcat2 sh -c 'ls webapps-javaee'
+if [ $? = 0 ]; then
+  docker cp websocket/websocket-hello-0.0.1.war tomcat1:/usr/local/tomcat/webapps-javaee
+  docker cp websocket/websocket-hello-0.0.1.war tomcat2:/usr/local/tomcat/webapps-javaee
+else
+  docker cp websocket/websocket-hello-0.0.1.war tomcat1:/usr/local/tomcat/webapps
+  docker cp websocket/websocket-hello-0.0.1.war tomcat2:/usr/local/tomcat/webapps
+fi
 
 # Put the testapp in the  tomcat we restarted.
 docker cp testapp tomcat1:/usr/local/tomcat/webapps


### PR DESCRIPTION
close #226 

Tomcat 10.1 is now the default (as requested by @jfclere ) with some necessary changes made to the tests.