### PR TITLE
Fix id for PING and STATUS responses

### DIFF
--- a/native/advertise/mod_advertise.c
+++ b/native/advertise/mod_advertise.c
@@ -691,8 +691,8 @@ static void advertise_info(request_rec *r)
         }
         if (mconf->ma_advertise_server != NULL) {
             ap_rprintf(r, " Advertising on Group %s Port %d ", mconf->ma_advertise_adrs, mconf->ma_advertise_port);
-            ap_rprintf(r, "for %s://%s:%d every %ld seconds<br/>", mconf->ma_advertise_srvm, mconf->ma_advertise_srvs,
-                       mconf->ma_advertise_srvp, apr_time_sec(mconf->ma_advertise_freq));
+            ap_rprintf(r, "for %s://%s:%d every %" APR_INT64_T_FMT " seconds<br/>", mconf->ma_advertise_srvm,
+                       mconf->ma_advertise_srvs, mconf->ma_advertise_srvp, apr_time_sec(mconf->ma_advertise_freq));
         } else {
             ap_rputs("<br/>", r);
         }

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -2442,7 +2442,7 @@ static char *process_status(request_rec *r, const char *const *ptr, int *errtype
 
     ap_rprintf(r, isnode_up(r, node->mess.id, Load) != OK ? "&State=NOTOK" : "&State=OK");
 
-    ap_rprintf(r, "&id=%ld", ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%" APR_INT64_T_FMT, ap_scoreboard_image->global->restart_time);
 
     ap_rprintf(r, "\n");
     return NULL;
@@ -2544,7 +2544,7 @@ static char *process_ping(request_rec *r, const char *const *ptr, int *errtype)
 
         ap_rprintf(r, isnode_up(r, node->mess.id, -2) != OK ? "&State=NOTOK" : "&State=OK");
     }
-    ap_rprintf(r, "&id=%ld", ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%" APR_INT64_T_FMT, ap_scoreboard_image->global->restart_time);
 
     ap_rprintf(r, "\n");
     return NULL;

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -2442,7 +2442,7 @@ static char *process_status(request_rec *r, const char *const *ptr, int *errtype
 
     ap_rprintf(r, isnode_up(r, node->mess.id, Load) != OK ? "&State=NOTOK" : "&State=OK");
 
-    ap_rprintf(r, "&id=%d", (int)ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%ld", ap_scoreboard_image->global->restart_time);
 
     ap_rprintf(r, "\n");
     return NULL;
@@ -2544,7 +2544,7 @@ static char *process_ping(request_rec *r, const char *const *ptr, int *errtype)
 
         ap_rprintf(r, isnode_up(r, node->mess.id, -2) != OK ? "&State=NOTOK" : "&State=OK");
     }
-    ap_rprintf(r, "&id=%d", (int)ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%ld", ap_scoreboard_image->global->restart_time);
 
     ap_rprintf(r, "\n");
     return NULL;

--- a/native/mod_manager/mod_manager.c
+++ b/native/mod_manager/mod_manager.c
@@ -2379,7 +2379,7 @@ static void print_status_response(request_rec *r, const char *jvmroute, int node
     ap_set_content_type(r, PLAINTEXT_CONTENT_TYPE);
     ap_rprintf(r, "Type=STATUS-RSP&JVMRoute=%.*s", JVMROUTESZ, jvmroute);
     ap_rprintf(r, node_up ? "&State=OK" : "&State=NOTOK");
-    ap_rprintf(r, "&id=%ld", ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%" APR_INT64_T_FMT, ap_scoreboard_image->global->restart_time);
     ap_rprintf(r, "\n");
 }
 
@@ -2477,7 +2477,7 @@ static void print_ping_response(request_rec *r, const char *jvmroute, int is_up)
         ap_rprintf(r, is_up ? "&State=OK" : "&State=NOTOK");
     }
 
-    ap_rprintf(r, "&id=%ld", ap_scoreboard_image->global->restart_time);
+    ap_rprintf(r, "&id=%" APR_INT64_T_FMT, ap_scoreboard_image->global->restart_time);
     ap_rprintf(r, "\n");
 }
 

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -1992,7 +1992,8 @@ static proxy_worker *searchworker(request_rec *r, const char *bal, const char *p
                 if (worker->s->index != -1) {
                     *id = worker->s->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker: %s worker->s->index: %d the_conf %ld", ptr, *id, (uintptr_t)conf);
+                                 "searchworker: %s worker->s->index: %d the_conf %" APR_INT64_T_FMT, ptr, *id,
+                                 (uintptr_t)conf);
                     *the_conf = conf;
                     return worker; /* Done current index */
                 }
@@ -2000,14 +2001,16 @@ static proxy_worker *searchworker(request_rec *r, const char *bal, const char *p
                 if (helper && helper->index != -1) {
                     *id = helper->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker: %s helper->index %d the_conf %ld", ptr, *id, (uintptr_t)conf);
+                                 "searchworker: %s helper->index %d the_conf %" APR_INT64_T_FMT, ptr, *id,
+                                 (uintptr_t)conf);
                     *the_conf = conf;
                     return worker; /* Done previous index */
                 }
                 if (helper && helper->shared) {
                     *id = helper->shared->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker: %s helper->shared->index %d the_conf %ld", ptr, *id, (uintptr_t)conf);
+                                 "searchworker: %s helper->shared->index %d the_conf %" APR_INT64_T_FMT, ptr, *id,
+                                 (uintptr_t)conf);
                     *the_conf = conf;
                     return worker; /* our index was saved when we remove... */
                 }
@@ -2042,7 +2045,8 @@ static proxy_worker *proxy_node_getid(request_rec *r, const char *balancername, 
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_node_getid: searchworker returns NULL");
         return NULL;
     }
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_node_getid: the_conf %ld", (uintptr_t)*the_conf);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_node_getid: the_conf %" APR_INT64_T_FMT,
+                 (uintptr_t)*the_conf);
     return worker;
 }
 
