### PR TITLE
Fix compile warnings on clang and includes + minor tweaks

### DIFF
--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -13,7 +13,7 @@ IF(WIN32)
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /O2 /Wall /Z7")
     SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Od /Wall /Zi")
 ELSE()
-    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -std=gnu99 -fPIC -Wall -Wextra")
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -std=gnu99 -fPIC -Wall -Wextra -Werror")
     SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -p -O1 -std=gnu99 -fPIC -Wall -Wextra")
 ENDIF()
 

--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -706,6 +706,7 @@ static void advertise_info(request_rec *r)
 /* List of directives specific to our module.                               */
 /*                                                                          */
 /*--------------------------------------------------------------------------*/
+/* clang-format off */
 static const command_rec cmd_table[] = {
     AP_INIT_TAKE12("ServerAdvertise", /* directive name               */
                    cmd_advertise_m,   /* config action routine        */
@@ -737,9 +738,9 @@ static const command_rec cmd_table[] = {
                   NULL,                   /* argument to include in call  */
                   RSRC_CONF,              /* where available              */
                   "Local adress to bind to for Multicast logic"),
-    {NULL},
-
+    {.name = NULL},
 };
+/* clang-format on */
 
 /*--------------------------------------------------------------------------*/
 /*                                                                          */

--- a/native/balancers/mod_lbmethod_cluster.c
+++ b/native/balancers/mod_lbmethod_cluster.c
@@ -445,6 +445,7 @@ static const char *cmd_proxyhctemplate(cmd_parms *cmd, void *dummy, const char *
     return NULL;
 }
 
+/* clang-format off */
 static const command_rec lbmethod_cmds[] = {
     AP_INIT_FLAG("UseNocanon", cmd_nocanon, NULL, OR_ALL,
                  "UseNocanon - When no ProxyPass or ProxyMatch for the URL, passes the URL path \"raw\" to the backend "
@@ -452,7 +453,9 @@ static const command_rec lbmethod_cmds[] = {
     AP_INIT_RAW_ARGS(
         "ModProxyClusterHCTemplate", cmd_proxyhctemplate, NULL, OR_ALL,
         "ModProxyClusterHCTemplate - Set of health check parameters to use with mod_lbmethod_cluster workers."),
-    {NULL}};
+    {.name = NULL}
+};
+/* clang-format on */
 
 static void register_hooks(apr_pool_t *p)
 {

--- a/native/include/balancer.h
+++ b/native/include/balancer.h
@@ -46,11 +46,6 @@ struct balancerinfo
 typedef struct balancerinfo balancerinfo_t;
 
 /**
- * Use apache httpd structure
- */
-typedef struct ap_slotmem_provider_t slotmem_storage_method;
-
-/**
  * Insert(alloc) and update a balancer record in the shared table
  * @param s pointer to the shared table
  * @param balancer balancer to store in the shared table

--- a/native/include/context.h
+++ b/native/include/context.h
@@ -51,11 +51,6 @@ struct contextinfo
 typedef struct contextinfo contextinfo_t;
 
 /**
- * Use apache httpd structure
- */
-typedef struct ap_slotmem_provider_t slotmem_storage_method;
-
-/**
  * Insert(alloc) and update a context record in the shared table
  * @param s pointer to the shared table
  * @param context context to store in the shared table

--- a/native/include/domain.h
+++ b/native/include/domain.h
@@ -41,11 +41,6 @@ struct domaininfo
 typedef struct domaininfo domaininfo_t;
 
 /**
- * Use apache httpd structure
- */
-typedef struct ap_slotmem_provider_t slotmem_storage_method;
-
-/**
  * Insert(alloc) and update a domain record in the shared table
  * @param s pointer to the shared table
  * @param domain domain to store in the shared table

--- a/native/include/host.h
+++ b/native/include/host.h
@@ -41,11 +41,6 @@ struct hostinfo
 typedef struct hostinfo hostinfo_t;
 
 /**
- * Use apache httpd structure
- */
-typedef struct ap_slotmem_provider_t slotmem_storage_method;
-
-/**
  * Insert(alloc) and update a host record in the shared table
  * @param s pointer to the shared table
  * @param host host to store in the shared table

--- a/native/include/mod_clustersize.h
+++ b/native/include/mod_clustersize.h
@@ -15,6 +15,11 @@
 #error "PROXY_WORKER_MAX_ROUTE_SIZE is not defined"
 #endif
 
+/**
+ * Use apache httpd structure
+ */
+typedef struct ap_slotmem_provider_t slotmem_storage_method;
+
 /* For host.h */
 #define HOSTALIASZ  255
 

--- a/native/include/node.h
+++ b/native/include/node.h
@@ -82,11 +82,6 @@ struct nodeinfo
 typedef struct nodeinfo nodeinfo_t;
 
 /**
- * Use apache httpd structure
- */
-typedef struct ap_slotmem_provider_t slotmem_storage_method;
-
-/**
  * Return the last stored in the mem structure
  * @param pointer to the shared table
  * @return APR_SUCCESS if all went well

--- a/native/include/sessionid.h
+++ b/native/include/sessionid.h
@@ -40,11 +40,6 @@ struct sessionidinfo
 typedef struct sessionidinfo sessionidinfo_t;
 
 /**
- * Use apache httpd structure
- */
-typedef struct ap_slotmem_provider_t slotmem_storage_method;
-
-/**
  * Insert(alloc) and update a sessionid record in the shared table
  * @param s pointer to the shared table
  * @param sessionid sessionid to store in the shared table

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -3866,7 +3866,7 @@ static const char *cmd_manager_responsefieldsize(cmd_parms *cmd, void *mconfig, 
     return "ResponseFieldSize requires mod_proxy_http.c";
 }
 
-
+/* clang-format off */
 static const command_rec manager_cmds[] = {
     AP_INIT_TAKE1("Maxcontext", cmd_manager_maxcontext, NULL, OR_ALL,
                   "Maxcontext - number max context supported by mod_cluster"),
@@ -3910,8 +3910,9 @@ static const command_rec manager_cmds[] = {
                   "AJPSecret - secret for all mod_cluster node, not configued no secret."),
     AP_INIT_TAKE1("ResponseFieldSize", cmd_manager_responsefieldsize, NULL, OR_ALL,
                   "ResponseFieldSize - Adjust the size of the proxy response field buffer."),
-    {NULL},
+    {.name = NULL}
 };
+/* clang-format on */
 
 /* hooks declaration */
 

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -3731,7 +3731,7 @@ static const command_rec proxy_cluster_cmds[] = {
     AP_INIT_TAKE1("ModProxyClusterThreadCount", cmd_mc_thread_count, NULL, OR_ALL,
                   "ModProxyClusterThreadCount - Set custom size for the watchdog thread pool (Default: 16)"),
 #endif
-    {NULL}
+    {.name = NULL}
 };
 /* clang-format on */
 

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2430,7 +2430,6 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t
     APR_OPTIONAL_FN_TYPE(ap_watchdog_register_callback) *mc_watchdog_register_callback;
     server_rec *s = main_s;
     void *sconf = s->module_config;
-    int idx;
     int has_static_workers = 0;
     proxy_server_conf *conf = (proxy_server_conf *)ap_get_module_config(sconf, &proxy_module);
     apr_time_t watchdog_interval = cache_share_for ? cache_share_for : apr_time_from_sec(1);
@@ -2489,7 +2488,7 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t
     }
 
     /* check for static workers and warn if that is the case */
-    for (idx = 0; s; ++idx) {
+    while (s) {
         int i;
         proxy_balancer *balancer;
         void *sconf = s->module_config;


### PR DESCRIPTION
Drops unnecessary variable with a for cycle and adds `-Werror` for cmake.

Because of the latter I had to use `{ .name = NULL }` instead of `{ NULL }` but these are equivalent (if the initializer list is not long enough to cover all the members, they are default-initialized). I would prefer `{ }` instead but that's in `C23` and we support `C89`... so next time :smile: 

close #336 