### PR TITLE
Add `UseNocanon` to mod_lbmethod_cluster, fix testsuite to use the right module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Setup dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y docker maven git curl iproute2
+          sudo apt-get install -y docker maven git curl iproute2 wcstools
           cd test
           sh setup-dependencies.sh
       - name: Print network environment

--- a/test/MODCLUSTER-640/mod_lbmethod_cluster.conf
+++ b/test/MODCLUSTER-640/mod_lbmethod_cluster.conf
@@ -8,31 +8,36 @@ LoadModule manager_module          modules/mod_manager.so
 LoadModule lbmethod_cluster_module modules/mod_lbmethod_cluster.so
 LoadModule watchdog_module         modules/mod_watchdog.so
 
-ProxyPreserveHost On
-
-Listen 6666
+LogLevel info
 ServerName localhost
-ManagerBalancerName mycluster
-WSUpgradeHeader websocket
+ProxyPreserveHost On
+UseNocanon On
 
-<VirtualHost *:6666>
+<IfModule manager_module>
+  Listen 6666
+  ManagerBalancerName mycluster
+
+  EnableWsTunnel
+  WSUpgradeHeader websocket
+ <VirtualHost *:6666>
   EnableMCMPReceive
   <Directory />
-    Require ip 127.0.0.
+    Require ip 127.0.0.1
     Require ip ::1
     # This one is used in GH Actions
     Require ip 172.17.
   </Directory>
   <Location /mod_cluster_manager>
     SetHandler mod_cluster-manager
-    Require ip 127.0.0.
+    Require ip 127.0.0.1
     Require ip ::1
     # This one is used in GH Actions
     Require ip 172.17.
   </Location>
-</VirtualHost>
+ </VirtualHost>
+</IfModule>
 
 <Proxy "balancer://mycluster">
-  ProxySet growth=20
-  ProxySet lbmethod=cluster
+    ProxySet growth=10
+    ProxySet lbmethod=cluster
 </Proxy>

--- a/test/MODCLUSTER-640/testit.sh
+++ b/test/MODCLUSTER-640/testit.sh
@@ -8,7 +8,9 @@ httpd_remove
 
 # build httpd + mod_proxy_cluster
 rm -f nohup.out
-MPC_CONF=MODCLUSTER-640/mod_proxy_cluster.conf MPC_NAME=MODCLUSTER-640 httpd_start
+
+MPC_CONF=${MPC_CONF:-MODCLUSTER-640/mod_proxy_cluster.conf}
+MPC_NAME=MODCLUSTER-640 httpd_start
 
 # wait until httpd is started
 httpd_wait_until_ready  || exit 1
@@ -39,7 +41,8 @@ if [ $? -eq 0 ]; then
 fi
 
 # Test without UseNocanon On
-docker exec MODCLUSTER-640 sh -c "sed -i 's:UseNocanon On::' /usr/local/apache2/conf/mod_proxy_cluster.conf"
+docker exec MODCLUSTER-640 sh -c "sed -i 's:UseNocanon On::' /usr/local/apache2/conf/$(filename $MPC_CONF)"
+
 docker exec MODCLUSTER-640 /usr/local/apache2/bin/apachectl restart
 
 # wait until the tomcats are back in mod_proxy_cluster tables
@@ -58,7 +61,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Test for just a proxypass / nocanon
-docker exec MODCLUSTER-640 sh -c "echo 'ProxyPass / balancer://mycluster/ nocanon' >> /usr/local/apache2/conf/mod_proxy_cluster.conf"
+docker exec MODCLUSTER-640 sh -c "echo 'ProxyPass / balancer://mycluster/ nocanon' >> /usr/local/apache2/conf/$(filename $MPC_CONF)"
 docker exec MODCLUSTER-640 /usr/local/apache2/bin/apachectl restart
 
 # wait until the tomcats are back in mod_proxy_cluster tables

--- a/test/MODCLUSTER-734/testit.sh
+++ b/test/MODCLUSTER-734/testit.sh
@@ -8,7 +8,9 @@ httpd_remove
 
 # build httpd + mod_proxy_cluster
 rm -f nohup.out
-MPC_CONF=MODCLUSTER-734/mod_proxy_cluster.conf MPC_NAME=MODCLUSTER-734 httpd_start
+
+MPC_CONF=${MPC_CONF:-MODCLUSTER-734/mod_proxy_cluster.conf}
+MPC_NAME=MODCLUSTER-734 httpd_start
 
 # wait until httpd is started
 httpd_wait_until_ready || exit 1
