### PR TITLE
Run some jobs on ARM runners as well

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,12 @@ jobs:
 
   cmake-fedora-latest:
     name: cmake-fedora-latest
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
-      matrix:
-        compiler: [ gcc, clang ]
+        fail-fast: false
+        matrix:
+            compiler: [ gcc, clang ]
+            os: [ ubuntu-latest, ubuntu-24.04-arm ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +43,10 @@ jobs:
           podman build .
 
   make-fedora-latest:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ ubuntu-latest, ubuntu-24.04-arm ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -188,7 +192,10 @@ jobs:
           retention-days: 0 
 
   cmake-windows-latest:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+        matrix:
+            os: [ windows-latest, windows-11-arm ]
     env:
       APACHE_LOUNGE_DISTRO_VERSION: 2.4.63-250122
       HTTPD_DEV_HOME: 'C:\Apache24'
@@ -220,7 +227,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: Windows logs
+          name: Windows logs for ${{ matrix.os }}
           path: C:\Apache24\logs\
           retention-days: 7
 


### PR DESCRIPTION
GitHub recently added ARM runners.

https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

They are still in preview, so they may change in the future, but I guess we can always fix or remove it...