@@ -2476,7 +2480,7 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t
     }
     if (SIZEOFSCORE <= sizeof(proxy_worker_shared)) {
         ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
-                     "SIZEOFSCORE too small for mod_proxy shared stat structure %d <= %ld", SIZEOFSCORE,
+                     "SIZEOFSCORE too small for mod_proxy shared stat structure %d <= %" APR_INT64_T_FMT, SIZEOFSCORE,
                      sizeof(proxy_worker_shared));
         return HTTP_INTERNAL_SERVER_ERROR;
     }

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -2069,7 +2069,8 @@ static proxy_worker *searchworker(request_rec *r, const char *bal, const char *u
                 if (worker->s->index != -1) {
                     *id = worker->s->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker: %s worker->s->index: %d the_conf %ld", url, *id, (uintptr_t)conf);
+                                 "searchworker: %s worker->s->index: %d the_conf %" APR_INT64_T_FMT, url, *id,
+                                 (uintptr_t)conf);
                     *the_conf = conf;
                     return worker; /* Done current index */
                 }
@@ -2077,14 +2078,16 @@ static proxy_worker *searchworker(request_rec *r, const char *bal, const char *u
                 if (helper && helper->index != -1) {
                     *id = helper->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker: %s helper->index %d the_conf %ld", url, *id, (uintptr_t)conf);
+                                 "searchworker: %s helper->index %d the_conf %" APR_INT64_T_FMT, url, *id,
+                                 (uintptr_t)conf);
                     *the_conf = conf;
                     return worker; /* Done previous index */
                 }
                 if (helper && helper->shared) {
                     *id = helper->shared->index;
                     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server,
-                                 "searchworker: %s helper->shared->index %d the_conf %ld", url, *id, (uintptr_t)conf);
+                                 "searchworker: %s helper->shared->index %d the_conf %" APR_INT64_T_FMT, url, *id,
+                                 (uintptr_t)conf);
                     *the_conf = conf;
                     return worker; /* our index was saved when we remove... */
                 }
@@ -2119,7 +2122,8 @@ static proxy_worker *proxy_node_getid(request_rec *r, const char *balancername, 
         ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_node_getid: searchworker returns NULL");
         return NULL;
     }
-    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_node_getid: the_conf %ld", (uintptr_t)*the_conf);
+    ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, r->server, "proxy_node_getid: the_conf %" APR_INT64_T_FMT,
+                 (uintptr_t)*the_conf);
     return worker;
 }
 
@@ -2553,7 +2557,7 @@ static int proxy_cluster_post_config(apr_pool_t *p, apr_pool_t *plog, apr_pool_t
     }
     if (SIZEOFSCORE <= sizeof(proxy_worker_shared)) {
         ap_log_error(APLOG_MARK, APLOG_EMERG, 0, s,
-                     "SIZEOFSCORE too small for mod_proxy shared stat structure %d <= %ld", SIZEOFSCORE,
+                     "SIZEOFSCORE too small for mod_proxy shared stat structure %d <= %" APR_INT64_T_FMT, SIZEOFSCORE,
                      sizeof(proxy_worker_shared));
         return HTTP_INTERNAL_SERVER_ERROR;
     }


### PR DESCRIPTION
`restart_time` is of type `apr_int64_t`, so `(int)` is not correct (it leads to ugly numbers)