### PR TITLE
ci: Run maintainer-mode job on the latest and the oldest supported httpd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,12 @@ jobs:
 
   make-httpd-maintainer-mode:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image-tag: [ "latest", "oldest-supported" ]
     container:
-      image: quay.io/mod_cluster/ci-httpd-dev
+      image: quay.io/mod_cluster/ci-httpd-dev:${{ matrix.image-tag }}
     defaults:
       run:
         shell: bash
@@ -114,6 +118,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Print httpd version
+        run: echo $HTTPD_VERSION
       - name: Build
         run: |
           cd native


### PR DESCRIPTION
close #321 

The solution uses a new container image (it's [the same one](https://github.com/modcluster/ci.modcluster.io/tree/main/httpd-dev) we already use but with a different version of httpd – 2.4.53). This image will be managed manually as the rebuild is necessary only in case the oldest supported version changes.

edit: Adding link https://quay.io/repository/mod_cluster/ci-httpd-dev?tab=tags