### PR TITLE
ci: Ignore dependabot branches on push event trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
     paths-ignore:
       - '.gitignore'
       - '**.md'


### PR DESCRIPTION
If you have a look at the dependabot behavior, it always creates a branch and opens a pull request. That means the CI runs twice (for each event, see [this](https://github.com/modcluster/mod_proxy_cluster/pull/346/checks) for example) within the project. We can add dependabot's branches among ignored for the push event so that the workflow runs only once.

We don't pay for the workflows, and we're usually not limited by the queue, so it's not needed, but it won't hurt.
(Also, I tried it in the "perf suite" repo and it seems it erases all the run logs triggerd by push on dependabot's branches from the past – an interesting effect).