### PR TITLE
Use Fedora 44 instead of 42, use `PROXY_STRNCPY` instead of `strncpy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Create container and build
         run: |
           {
-              echo 'FROM fedora:42'
+              echo 'FROM fedora:44'
               echo 'RUN dnf install --assumeyes @c-development cmake httpd-devel ${{ matrix.compiler }}'
               echo 'RUN dnf clean all'
               echo 'COPY mod_proxy_cluster mod_proxy_cluster'
@@ -86,7 +86,7 @@ jobs:
       - name: Create container and build
         run: |
           {
-              echo 'FROM fedora:42'
+              echo 'FROM fedora:44'
               echo 'RUN dnf install --assumeyes @c-development httpd-devel redhat-rpm-config'
               echo 'RUN dnf clean all'
               echo 'COPY mod_proxy_cluster mod_proxy_cluster'

--- a/native/mod_proxy_cluster/mod_proxy_cluster.c
+++ b/native/mod_proxy_cluster/mod_proxy_cluster.c
@@ -404,27 +404,27 @@ static void create_worker_arrange_shared_mem(proxy_server_conf *conf, proxy_work
     pair_worker_node(worker->s, node);
 
 #ifdef PROXY_WORKER_EXT_NAME_SIZE
-    strncpy(worker->s->name_ex, shared->name_ex, sizeof(worker->s->name_ex));
+    PROXY_STRNCPY(worker->s->name_ex, shared->name_ex);
 #else
-    strncpy(worker->s->name, shared->name, sizeof(worker->s->name));
+    PROXY_STRNCPY(worker->s->name, shared->name);
 #endif
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                  "create_worker: worker for %s arranging shared memory hostname %s:%s", url, worker->s->hostname,
                  shared->hostname);
-    strncpy(worker->s->hostname, shared->hostname, sizeof(worker->s->hostname));
+    PROXY_STRNCPY(worker->s->hostname, shared->hostname);
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                  "create_worker: worker for %s arranging shared memory hostname_ex %s:%s", url, worker->s->hostname_ex,
                  shared->hostname_ex);
-    strncpy(worker->s->hostname_ex, shared->hostname_ex, sizeof(worker->s->hostname_ex));
+    PROXY_STRNCPY(worker->s->hostname_ex, shared->hostname_ex);
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, server,
                  "create_worker: worker for %s arranging shared memory scheme %s:%s", url, worker->s->scheme,
                  shared->scheme);
-    strncpy(worker->s->scheme, shared->scheme, sizeof(worker->s->scheme));
+    PROXY_STRNCPY(worker->s->scheme, shared->scheme);
     worker->s->port = shared->port;
     worker->s->hmax = shared->hmax;
-    strncpy(worker->s->route, node->mess.jvm_route, sizeof(worker->s->route));
+    PROXY_STRNCPY(worker->s->route, node->mess.jvm_route);
     worker->s->route[sizeof(worker->s->route) - 1] = '\0';
-    strncpy(worker->s->upgrade, node->mess.upgrade, sizeof(worker->s->upgrade));
+    PROXY_STRNCPY(worker->s->upgrade, node->mess.upgrade);
     worker->s->upgrade[sizeof(worker->s->upgrade) - 1] = '\0';
     if (node->mess.response_field_size > 0) {
         worker->s->response_field_size = node->mess.response_field_size;
@@ -432,7 +432,7 @@ static void create_worker_arrange_shared_mem(proxy_server_conf *conf, proxy_work
     } else {
         worker->s->response_field_size_set = 0;
     }
-    strncpy(worker->s->secret, node->mess.ajp_secret, sizeof(worker->s->secret));
+    PROXY_STRNCPY(worker->s->secret, node->mess.ajp_secret);
     worker->s->secret[sizeof(worker->s->secret) - 1] = '\0';
     worker->s->redirect[0] = '\0';
     worker->s->smax = node->mess.smax;

--- a/test/httpd/Containerfile
+++ b/test/httpd/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:42 AS builder
+FROM fedora:44 AS builder
 
 ARG HTTPD_SOURCES="https://dlcdn.apache.org/httpd/httpd-2.4.68.tar.gz"
 
@@ -43,7 +43,7 @@ RUN for m in advertise mod_proxy_cluster balancers mod_manager; \
 
 RUN rm -rf /test/httpd/mod_proxy_cluster
 
-FROM fedora:42
+FROM fedora:44
 
 ENV CONF=httpd/mod_proxy_cluster.conf
 


### PR DESCRIPTION
The `PROXY_STRNCPY` addresses a new issue that arose with the new Fedora and `-Werror=stringop-truncation`.