### PR TITLE
[CI] Fix the Podman logging driver issue, drop net env printing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,8 +320,16 @@ jobs:
           sudo touch /etc/containers/nodocker
           cd test
           sh setup-dependencies.sh
-      - name: Print network environment
-        run: ss -ltp
+      - name: Configure Podman logging driver
+        run: |
+          mkdir -p ~/.config/containers
+          cat <<EOF > ~/.config/containers/containers.conf
+          [containers]
+          log_driver = "k8s-file"
+
+          [engine]
+          events_logger = "file"
+          EOF
       - name: Run testsuite
         run: |
           cd test


### PR DESCRIPTION
I started getting following errors in the CI (even on [the current main](https://github.com/jajik/mod_proxy_cluster/actions/runs/33065503905/job/98522571030), so the issue is not caused by us):

```
httpd mod_proxy_cluster image config:
    CONF:    httpd/mod_proxy_cluster.conf
    NAME:    httpd-mod_proxy_cluster
You can config those with envars MPC_SOURCES, MPC_BRANCH, MPC_CONF, MPC_NAME respectively
[conmon:e]: Include journald in compilation path to log to systemd journal
Error: conmon failed: exit status 1
Thu Aug 27 09:38:56 UTC 2026 Failed to run httpd container
```

This is a podman issue. And this PR should fix it. (Alternatively, we could move to docker, but we wanted to run `podman` for some reason.)
