### PR TITLE
test: Add timeout for curls, minor syntax tweaks

### DIFF
--- a/test/MODCLUSTER-640/testit.sh
+++ b/test/MODCLUSTER-640/testit.sh
@@ -29,12 +29,12 @@ docker cp MODCLUSTER-640/webapp1 tomcat2:/usr/local/tomcat/webapps/webapp1
 sleep 12
 
 # test the URL
-code=$(/usr/bin/curl -o /dev/null --silent --write-out '%{http_code}' http://localhost:8000/webapp1/index.html)
+code=$(/usr/bin/curl -o /dev/null -s -m 20 --write-out '%{http_code}' http://localhost:8000/webapp1/index.html)
 if [ "${code}" != "200" ]; then
     echo "nocanon test failed, we get ${code} on http://localhost:8000/webapp1/index.html"
     exit 1
 fi
-curl -v "http://localhost:8000/webapp1/jsr%3aroot/toto" | grep "jsr:root"
+curl -v -m 20 "http://localhost:8000/webapp1/jsr%3aroot/toto" | grep "jsr:root"
 if [ $? -eq 0 ]; then
     echo "nocanon test failed, we get \"jsr:root\"!!!"
     exit 1
@@ -49,12 +49,12 @@ docker exec MODCLUSTER-640 /usr/local/apache2/bin/apachectl restart
 tomcat_wait_for_n_nodes 2
 
 # test the URL
-code=$(/usr/bin/curl -o /dev/null --silent --write-out '%{http_code}' http://localhost:8000/webapp1/index.html)
+code=$(/usr/bin/curl -o /dev/null -s -m 20 --write-out '%{http_code}' http://localhost:8000/webapp1/index.html)
 if [ "${code}" != "200" ]; then
     echo "nocanon test failed, we get ${code} on http://localhost:8000/webapp1/index.html"
     exit 1
 fi
-curl -v "http://localhost:8000/webapp1/jsr%3aroot/toto" | grep "jsr:root"
+curl -v -m 20 "http://localhost:8000/webapp1/jsr%3aroot/toto" | grep "jsr:root"
 if [ $? -ne 0 ]; then
     echo "NO nocanon test failed, we don't get \"jsr:root\"!!!"
     exit 1
@@ -68,12 +68,12 @@ docker exec MODCLUSTER-640 /usr/local/apache2/bin/apachectl restart
 tomcat_wait_for_n_nodes 2
 
 # test the URL
-code=$(/usr/bin/curl -o /dev/null --silent --write-out '%{http_code}' http://localhost:8000/webapp1/index.html)
+code=$(/usr/bin/curl -o /dev/null -s -m 20 --write-out '%{http_code}' http://localhost:8000/webapp1/index.html)
 if [ "${code}" != "200" ]; then
     echo "nocanon test failed, we get ${code} on http://localhost:8000/webapp1/index.html"
     exit 1
 fi
-curl -v "http://localhost:8000/webapp1/jsr%3aroot/toto" | grep "jsr:root"
+curl -v -m 20 "http://localhost:8000/webapp1/jsr%3aroot/toto" | grep "jsr:root"
 if [ $? -eq 0 ]; then
     echo "nocanon test failed, we get \"jsr:root\"!!!"
     tomcat_all_remove

--- a/test/MODCLUSTER-734/testit.sh
+++ b/test/MODCLUSTER-734/testit.sh
@@ -31,7 +31,7 @@ docker cp MODCLUSTER-734/ROOT_OK tomcat2:/usr/local/tomcat/webapps/ROOT
 # and mark the node not OK.
 sleep 15
 
-curl -s http://localhost:6666/mod_cluster_manager | grep "Status: NOTOK"
+curl -s -m 20 http://localhost:6666/mod_cluster_manager | grep "Status: NOTOK"
 if [ $? -eq 0 ]; then
     echo "MODCLUSTER-734 Done!"
 else

--- a/test/MODCLUSTER-736/testit.sh
+++ b/test/MODCLUSTER-736/testit.sh
@@ -89,7 +89,7 @@ singlecycle() {
     i=0
     while true
     do
-        curl -s http://localhost:6666/mod_cluster_manager | grep Node | grep tomcat$1 > /dev/null
+        curl -s -m 20 http://localhost:6666/mod_cluster_manager | grep Node | grep tomcat$1 > /dev/null
         if [ $? -eq 0 ]; then
             break
         fi
@@ -106,7 +106,7 @@ singlecycle() {
     i=0
     while true
     do
-        curl -s http://localhost:6666/mod_cluster_manager | grep /tomcat$1 > /dev/null
+        curl -s -m 20 http://localhost:6666/mod_cluster_manager | grep /tomcat$1 > /dev/null
         if [ $? -eq 0 ]; then
             break
         fi
@@ -126,7 +126,7 @@ singlecycle() {
     tomcat_shutdown $1 127.0.0.$R || exit 1
     while true
     do
-        curl -s http://localhost:6666/mod_cluster_manager | grep Node | grep tomcat$1 > /dev/null
+        curl -s -m 20 http://localhost:6666/mod_cluster_manager | grep Node | grep tomcat$1 > /dev/null
         if [ $? -ne 0 ]; then
             break
         fi

--- a/test/MODCLUSTER-785/testit.sh
+++ b/test/MODCLUSTER-785/testit.sh
@@ -25,7 +25,7 @@ docker cp MODCLUSTER-785/app tomcat1:/usr/local/tomcat/webapps/app
 
 # check that the app is answering
 sleep 15
-curl -s http://localhost:8000/app/status.jsp | grep "785"
+curl -s -m 20 http://localhost:8000/app/status.jsp | grep "785"
 if [ $? -ne 0 ]; then
   echo "MODCLUSTER-785 Failed!"
   exit 1
@@ -37,7 +37,7 @@ tomcat_remove 1
 # it return 503
 # make sure we use enough workers
 ab -c 10 -n100 http://localhost:8000/app/
-http_code=`curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/app/`
+http_code=$(curl -s -m 20 -o /dev/null -w "%{http_code}" http://localhost:8000/app/)
 if [ ${http_code} != 503 ]; then
   echo "MODCLUSTER-785 Failed! not 503 but ${http_code}"
   exit 1
@@ -57,16 +57,16 @@ sleep 15
 
 # check that the app is answering
 # does it return 503
-http_code=`curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/app/status.jsp`
+http_code=$(curl -s -m 20 -o /dev/null -w "%{http_code}" http://localhost:8000/app/status.jsp)
 i=0
 while true
 do
   sleep 1
-  http_code=`curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/app/status.jsp`
+  http_code=$(curl -s -m 20 -o /dev/null -w "%{http_code}" http://localhost:8000/app/status.jsp)
   if [ ${http_code} == 200 ]; then
     break
   fi
-  i=`expr $i + 1`
+  i=$(expr $i + 1)
   if [ $i -gt 60 ]; then
     break
   fi
@@ -86,12 +86,12 @@ i=0
 while true
 do
   sleep 1
-  http_code=`curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/app/status.jsp`
+  http_code=$(curl -s -m 20 -o /dev/null -w "%{http_code}" http://localhost:8000/app/status.jsp)
   if [ ${http_code} == 503 ]; then
     echo "MODCLUSTER-785 Failed! return 503"
     exit 1
   fi
-  i=`expr $i + 1`
+  i=$(expr $i + 1)
   if [ $i -gt 60 ]; then
     break
   fi

--- a/test/basetests.sh
+++ b/test/basetests.sh
@@ -20,12 +20,12 @@ sleep 12
 
 # Basic 200 and 404 tests.
 echo "basic 200 and 404 tests"
-CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/testapp/test.jsp)
+CODE=$(curl -s -m 20 -o /dev/null -w "%{http_code}" http://localhost:8000/testapp/test.jsp)
 if [ ${CODE} != "200" ]; then
   echo "Failed can't reach webapp: ${CODE}"
   exit 1
 fi
-CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/testapp/toto.jsp)
+CODE=$(curl -s -m 20 -o /dev/null -w "%{http_code}" http://localhost:8000/testapp/toto.jsp)
 if [ ${CODE} != "404" ]; then
   echo "Failed should get 404"
   exit 1

--- a/test/curlloop.sh
+++ b/test/curlloop.sh
@@ -11,7 +11,7 @@ done
 while true
 do
   found=0
-  http_code=`curl -s -m10 -o /dev/null -w "%{http_code}" http://localhost:8000/testapp/test.jsp`
+  http_code=$(curl -s -m 10 -o /dev/null -w "%{http_code}" http://localhost:8000/testapp/test.jsp)
   for var in "$@"
   do 
     if [ "${http_code}" -eq "${var}" ]; then
@@ -20,7 +20,7 @@ do
     fi
   done
   if [ ${found} -eq 0 ]; then
-    echo "ERROR got: ${http_code} expects one of ${codes} `date`"
+    echo "ERROR got: ${http_code} expects one of ${codes} $(date)"
     exit 1
   fi
 

--- a/test/includes/common.sh
+++ b/test/includes/common.sh
@@ -76,7 +76,7 @@ httpd_start() {
 
 httpd_wait_until_ready() {
     local i=0
-    curl localhost:6666 > /dev/null 2>&1
+    curl -m 20 localhost:6666 > /dev/null 2>&1
     while [ $? != 0 ];
     do
         i=$(expr $i + 1)
@@ -85,7 +85,7 @@ httpd_wait_until_ready() {
             exit 1;
         fi
         sleep 10;
-        curl localhost:6666 > /dev/null 2>&1
+        curl -m 20 localhost:6666 > /dev/null 2>&1
     done
     echo "httpd ready after $i attempts"
 }
@@ -166,7 +166,7 @@ tomcat_start() {
 # Wait until there are $1 nodes in OK state (i.e., some will start or go away if the count is different)
 tomcat_wait_for_n_nodes() {
     nodes=${1:-0}
-    curl -s http://localhost:6666/mod_cluster_manager -o /dev/null
+    curl -s http://localhost:6666/mod_cluster_manager -m 20 -o /dev/null
     if [ $? -ne 0 ]; then
         echo "httpd isn't running or something is VERY wrong"
         exit 1
@@ -175,7 +175,7 @@ tomcat_wait_for_n_nodes() {
     i=0
     while [ ${NBNODES} != ${nodes} ]
     do
-        NBNODES=$(curl -s http://localhost:6666/mod_cluster_manager | grep "Status: OK" | awk ' { print $3} ' | wc -l)
+        NBNODES=$(curl -s http://localhost:6666/mod_cluster_manager -m 20 | grep "Status: OK" | awk ' { print $3} ' | wc -l)
         sleep 10
         echo "Waiting for ${nodes} node to be ready: $(date)"
         i=$(expr $i + 1)
@@ -184,7 +184,7 @@ tomcat_wait_for_n_nodes() {
             exit 1
         fi
     done
-    curl -s http://localhost:6666/mod_cluster_manager -o /dev/null
+    curl -s http://localhost:6666/mod_cluster_manager -m 20 -o /dev/null
     if [ $? -ne 0 ]; then
         echo "httpd isn't running or something VERY wrong"
         exit 1
@@ -298,7 +298,7 @@ tomcat_all_run_ab() {
 
 # Test whether the webapp is working (responding)
 tomcat_test_app() {
-    CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/tomcat$1/test.jsp)
+    CODE=$(curl -s -o /dev/null -m 20 -w "%{http_code}" http://localhost:8000/tomcat$1/test.jsp)
     if [ ${CODE} != "200" ]; then
         echo "Failed can't reach tomcat$1: ${CODE}"
         exit 1

--- a/test/maintests.sh
+++ b/test/maintests.sh
@@ -29,13 +29,13 @@ sleep 12
 
 # Sticky (yes, there is only one app!!!)
 echotestlabel "sticky one app"
-SESSIONCO=$(curl -v http://localhost:8000/testapp/test.jsp -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
+SESSIONCO=$(curl -v http://localhost:8000/testapp/test.jsp -m 20 -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
 if [ "${SESSIONCO}" == "" ];then
   echo "Failed no sessionid in curl output..."
   curl -v http://localhost:8000/testapp/test.jsp
 fi
 echo ${SESSIONCO}
-NEWCO=$(curl -v --cookie "${SESSIONCO}" http://localhost:8000/testapp/test.jsp -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
+NEWCO=$(curl -v --cookie "${SESSIONCO}" http://localhost:8000/testapp/test.jsp -m 20 -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
 if [ "${NEWCO}" != "" ]; then
   echo "Failed not sticky received : ${NEWCO}???"
   exit 1
@@ -47,17 +47,17 @@ sleep 12
 
 # Sticky (yes there are 2 apps now)
 echotestlabel "sticky 2 app"
-SESSIONCO=$(curl -v http://localhost:8000/testapp/test.jsp -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
+SESSIONCO=$(curl -v http://localhost:8000/testapp/test.jsp -m 20 -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
 NODE=$(echo ${SESSIONCO} | awk -F = '{ print $2 }' | awk -F . '{ print $2 }')
 echo "first: ${SESSIONCO} node: ${NODE}"
-NEWCO=$(curl -v http://localhost:8000/testapp/test.jsp -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
+NEWCO=$(curl -v http://localhost:8000/testapp/test.jsp -m 20 -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
 NEWNODE=$(echo ${NEWCO} | awk -F = '{ print $2 }' | awk -F . '{ print $2 }')
 echo "second: ${NEWCO} node: ${NEWNODE}"
 echo "Checking we can reach the 2 nodes"
 i=0
 while [ "${NODE}" == "${NEWNODE}" ]
 do
-  NEWCO=$(curl -v http://localhost:8000/testapp/test.jsp -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
+  NEWCO=$(curl -v http://localhost:8000/testapp/test.jsp -m 20 -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
   NEWNODE=$(echo ${NEWCO} | awk -F = '{ print $2 }' | awk -F . '{ print $2 }')
   i=$(expr $i + 1)
   if [ $i -gt 40 ]; then
@@ -73,12 +73,12 @@ done
 echo "${i} try gives: ${NEWCO} node: ${NEWNODE}"
 
 # Still sticky
-CO=$(curl -v --cookie "${SESSIONCO}" http://localhost:8000/testapp/test.jsp -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
+CO=$(curl -v --cookie "${SESSIONCO}" http://localhost:8000/testapp/test.jsp -m 20 -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
 if [ "${CO}" != "" ]; then
   echo "Failed not sticky received : ${CO}???"
   exit 1
 fi
-CO=$(curl -v --cookie "${NEWCO}" http://localhost:8000/testapp/test.jsp -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
+CO=$(curl -v --cookie "${NEWCO}" http://localhost:8000/testapp/test.jsp -m 20 -o /dev/null 2>&1 | grep Set-Cookie | awk '{ print $3 } ' | sed 's:;::')
 if [ "${CO}" != "" ]; then
   echo "Failed not sticky received : ${CO}???"
   exit 1
@@ -88,7 +88,7 @@ fi
 echotestlabel "sticky: stopping one node and doing requests..."
 NODE=$(echo ${NEWCO} | awk -F = '{ print $2 }' | awk -F . '{ print $2 }')
 echo $NODE
-PORT=$(curl http://localhost:6666/mod_cluster_manager | grep Node | grep $NODE | sed 's:)::' | awk -F : '{ print $3 } ')
+PORT=$(curl http://localhost:6666/mod_cluster_manager -m 20 | grep Node | grep $NODE | sed 's:)::' | awk -F : '{ print $3 } ')
 NAME=$(expr ${PORT} - 8080 + 1)
 echo "Will stop tomcat$NAME corresponding to ${NODE} and cookie: ${NEWCO}"
 CODE="200"
@@ -99,7 +99,7 @@ do
     echo "Done remaining tomcat still answering!"
     break
   fi
-  CODE=$(curl -s -o /dev/null -w "%{http_code}" --cookie "${NEWCO}" http://localhost:8000/testapp/test.jsp)
+  CODE=$(curl -s -o /dev/null -m 20 -w "%{http_code}" --cookie "${NEWCO}" http://localhost:8000/testapp/test.jsp)
   if [ $i -eq 0 ]; then
     # stop the tomcat
     echo "tomcat${NAME} being stopped"
@@ -109,7 +109,7 @@ do
 done
 if [ ${CODE} != "200" ]; then
   echo "Something was wrong... got: ${CODE}"
-  curl -v --cookie "${NEWCO}" http://localhost:8000/testapp/test.jsp
+  curl -v --cookie "${NEWCO}" -m 20 http://localhost:8000/testapp/test.jsp
   exit 1
 fi
 
@@ -148,25 +148,25 @@ tomcat_wait_for_n_nodes 2  || exit 1
 # X-Forwarded-Server: fe80::faf4:935b:9dda:2adf
 # therefore don't forget ProxyPreserveHost On (otherwise UseAlias On failed...)
 #
-CODE=$(curl -s -o /dev/null -w "%{http_code}" --header "Host: example.com" http://127.0.0.1:8000/test/test.jsp)
+CODE=$(curl -s -o /dev/null -m 20 -w "%{http_code}" --header "Host: example.com" http://127.0.0.1:8000/test/test.jsp)
 if [ ${CODE} != "200" ]; then
   echo "Failed can't rearch webapp at example.com: ${CODE}"
   exit 1
 fi
 # Basically curl --header "Host: localhost" http://127.0.0.1:8000/test/test.jsp gives 400
-CODE=$(curl -s -o /dev/null -w "%{http_code}" --header "Host: localhost" http://127.0.0.1:8000/test/test.jsp)
+CODE=$(curl -s -o /dev/null -m 20 -w "%{http_code}" --header "Host: localhost" http://127.0.0.1:8000/test/test.jsp)
 if [ ${CODE} != "404" ]; then
   echo "Failed should NOT rearch webapp at localhost: ${CODE}"
   exit 1
 fi
 # Same using localhost/testapp2 and curl --header "Host: localhost" http://127.0.0.1:8000/testapp2/test.jsp
-CODE=$(curl -s -o /dev/null -w "%{http_code}" --header "Host: localhost" http://127.0.0.1:8000/testapp2/test.jsp)
+CODE=$(curl -s -o /dev/null -m 20 -w "%{http_code}" --header "Host: localhost" http://127.0.0.1:8000/testapp2/test.jsp)
 if [ ${CODE} != "200" ]; then
   echo "Failed can't rearch webapp at localhost: ${CODE}"
   exit 1
 fi
 # Basically curl --header "Host: example.com" http://127.0.0.1:8000/testapp2/test.jsp gives 400
-CODE=$(curl -s -o /dev/null -w "%{http_code}" --header "Host: example.com" http://127.0.0.1:8000/testapp2/test.jsp)
+CODE=$(curl -s -o /dev/null -m 20 -w "%{http_code}" --header "Host: example.com" http://127.0.0.1:8000/testapp2/test.jsp)
 if [ ${CODE} != "404" ]; then
   echo "Failed should NOT rearch webapp at localhost: ${CODE}"
   exit 1


### PR DESCRIPTION
With a timeout set, tests shouldn't get stuck waiting for a response.

Also I've changed `\`...\`` to `$(...)` syntax on a few places to be consistent with the rest.

close #326 