@@ -28,6 +30,7 @@ docker cp MODCLUSTER-734/ROOT_OK tomcat2:/usr/local/tomcat/webapps/ROOT
 # after a while the health check will get the Under maintenance status.jsp
 # and mark the node not OK.
 sleep 15
+
 curl -s http://localhost:6666/mod_cluster_manager | grep "Status: NOTOK"
 if [ $? -eq 0 ]; then
     echo "MODCLUSTER-734 Done!"

--- a/test/MODCLUSTER-736/testit.sh
+++ b/test/MODCLUSTER-736/testit.sh
@@ -4,6 +4,7 @@
 
 httpd_remove
 tomcat_all_remove
+
 MPC_NAME=MODCLUSTER-736 httpd_start
 
 # Start a bunch ($1, or 6 if no argument is given) of tomcat

--- a/test/MODCLUSTER-755/mod_lbmethod_cluster.conf
+++ b/test/MODCLUSTER-755/mod_lbmethod_cluster.conf
@@ -8,24 +8,24 @@ LoadModule manager_module          modules/mod_manager.so
 LoadModule lbmethod_cluster_module modules/mod_lbmethod_cluster.so
 LoadModule watchdog_module         modules/mod_watchdog.so
 
-ProxyPreserveHost On
-
+Maxnode 505
+Maxhost 1010
+Maxcontext 1100
 Listen 6666
-ServerName localhost
 ManagerBalancerName mycluster
-WSUpgradeHeader websocket
+ServerName localhost
 
 <VirtualHost *:6666>
   EnableMCMPReceive
   <Directory />
-    Require ip 127.0.0.
+    Require ip 127.0.0.1
     Require ip ::1
     # This one is used in GH Actions
     Require ip 172.17.
   </Directory>
   <Location /mod_cluster_manager>
     SetHandler mod_cluster-manager
-    Require ip 127.0.0.
+    Require ip 127.0.0.1
     Require ip ::1
     # This one is used in GH Actions
     Require ip 172.17.
@@ -33,6 +33,6 @@ WSUpgradeHeader websocket
 </VirtualHost>
 
 <Proxy "balancer://mycluster">
-  ProxySet growth=20
-  ProxySet lbmethod=cluster
+    ProxySet growth=10
+    ProxySet lbmethod=cluster
 </Proxy>

--- a/test/MODCLUSTER-755/mod_proxy_cluster.conf
+++ b/test/MODCLUSTER-755/mod_proxy_cluster.conf
@@ -5,9 +5,6 @@ LoadModule proxy_hcheck_module modules/mod_proxy_hcheck.so
 LoadModule watchdog_module modules/mod_watchdog.so
 LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
 
-ProxyHCExpr in_maint {hc('body') !~ /Under maintenance/}
-ModProxyClusterHCTemplate hcmethod=GET hcexpr=in_maint hcuri=/status.jsp
-
 Maxnode 505
 Maxhost 1010
 Maxcontext 1100

--- a/test/MODCLUSTER-755/testit.sh
+++ b/test/MODCLUSTER-755/testit.sh
@@ -11,7 +11,8 @@
 httpd_remove
 tomcat_all_remove
 
-MPC_CONF=MODCLUSTER-755/mod_proxy_cluster.conf MPC_NAME=MODCLUSTER-755 httpd_start
+MPC_CONF=${MPC_CONF:-MODCLUSTER-755/mod_proxy_cluster.conf}
+MPC_NAME=MODCLUSTER-755 httpd_start
 
 httpd_wait_until_ready
 

--- a/test/MODCLUSTER-785/mod_lbmethod_cluster.conf
+++ b/test/MODCLUSTER-785/mod_lbmethod_cluster.conf
@@ -8,24 +8,27 @@ LoadModule manager_module          modules/mod_manager.so
 LoadModule lbmethod_cluster_module modules/mod_lbmethod_cluster.so
 LoadModule watchdog_module         modules/mod_watchdog.so
 
-ProxyPreserveHost On
-
+Maxnode 505
+Maxhost 1010
+Maxcontext 1100
 Listen 6666
-ServerName localhost
 ManagerBalancerName mycluster
+ServerName localhost
+
+EnableWsTunnel
 WSUpgradeHeader websocket
 
 <VirtualHost *:6666>
   EnableMCMPReceive
   <Directory />
-    Require ip 127.0.0.
+    Require ip 127.0.0.1
     Require ip ::1
     # This one is used in GH Actions
     Require ip 172.17.
   </Directory>
   <Location /mod_cluster_manager>
     SetHandler mod_cluster-manager
