### PR TITLE
Fix condition in find_node_context_host

### DIFF
--- a/native/common/common.c
+++ b/native/common/common.c
@@ -434,7 +434,7 @@ node_context *find_node_context_host(request_rec *r, const proxy_balancer *balan
             if (node == NULL) {
                 continue;
             }
-            if (strlen(balancer->s->name) > BALANCER_PREFIX_LENGTH &&
+            if (strlen(balancer->s->name) <= BALANCER_PREFIX_LENGTH ||
                 strcasecmp(&balancer->s->name[BALANCER_PREFIX_LENGTH], node->mess.balancer) != 0) {
                 continue;
             }


### PR DESCRIPTION
I believe the current condition is incorrect, because in case of `balancer-s->name` is shorter than the prefix, it gets included for `node->mess.balancer` even though they don't match.

In combination with #267 it prevents 404 when the node is up but without app (yet).