### PR TITLE
Do not accept CMD parameters without a value in manager

### DIFF
--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -1343,6 +1343,11 @@ static char *process_config(request_rec *r, char **ptr, int *errtype)
 
     while (ptr[i]) {
         char *err_msg = NULL;
+        if (ptr[i + 1] && *ptr[i + 1] == '\0') {
+            *errtype = TYPESYNTAX;
+            return SMESPAR;
+        }
+
         /* Balancer part */
         err_msg = process_config_balancer(r, ptr[i], ptr[i + 1], &balancerinfo, &nodeinfo, errtype);
         if (err_msg != NULL) {


### PR DESCRIPTION
e.g. CONFIG msg with `Host=`. This change causes such message to be declined with the same error as is used in 1.3.x.