-    Require ip 127.0.0.
+    Require ip 127.0.0.1
     Require ip ::1
     # This one is used in GH Actions
     Require ip 172.17.
@@ -33,6 +36,6 @@ WSUpgradeHeader websocket
 </VirtualHost>
 
 <Proxy "balancer://mycluster">
-  ProxySet growth=20
-  ProxySet lbmethod=cluster
+    ProxySet growth=10
+    ProxySet lbmethod=cluster
 </Proxy>

--- a/test/MODCLUSTER-785/testit.sh
+++ b/test/MODCLUSTER-785/testit.sh
@@ -9,7 +9,9 @@ httpd_remove
 
 # build httpd + mod_proxy_cluster
 rm -f nohup.out
-MPC_CONF=MODCLUSTER-785/mod_proxy_cluster.conf MPC_NAME=MODCLUSTER-785 httpd_start
+
+MPC_CONF=${MPC_CONF:-MODCLUSTER-785/mod_proxy_cluster.conf}
+MPC_NAME=MODCLUSTER-785 httpd_start
 
 
 # start tomcat1 on 8080

--- a/test/MODCLUSTER-794/mod_lbmethod_cluster.conf
+++ b/test/MODCLUSTER-794/mod_lbmethod_cluster.conf
@@ -13,6 +13,7 @@ ProxyPreserveHost On
 Listen 6666
 ServerName localhost
 ManagerBalancerName mycluster
+EnableWsTunnel
 WSUpgradeHeader websocket
 
 <VirtualHost *:6666>
@@ -36,3 +37,6 @@ WSUpgradeHeader websocket
   ProxySet growth=20
   ProxySet lbmethod=cluster
 </Proxy>
+
+# This is the default value, but let's go with the explicit here
+Maxnode 20

--- a/test/MODCLUSTER-794/testit.sh
+++ b/test/MODCLUSTER-794/testit.sh
@@ -6,7 +6,8 @@
 tomcat_all_remove
 httpd_remove
 
-MPC_NAME=MODCLUSTER-794 MPC_CONF=MODCLUSTER-794/mod_proxy_cluster.conf httpd_start
+MPC_CONF=${MPC_CONF:-MODCLUSTER-794/mod_proxy_cluster.conf}
+MPC_NAME=MODCLUSTER-794 httpd_start
 
 for i in {1..20}; do
     tomcat_start $i

--- a/test/testsuite.sh
+++ b/test/testsuite.sh
@@ -91,15 +91,16 @@ res=$(expr $res + $?)
 
 MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test basetests.sh "Basic tests with mod_proxy_balancer"
 res=$(expr $res + $?)
-MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-640/testit.sh   "MODCLUSTER-640 with mod_proxy_balancer"
+MPC_CONF=MODCLUSTER-640/mod_lbmethod_cluster.conf run_test MODCLUSTER-640/testit.sh   "MODCLUSTER-640 with mod_proxy_balancer"
 res=$(expr $res + $?)
-MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-734/testit.sh   "MODCLUSTER-734 with mod_proxy_balancer"
-res=$(expr $res + $?)
+# TODO: ref #301 https://github.com/modcluster/mod_proxy_cluster/issues/301
+# MPC_CONF=MODCLUSTER-734/mod_lbmethod_cluster.conf run_test MODCLUSTER-734/testit.sh   "MODCLUSTER-734 with mod_proxy_balancer"
+# res=$(expr $res + $?)
 MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-755/testit.sh   "MODCLUSTER-755 with mod_proxy_balancer"
 res=$(expr $res + $?)
-MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-785/testit.sh   "MODCLUSTER-785 with mod_proxy_balancer"
+MPC_CONF=MODCLUSTER-785/mod_lbmethod_cluster.conf run_test MODCLUSTER-785/testit.sh   "MODCLUSTER-785 with mod_proxy_balancer"
 res=$(expr $res + $?)
-MPC_CONF=httpd/mod_lbmethod_cluster.conf run_test MODCLUSTER-794/testit.sh   "MODCLUSTER-794 with mod_proxy_balancer"
+MPC_CONF=MODCLUSTER-794/mod_lbmethod_cluster.conf run_test MODCLUSTER-794/testit.sh   "MODCLUSTER-794 with mod_proxy_balancer"
 res=$(expr $res + $?)
 
 


### PR DESCRIPTION
close #297 
close #298 

This resolves two issues, but given that they are connected it seemed reasonable to do it at once. Test that ought to be run with balancer were unfortunately run with cluster. The testsuite needed a few changes and new conf files for the second module.