### PR TITLE
ci: Tweak ci so it doesn't run without meaningful changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,19 @@ on:
   push:
     branches:
       - '*'
+    paths:
+      - test/**
+      - native/**
+      - .github/workflows/ci.yml
+      - Doxyfile
   pull_request:
     branches:
       - '*'
+    paths:
+      - test/**
+      - native/**
+      - .github/workflows/ci.yml
+      - Doxyfile
 jobs:
 
   cmake-fedora-latest:


### PR DESCRIPTION
It occurred to me that we run CI on all commits regardless the changes. This PR will cause CI running only if anything within the CI file, or `native/`, `test/` directories changes. 