### PR TITLE
Fix handling of duplicite MCMP command parameters 

### DIFF
--- a/test-perl/t/issues/GH-issue-329.t
+++ b/test-perl/t/issues/GH-issue-329.t
@@ -1,0 +1,105 @@
+# Before 'make install' is performed this script should be runnable with
+# 'make test'. After 'make install' it should work as 'perl Apache-ModProxyCluster.t'
+#########################
+
+use strict;
+use warnings;
+
+use Apache::Test;
+use Apache::TestUtil;
+use Apache::TestConfig;
+
+use HTTP::Request;
+use LWP::UserAgent;
+
+use ModProxyCluster;
+
+plan tests => 27;
+
+Apache::TestRequest::module("mpc_test_host");
+my $hostport = Apache::TestRequest::hostport();
+
+my $url = "http://$hostport/";
+
+# needed in order to send the same parameter twice
+sub CMD_internal {
+	my ($cmd, $url, $params) = @_;
+	my $header = [];
+
+	my $ua = LWP::UserAgent->new();
+	my $request = HTTP::Request->new($cmd, $url, $header, $params);
+
+	return $ua->request($request);
+}
+
+my $resp = CMD 'CONFIG', $url, ( JVMRoute => "issue-329", Context => "/news,/test", Alias => "testalias,example" );
+ok $resp->is_success;
+
+
+$resp = CMD 'INFO', $url;
+ok $resp->is_success;
+my %p = parse_response 'INFO', $resp->content;
+
+ok(@{$p{Nodes}} == 1);
+
+ok (@{$p{Contexts}} == 2);
+ok ($p{Contexts}->[0]{Context} eq '/news');
+ok ($p{Contexts}->[1]{Context} eq '/test');
+
+ok (@{$p{Hosts}} == 2);
+ok ($p{Hosts}->[0]{Alias} eq 'testalias');
+ok ($p{Hosts}->[1]{Alias} eq 'example');
+
+# Clean after yourself
+CMD 'REMOVE-APP', "$url/*", ( JVMRoute => 'issue-329' );
+sleep 25; # just to make sure we'll have enough time to get it removed
+
+#################################################
+### THIS SHOULD BE EQUIVALENT TO THE PREVIOUS ###
+#################################################
+
+$resp = CMD_internal 'CONFIG', $url, "JVMRoute=issue-329&Alias=testalias&Context=/news,/test&Alias=example";
+ok $resp->is_success;
+
+$resp = CMD 'INFO', $url;
+ok $resp->is_success;
+%p = parse_response 'INFO', $resp->content;
+
+ok(@{$p{Nodes}} == 1);
+
+ok (@{$p{Contexts}} == 2);
+ok ($p{Contexts}->[0]{Context} eq '/news');
+ok ($p{Contexts}->[1]{Context} eq '/test');
+
+ok (@{$p{Hosts}} == 2);
+ok ($p{Hosts}->[0]{Alias} eq 'testalias');
+ok ($p{Hosts}->[1]{Alias} eq 'example');
+
+# Clean after yourself
+CMD 'REMOVE-APP', "$url/*", ( JVMRoute => 'issue-329' );
+sleep 25; # just to make sure we'll have enough time to get it removed
+
+#################################################
+### THIS SHOULD BE EQUIVALENT AS THE ALIAS IS ###
+#################################################
+$resp = CMD_internal 'CONFIG', $url, "JVMRoute=issue-329&Alias=testalias&Context=/news&Alias=example&Context=/test";
+ok $resp->is_success;
+
+
+$resp = CMD 'INFO', $url;
+ok $resp->is_success;
+%p = parse_response 'INFO', $resp->content;
+
+ok(@{$p{Nodes}} == 1);
+
+ok (@{$p{Contexts}} == 2);
+ok ($p{Contexts}->[0]{Context} eq '/news');
+ok ($p{Contexts}->[1]{Context} eq '/test');
+
+ok (@{$p{Hosts}} == 2);
+ok ($p{Hosts}->[0]{Alias} eq 'testalias');
+ok ($p{Hosts}->[1]{Alias} eq 'example');
+
+# Clean after yourself
+CMD 'REMOVE-APP', "$url/*", ( JVMRoute => 'issue-329' );
+sleep 25; # just to make sure we'll have enough time to get it removed

--- a/test-perl/t/mod_proxy_cluster/messages_config_nok.t
+++ b/test-perl/t/mod_proxy_cluster/messages_config_nok.t
@@ -10,7 +10,6 @@ use Apache::TestUtil;
 use Apache::TestConfig;
 use Apache::TestRequest 'GET';
 
-# use Test::More;
 use ModProxyCluster;
 
 plan tests => 70;
@@ -36,7 +35,8 @@ $resp = CMD 'CONFIG', $url;
 ok $resp->is_error;
 ok ($resp->content ne "");
 ok ($resp->header("Type") eq "SYNTAX");
-ok ($resp->header("Mess") eq "SYNTAX: JVMRoute can't be empty");
+# ok ($resp->header("Mess") eq "SYNTAX: JVMRoute can't be empty");
+ok ($resp->header("Mess") eq "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements.");
 
 ## Empty JVMRoute
 $resp = CMD 'CONFIG', $url, ( JVMRoute => '' );
@@ -44,8 +44,9 @@ $resp = CMD 'CONFIG', $url, ( JVMRoute => '' );
 ok $resp->is_error;
 ok ($resp->content ne "");
 ok ($resp->header("Type") eq "SYNTAX");
-# ok ($resp->header("Mess") eq "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements.");
-ok ($resp->header("Mess") eq "SYNTAX: JVMRoute can't be empty");
+ok ($resp->header("Mess") eq "SYNTAX: Can't parse MCMP message. It might have contained illegal symbols or unknown elements.");
+# TODO: Revisit this one
+# ok ($resp->header("Mess") eq "SYNTAX: JVMRoute can't be empty");
 
 # LIMITS
 ## Alias


### PR DESCRIPTION
This addresses #329 and adds additional tests for it. However, there is an error message change for which I opened #330. (tl;dr This unifies the behaviour of 2.x with 1.3.x but both are inaccurate.)