### PR TITLE
ci: Add -Werror and -Wall to trunk and maintainer mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
           for module in advertise/ mod_proxy_cluster/ balancers/ mod_manager/; do \
             cd $module; \
             sh buildconf; \
-            ./configure  --with-apxs=/usr/local/apache2/bin/apxs; \
+            ./configure CFLAGS="-Wall -Werror" --with-apxs=/usr/local/apache2/bin/apxs; \
             make clean; \
             make || exit 1; \
             cd ..; \
@@ -163,7 +163,7 @@ jobs:
           for module in advertise/ mod_proxy_cluster/ balancers/ mod_manager/; do \
             cd $module; \
             sh buildconf; \
-            ./configure  --with-apxs=/usr/local/apache2/bin/apxs; \
+            ./configure CFLAGS="-Wall -Werror" --with-apxs=/usr/local/apache2/bin/apxs; \
             make clean; \
             make || exit 1; \
             cd ..; \


### PR DESCRIPTION
close #230 

It wasn't as straightforward as expected. I did not add it into the cmake option, because for gcc it is the same, and for clang it will fail, because it complains about some apr stuff.