### PR TITLE
Clear the worker status when reusing cleaned worker

### DIFF
--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -369,6 +369,7 @@ static apr_status_t create_worker_reuse(proxy_server_conf *conf, const char *ptr
     worker->s->was_malloced = 0; /* Prevent mod_proxy to free it */
     helper->isinnodes = 1;
     helper->index = node->mess.id;
+    worker->s->status = 0; /* Reset the status and let ap_proxy_initialize_worker set it */
 
     if ((rv = ap_proxy_initialize_worker(worker, server, conf->pool)) != APR_SUCCESS) {
         ap_log_error(APLOG_MARK, APLOG_ERR, rv, server, "create_worker: ap_proxy_initialize_worker failed %d for %s",


### PR DESCRIPTION
The current behaviour is suspicious. The call to `ap_proxy_initialize_worker` has basically no effect and without this change the connection to backend fails from time to time (when running perf tests with dynamic worker removal) which causes `all workers in error state` (= 503) even though a corresponding node to the worker is up and running.