### PR TITLE
ci: Drop abandoned ilammy/msvc-dev-cmd in Windows job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,21 +223,25 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ windows-latest, windows-11-arm ]
+            include:
+                - os: windows-latest
+                  arch: amd64
+
+                - os: windows-11-arm
+                  arch: amd64 # we're cross-compiling at this point
     env:
       APACHE_LOUNGE_DISTRO_VERSION: 2.4.67-260504
       HTTPD_DEV_HOME: 'C:\Apache24'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup Developer Command Prompt for Microsoft Visual C++
-        uses: ilammy/msvc-dev-cmd@v1
       - name: Get httpd
         run: |
           curl.exe --output "httpd-apache-lounge.zip" --url "https://www.apachelounge.com/download/VS18/binaries/httpd-${{ env.APACHE_LOUNGE_DISTRO_VERSION }}-win64-VS18.zip"
           Expand-Archive -Path "httpd-apache-lounge.zip" -DestinationPath "C:\"
       - name: Build
         run: |
+          & (Get-ChildItem -Path "C:\Program Files\Microsoft Visual Studio\" -Filter "Launch-VsDevShell.ps1" -Recurse).FullName -Arch ${{ matrix.arch }} -SkipAutomaticLocation
           ./native/scripts/windows-build.bat
           cp cmakebuild/modules/*.so C:/Apache24/modules/
       - name: Fix and prepare config files


### PR DESCRIPTION
close #379 

The `amd64` arch for Windows on ARM is intended. The Apache Lounge bits are amd64, so we're cross-compiling. It would be nice to be able to run `VsDevShell` with `-Arch amd64 -HostArch arm64`, but MS does not support that at the moment.
