### PR TITLE
ci: Remove branches '*' when it's the default behaviour

### DIFF
--- a/.github/workflows/ci-ignored-workaround.yml
+++ b/.github/workflows/ci-ignored-workaround.yml
@@ -1,15 +1,11 @@
 name: Skip CI on ignored paths
 on:
   push:
-    branches:
-      - '*'
     paths:
       - '.gitignore'
       - '**.md'
       - 'LICENSE'
   pull_request:
-    branches:
-      - '*'
     paths:
       - '.gitignore'
       - '**.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,11 @@
 name: CI
 on:
   push:
-    branches:
-      - '*'
     paths-ignore:
       - '.gitignore'
       - '**.md'
       - 'LICENSE'
   pull_request:
-    branches:
-      - '*'
     paths-ignore:
       - '.gitignore'
       - '**.md'


### PR DESCRIPTION
Well, that's not completely true. The default behaviour is `'**'`, the single `*` does not match branches with `/` in their name. Fortunately, we are all well behaved and don't use such names. :slightly_smiling_face: 

https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags